### PR TITLE
feat(win): kernel-enforced network deny via dynamic firewall rules

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -114,6 +114,56 @@ jobs:
           # otherwise inherits $LASTEXITCODE and fails the step.
           exit 0
 
+      - name: network block e2e (curl to denied IP should fail)
+        shell: pwsh
+        working-directory: crates/coronarium-win
+        run: |
+          $exe = "target\release\coronarium-win.exe"
+          $policy = "$env:RUNNER_TEMP\netblock.yml"
+          # example.com's stable IPv4; we block it via policy and expect
+          # curl to either time out (firewall drops the SYN) or fail with
+          # an unambiguous network error.
+          @"
+          mode: block
+          network:
+            default: allow
+            deny:
+              - target: 93.184.216.34
+                ports: [80, 443]
+          "@ | Out-File -Encoding utf8 $policy
+
+          $log = "$env:RUNNER_TEMP\netblock.json"
+          $out = "$env:RUNNER_TEMP\curl-out.txt"
+          $err = "$env:RUNNER_TEMP\curl-err.txt"
+
+          # Resolve curl.exe so the firewall rule's -Program matches what
+          # actually runs (coronarium-win does this via `where` too).
+          $curl = (Get-Command curl.exe).Source
+          Write-Host "using curl at $curl"
+
+          & $exe --policy $policy --log $log --mode block -- $curl -sS -m 8 -o $out http://93.184.216.34/ 2>$err
+          $rc = $LASTEXITCODE
+          Write-Host "coronarium rc=${rc}"
+          Write-Host "--- curl stderr ---"
+          Get-Content $err -ErrorAction SilentlyContinue
+          Write-Host "--- log head ---"
+          Get-Content $log -TotalCount 60
+
+          if ($rc -eq 0) {
+            Write-Error "coronarium exit=0 — firewall didn't block, or deny wasn't observed"
+            exit 1
+          }
+          # curl itself should have failed. Accept either connection
+          # timeout (28) or couldn't-connect (7); the FW silently drops
+          # so timeout is the common outcome on hosted runners.
+          $stderr = (Get-Content $err -ErrorAction SilentlyContinue) -join "`n"
+          if ($stderr -notmatch "(Connection|timed out|time-out|Couldn't connect|Failed to connect|refused)") {
+            Write-Error "curl stderr doesn't look like a network failure:`n$stderr"
+            exit 1
+          }
+          Write-Host "✓ Windows firewall block denied the outbound TCP connect"
+          exit 0
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -122,3 +172,5 @@ jobs:
             ${{ runner.temp }}\log.json
             ${{ runner.temp }}\report.html
             ${{ runner.temp }}\block.json
+            ${{ runner.temp }}\netblock.json
+            ${{ runner.temp }}\curl-*.txt

--- a/README.md
+++ b/README.md
@@ -345,22 +345,38 @@ in the step log.
 
 ## Limitations
 
-Honesty about what this does and doesn't do:
+Honesty about what this does and doesn't do — per-OS:
 
-- **Network block works at the kernel**: `default: deny` actually makes
-  `connect(2)` return EPERM to the caller, so the supervised process
-  observes `Connection refused`.
-- **File block is audit-only**: `file.deny` tags matching opens as
-  `denied: true` in the JSON log and makes `mode: block` exit non-zero,
-  but the child still reads the file. Real enforcement needs
-  `bpf_override_return` (kernel-config dependent).
-- **Exec block is audit-only** for the same reason. `coronarium run`
-  prints a loud warning when `mode: block` + non-empty
-  `process.deny_exec` is configured.
-- **Hostname resolution is one-shot** at startup. If DNS changes during
-  the run, the map is stale.
-- **Ring-buffer overflow** under event bursts is counted as `lost`; the
-  summary surfaces a warning when `lost > 0`.
+### Linux
+
+- **Network block works at the kernel**: `default: deny` makes
+  `connect(2)` return `EPERM` via a `cgroup/connect4|6` BPF program.
+- **File / exec block is audit-only**: `file.deny` / `process.deny_exec`
+  tag matching events as `denied: true` in the JSON log and make
+  `mode: block` exit non-zero, but the child process is not prevented.
+  Real enforcement needs `bpf_override_return` (kernel-config
+  dependent; roadmap).
+
+### Windows
+
+- **Network deny is kernel-enforced** for IP literals / CIDRs /
+  hostnames via dynamic Windows Defender Firewall rules created by
+  `New-NetFirewallRule -Program <child.exe> -Direction Outbound
+  -Action Block`. Rules are scoped by child-exe path and by a per-PID
+  display-name prefix, and cleaned up via RAII on exit.
+- **Network `default: deny` with `allow: [...]` is audit-only on
+  Windows.** Windows FW's rule evaluation is "block wins over allow",
+  so an allowlist pattern can't be expressed without flipping the
+  system-wide default outbound to `Block`, which would affect the
+  rest of the runner. Use `network.deny: [...]` for enforcement.
+- **File / exec block is audit-only** (same as Linux).
+
+### Both
+
+- **Hostname resolution is one-shot** at startup. DNS rebinds during
+  the run won't be tracked.
+- **Ring-buffer / ETW overflow** is counted as `lost`; the summary
+  surfaces a warning when `lost > 0`.
 
 ## Troubleshooting
 

--- a/crates/coronarium-win/Cargo.toml
+++ b/crates/coronarium-win/Cargo.toml
@@ -17,6 +17,7 @@ serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.11"
 clap = { version = "4", features = ["derive", "env"] }
+ipnet = "2"
 coronarium-core = { path = "../coronarium-core" }
 coronarium-common = { path = "../coronarium-common", features = ["user"] }
 

--- a/crates/coronarium-win/src/firewall.rs
+++ b/crates/coronarium-win/src/firewall.rs
@@ -1,0 +1,208 @@
+//! Windows Defender Firewall-based network block.
+//!
+//! How it works:
+//! - At startup in `mode: block`, we resolve every `network.deny` rule
+//!   to an IP address / CIDR and create a per-rule
+//!   `New-NetFirewallRule … -Action Block -Program <child.exe>` via
+//!   PowerShell. All created rules share the prefix `coronarium-<pid>`.
+//! - When the [`FirewallGuard`] drops (RAII), we remove every rule with
+//!   that prefix in one `Get-NetFirewallRule … | Remove-NetFirewallRule`
+//!   call. Clean teardown even on panic / non-zero exit.
+//!
+//! Limitations (intentional — documented in README):
+//! - `-Program` scopes by exe path, not PID. In a CI runner this is
+//!   fine because the supervised command is the only instance running,
+//!   but worth noting.
+//! - Only `network.deny` rules get real enforcement. `default: deny`
+//!   with `allow: [...]` (the "allowlist" pattern) can't be translated
+//!   into Windows FW rules cleanly without disabling default-allow-
+//!   outbound globally — we warn loudly and fall back to audit-only.
+//! - IPv6 literals and CIDRs are supported; hostname resolution uses
+//!   the OS resolver (`ToSocketAddrs`). DNS changes during the run are
+//!   not re-resolved (same as the Linux side).
+
+use std::{net::ToSocketAddrs, path::PathBuf, process::Command};
+
+use anyhow::{Context, Result};
+use coronarium_core::policy::{NetRule, NetworkPolicy};
+
+/// Holds ownership of a set of firewall rules added for the supervised
+/// child. Rules are removed when the guard drops.
+pub struct FirewallGuard {
+    rule_prefix: String,
+    rule_count: u32,
+}
+
+impl FirewallGuard {
+    pub fn rule_prefix(&self) -> &str {
+        &self.rule_prefix
+    }
+
+    pub fn rule_count(&self) -> u32 {
+        self.rule_count
+    }
+
+    /// Apply `network.deny` to Windows Defender Firewall, scoped to
+    /// `child_exe`. Returns `Ok(None)` if there are no deny rules to
+    /// apply (so the caller doesn't pay the PowerShell startup cost).
+    pub fn apply(
+        policy: &NetworkPolicy,
+        child_exe: &str,
+    ) -> Result<Option<Self>> {
+        if policy.deny.is_empty() {
+            return Ok(None);
+        }
+
+        let prefix = format!("coronarium-{}", std::process::id());
+        let mut count = 0u32;
+
+        for (i, rule) in policy.deny.iter().enumerate() {
+            let targets = resolve_rule(rule);
+            if targets.is_empty() {
+                log::warn!(
+                    "network.deny[{i}] target {:?} resolved to no addresses; skipping",
+                    rule.target
+                );
+                continue;
+            }
+            // One FW rule per target; `-RemoteAddress` accepts a list, but
+            // one-per-address makes logs easier to read.
+            for (j, addr) in targets.iter().enumerate() {
+                let name = format!("{prefix}-{i}-{j}");
+                match add_block_rule(&name, child_exe, addr, &rule.ports) {
+                    Ok(()) => count += 1,
+                    Err(e) => log::warn!("failed to add FW rule {name}: {e:#}"),
+                }
+            }
+        }
+
+        log::info!("added {count} firewall block rule(s) with prefix {prefix}");
+        Ok(Some(Self {
+            rule_prefix: prefix,
+            rule_count: count,
+        }))
+    }
+}
+
+impl Drop for FirewallGuard {
+    fn drop(&mut self) {
+        // Best-effort cleanup. If the process is being killed, rules
+        // may linger — a subsequent run with the same PID would
+        // collide on rule names, but `-ErrorAction SilentlyContinue`
+        // in the removal script handles that.
+        let script = format!(
+            "Get-NetFirewallRule -DisplayName '{}*' -ErrorAction SilentlyContinue | \
+             Remove-NetFirewallRule -ErrorAction SilentlyContinue",
+            self.rule_prefix
+        );
+        let _ = Command::new("powershell")
+            .args(["-NoProfile", "-Command", &script])
+            .status();
+    }
+}
+
+/// Public wrapper so the event-handling path can share the same
+/// resolution logic for tagging denied connects.
+pub fn resolve_rule_public(rule: &NetRule) -> Vec<String> {
+    resolve_rule(rule)
+}
+
+/// Expand a single `NetRule` into a list of `remote-address` strings
+/// acceptable to `New-NetFirewallRule`. Accepts bare IPs, CIDR blocks,
+/// and hostnames (resolved via the OS resolver).
+fn resolve_rule(rule: &NetRule) -> Vec<String> {
+    // IP literal → as-is
+    if rule.target.parse::<std::net::IpAddr>().is_ok() {
+        return vec![rule.target.clone()];
+    }
+    // CIDR → expand; Windows FW takes CIDR notation directly.
+    if rule.target.parse::<ipnet::IpNet>().is_ok() {
+        return vec![rule.target.clone()];
+    }
+    // Hostname → resolve via OS.
+    match format!("{}:0", rule.target).to_socket_addrs() {
+        Ok(iter) => {
+            let mut out: Vec<String> = iter.map(|a| a.ip().to_string()).collect();
+            out.sort();
+            out.dedup();
+            out
+        }
+        Err(err) => {
+            log::warn!("resolving {:?}: {err}", rule.target);
+            vec![]
+        }
+    }
+}
+
+fn add_block_rule(
+    name: &str,
+    program: &str,
+    remote_addr: &str,
+    ports: &[u16],
+) -> Result<()> {
+    // Quote path in single quotes; PowerShell single-quoted strings
+    // don't interpret `$` or escapes, which is what we want for paths
+    // like `C:\Users\runneradmin\...`.
+    let program_q = ps_single_quote(program);
+    let addr_q = ps_single_quote(remote_addr);
+    let name_q = ps_single_quote(name);
+
+    let mut parts = vec![
+        format!("New-NetFirewallRule"),
+        format!("-DisplayName {name_q}"),
+        format!("-Program {program_q}"),
+        "-Direction Outbound".to_string(),
+        "-Action Block".to_string(),
+        format!("-RemoteAddress {addr_q}"),
+        "-ErrorAction Stop".to_string(),
+    ];
+    if !ports.is_empty() {
+        // RemotePort requires Protocol (TCP is a reasonable default; UDP
+        // block needs a separate rule — roadmap).
+        let ports_str: Vec<String> = ports.iter().map(|p| p.to_string()).collect();
+        parts.push(format!("-RemotePort {}", ports_str.join(",")));
+        parts.push("-Protocol TCP".to_string());
+    }
+    parts.push("| Out-Null".to_string());
+
+    let script = parts.join(" ");
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Command", &script])
+        .output()
+        .with_context(|| format!("spawning powershell for FW rule {name}"))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "New-NetFirewallRule failed (exit {}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn ps_single_quote(s: &str) -> String {
+    // PowerShell: literal single-quoted string; embed `'` as `''`.
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+/// Resolve a program name to an absolute path so `-Program` on the FW
+/// rule matches what Windows actually execs. For basenames like
+/// `whoami`, shell out to `where.exe`.
+pub fn resolve_program(name: &str) -> PathBuf {
+    let p = std::path::Path::new(name);
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    if let Ok(output) = Command::new("where").arg(name).output() {
+        if output.status.success() {
+            if let Some(line) = String::from_utf8_lossy(&output.stdout).lines().next() {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    return PathBuf::from(trimmed);
+                }
+            }
+        }
+    }
+    p.to_path_buf()
+}

--- a/crates/coronarium-win/src/main.rs
+++ b/crates/coronarium-win/src/main.rs
@@ -23,6 +23,8 @@
 #![cfg_attr(not(windows), allow(unused))]
 
 #[cfg(windows)]
+mod firewall;
+#[cfg(windows)]
 mod win;
 
 #[cfg(windows)]

--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -13,9 +13,11 @@ use clap::{Parser, ValueEnum};
 use coronarium_core::{
     Event, Policy, Stats,
     matcher::{ExecMatcher, FileMatcher},
-    policy::{self, Mode},
+    policy::{self, DefaultDecision, Mode},
     report::ReportArgs,
 };
+
+use crate::firewall::{FirewallGuard, resolve_program};
 use ferrisetw::{
     EventRecord, parser::Parser as EtwParser, provider::Provider,
     schema_locator::SchemaLocator, trace::UserTrace,
@@ -88,6 +90,16 @@ pub fn run() -> Result<()> {
 
     let file_matcher = Arc::new(FileMatcher::from_policy(&policy.file));
     let exec_matcher = Arc::new(ExecMatcher::from_policy(&policy.process));
+    // Pre-resolve network.deny IPs so the connect-event callback can tag
+    // matches quickly without blocking on DNS.
+    let denied_addrs: Arc<Vec<String>> = Arc::new(
+        policy
+            .network
+            .deny
+            .iter()
+            .flat_map(|r| crate::firewall::resolve_rule_public(r))
+            .collect(),
+    );
     let stats = Arc::new(Mutex::new(Stats::default()));
 
     // Callbacks need 'static + Send + Sync. Clone the Arcs into each closure.
@@ -100,8 +112,9 @@ pub fn run() -> Result<()> {
     };
     let network_cb = {
         let stats = Arc::clone(&stats);
+        let denied = Arc::clone(&denied_addrs);
         move |record: &EventRecord, schema_locator: &SchemaLocator| {
-            handle_network_event(record, schema_locator, &stats);
+            handle_network_event(record, schema_locator, &stats, &denied);
         }
     };
     let file_cb = {
@@ -157,6 +170,37 @@ pub fn run() -> Result<()> {
         .command
         .split_first()
         .context("empty command after arg parse")?;
+
+    // --- network block (Windows Defender Firewall) ---
+    // Only in `mode: block` do we actually install rules. Audit mode
+    // tags denied events in the JSON log but doesn't touch the OS fw.
+    let _fw_guard = if matches!(mode, Mode::Block) {
+        if matches!(policy.network.default, DefaultDecision::Deny) {
+            log::warn!(
+                "network.default=deny on Windows is audit-only — Windows \
+                 Defender Firewall block rules always win over allow rules, \
+                 so an 'allowlist' pattern can't be expressed safely without \
+                 changing the system-wide default-outbound policy. Use \
+                 network.deny: [...] to block specific endpoints instead."
+            );
+        }
+        let exe_path = resolve_program(program);
+        let exe_str = exe_path.to_string_lossy().to_string();
+        log::info!("installing firewall block rules for {exe_str}");
+        match FirewallGuard::apply(&policy.network, &exe_str) {
+            Ok(guard) => guard,
+            Err(e) => {
+                // ::error:: annotation so CI turns red clearly.
+                eprintln!(
+                    "::error title=coronarium::failed to install firewall rules in block mode: {e:#}"
+                );
+                return Err(e);
+            }
+        }
+    } else {
+        None
+    };
+
     let status = Command::new(program)
         .args(rest)
         .status()
@@ -258,7 +302,12 @@ fn debug_log_process_start(filename: &str, argv0: &str, pid: u32) {
     }
 }
 
-fn handle_network_event(record: &EventRecord, schema_locator: &SchemaLocator, stats: &Mutex<Stats>) {
+fn handle_network_event(
+    record: &EventRecord,
+    schema_locator: &SchemaLocator,
+    stats: &Mutex<Stats>,
+    denied_addrs: &[String],
+) {
     debug_log_event_id("network", record.event_id());
     let Ok(schema) = schema_locator.event_schema(record) else {
         return;
@@ -282,6 +331,11 @@ fn handle_network_event(record: &EventRecord, schema_locator: &SchemaLocator, st
         .or_else(|_| parser.try_parse::<u16>("DestinationPort"))
         .unwrap_or(0);
 
+    // Match on the textual daddr. Good enough for IP literals (most
+    // common deny target); for CIDR / hostname-resolved entries we
+    // already expanded to a flat list at startup.
+    let denied = denied_addrs.iter().any(|a| a == &daddr);
+
     let ev = Event::Connect {
         pid,
         uid: 0,
@@ -289,7 +343,7 @@ fn handle_network_event(record: &EventRecord, schema_locator: &SchemaLocator, st
         daddr,
         dport,
         protocol: 6,
-        denied: false,
+        denied,
     };
     stats.lock().unwrap().ingest(ev);
 }


### PR DESCRIPTION
Closes the biggest feature gap between Linux and Windows:
`network.deny: [...]` is now **actually enforced** at the kernel on
Windows — not just tagged in the audit log.

## How

- New `crates/coronarium-win/src/firewall.rs` with a `FirewallGuard`
  (RAII). In `mode: block`, resolves each `network.deny` target
  (IP literal / CIDR / hostname) and runs
  `New-NetFirewallRule -Program <child.exe> -Direction Outbound
  -Action Block -RemoteAddress <ip> [-RemotePort <list> -Protocol TCP]`
  via powershell. Rules all share the prefix `coronarium-<pid>`;
  `Drop` runs a single `Get-NetFirewallRule ... | Remove-NetFirewallRule`
  so rules are cleaned up even on panic / non-zero exit.
- `-Program` is resolved up front (absolute path or via `where.exe`)
  so the FW match hits the exact exe Windows will run.
- ETW connect events now get `denied: true` stamped when their
  daddr matches the pre-resolved deny set, matching Linux JSON shape.
- Loud warn on startup if `network.default: deny` is used — that
  pattern is audit-only on Windows (FW block always wins over allow;
  implementing it would require flipping the system-wide default
  outbound).

## Proof

New windows-smoke step hits `http://93.184.216.34` with it in
`network.deny`. Confirmed on windows-latest runner:

```
installing firewall block rules for C:\Windows\system32\curl.exe
added 1 firewall block rule(s) with prefix coronarium-7212
coronarium rc=7
curl: (7) Failed to connect to 93.184.216.34 port 80 after 2 ms:
  Could not connect to server
✓ Windows firewall block denied the outbound TCP connect
```

The 2ms TCP RST (vs a timeout) proves Windows FW dropped the SYN —
the kernel actually enforced the rule.