### PR TITLE
feat(deps): PyPI + NuGet minimumReleaseAge support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,67 @@ jobs:
           target/release/coronarium deps check --min-age 1d --no-cache --format json Cargo.lock \
             | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['violations']==0; assert d['checked']>100; print(f\"ok violations=0 checked={d['checked']}\")"
 
+      - name: deps check — PyPI fixture (requirements.txt)
+        run: |
+          target/release/coronarium deps check \
+            --min-age 1d --no-cache --format json tests/fixtures/requirements.txt \
+            | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          assert d['violations'] == 0, d
+          assert d['checked'] == 2, d
+          labels = {p['ecosystem'] for p in d['packages']}
+          assert labels == {'pypi'}, labels
+          print('ok pypi', d['checked'])
+          "
+      - name: deps check — NuGet fixture (packages.lock.json)
+        run: |
+          target/release/coronarium deps check \
+            --min-age 1d --no-cache --format json tests/fixtures/packages.lock.json \
+            | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          assert d['violations'] == 0, d
+          assert d['checked'] == 1, d
+          labels = {p['ecosystem'] for p in d['packages']}
+          assert labels == {'nuget'}, labels
+          print('ok nuget', d['checked'])
+          "
+      - name: deps check — npm fixture (package-lock.json)
+        run: |
+          target/release/coronarium deps check \
+            --min-age 1d --no-cache --format json tests/fixtures/package-lock.json \
+            | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          assert d['violations'] == 0, d
+          assert d['checked'] == 1, d
+          labels = {p['ecosystem'] for p in d['packages']}
+          assert labels == {'npm'}, labels
+          print('ok npm', d['checked'])
+          "
+      - name: deps check — all 4 ecosystems in one invocation
+        run: |
+          set +e
+          target/release/coronarium deps check --min-age 3650d --no-cache \
+            Cargo.lock \
+            tests/fixtures/requirements.txt \
+            tests/fixtures/packages.lock.json \
+            tests/fixtures/package-lock.json \
+            > /tmp/mixed.txt
+          rc=$?
+          set -e
+          head -10 /tmp/mixed.txt
+          if [ "$rc" = "0" ]; then
+            echo "::error::min-age=3650d should have failed across all ecosystems"
+            exit 1
+          fi
+          # Confirm all four ecosystem labels appear among the violations.
+          for label in crates pypi nuget npm; do
+            grep -q "${label}/" /tmp/mixed.txt || { echo "::error::no ${label} violations surfaced"; exit 1; }
+          done
+          echo "✓ all 4 ecosystems produced violations at --min-age 3650d"
+
   ebpf:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ coronarium deps check --min-age 7d --format json Cargo.lock
 |---|---|---|
 | cargo | `Cargo.lock` | crates.io `/api/v1/crates/<name>` |
 | npm | `package-lock.json` (lockfileVersion ≥ 2) | registry.npmjs.org |
+| pypi | `uv.lock`, `poetry.lock`, `requirements.txt` (exact `==` pins only) | pypi.org `/pypi/<name>/<version>/json` |
+| nuget | `packages.lock.json` (central-package-management) | api.nuget.org `/v3/registration5-{semver1,gz-semver2}/…` |
 
 Exit codes: `0` = all packages meet the threshold, `1` = at least one
 violation, `2` = parse/I/O error. A single on-disk cache at

--- a/crates/coronarium-core/src/deps/cache.rs
+++ b/crates/coronarium-core/src/deps/cache.rs
@@ -65,10 +65,6 @@ impl Cache {
     }
 
     fn key(eco: &Ecosystem, name: &str, version: &str) -> String {
-        let eco_str = match eco {
-            Ecosystem::Npm => "npm",
-            Ecosystem::Crates => "crates",
-        };
-        format!("{eco_str}/{name}@{version}")
+        format!("{}/{}@{}", eco.label(), name, version)
     }
 }

--- a/crates/coronarium-core/src/deps/lockfile/mod.rs
+++ b/crates/coronarium-core/src/deps/lockfile/mod.rs
@@ -1,5 +1,7 @@
 pub mod cargo;
 pub mod npm;
+pub mod nuget;
+pub mod pypi;
 
 use std::path::Path;
 
@@ -15,8 +17,12 @@ pub fn detect(path: &Path) -> Result<Ecosystem> {
     match fname {
         "package-lock.json" => Ok(Ecosystem::Npm),
         "Cargo.lock" => Ok(Ecosystem::Crates),
+        "uv.lock" | "poetry.lock" => Ok(Ecosystem::Pypi),
+        "requirements.txt" => Ok(Ecosystem::Pypi),
+        "packages.lock.json" => Ok(Ecosystem::Nuget),
         _ => anyhow::bail!(
-            "unsupported lockfile '{fname}' (supported: package-lock.json, Cargo.lock)"
+            "unsupported lockfile '{fname}' (supported: package-lock.json, Cargo.lock, \
+             uv.lock, poetry.lock, requirements.txt, packages.lock.json)"
         ),
     }
 }
@@ -25,5 +31,7 @@ pub fn parse(eco: Ecosystem, path: &Path) -> Result<Vec<Package>> {
     match eco {
         Ecosystem::Npm => npm::parse(path),
         Ecosystem::Crates => cargo::parse(path),
+        Ecosystem::Pypi => pypi::parse(path),
+        Ecosystem::Nuget => nuget::parse(path),
     }
 }

--- a/crates/coronarium-core/src/deps/lockfile/nuget.rs
+++ b/crates/coronarium-core/src/deps/lockfile/nuget.rs
@@ -1,0 +1,70 @@
+//! NuGet `packages.lock.json`.
+//!
+//! Shape (version 1 and 2):
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "dependencies": {
+//!     "net6.0": {
+//!       "Newtonsoft.Json": {
+//!         "type": "Direct" | "Transitive" | "Project" | ...,
+//!         "resolved": "13.0.1",
+//!         "contentHash": "..."
+//!       },
+//!       ...
+//!     },
+//!     "net8.0": { ... }
+//!   }
+//! }
+//! ```
+//!
+//! We collect the union of `(name, resolved)` across all target
+//! frameworks and skip entries whose `type` is `Project` (intra-solution
+//! project references, not registry packages).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::deps::{Ecosystem, Package};
+
+#[derive(Debug, Deserialize)]
+struct Lock {
+    #[serde(default)]
+    dependencies: BTreeMap<String, BTreeMap<String, Entry>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Entry {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    resolved: Option<String>,
+}
+
+pub fn parse(path: &Path) -> Result<Vec<Package>> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let lock: Lock = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing {} as packages.lock.json", path.display()))?;
+
+    let mut out = Vec::new();
+    for packages in lock.dependencies.values() {
+        for (name, entry) in packages {
+            if matches!(entry.r#type.as_deref(), Some("Project")) {
+                continue;
+            }
+            let Some(version) = entry.resolved.as_deref() else {
+                continue;
+            };
+            out.push(Package {
+                ecosystem: Ecosystem::Nuget,
+                name: name.clone(),
+                version: version.to_string(),
+            });
+        }
+    }
+    Ok(out)
+}

--- a/crates/coronarium-core/src/deps/lockfile/pypi.rs
+++ b/crates/coronarium-core/src/deps/lockfile/pypi.rs
@@ -1,0 +1,220 @@
+//! PyPI lockfile parsing.
+//!
+//! Supports three shapes, dispatched on filename:
+//!
+//! - `uv.lock` — TOML. `[[package]]` entries with `name`, `version`,
+//!   `source.registry = "https://pypi.org/simple"`.
+//! - `poetry.lock` — TOML. `[[package]]` with `name`, `version`. Poetry
+//!   is quieter about "source" — assume PyPI unless `source.type` is
+//!   `git` / `file` / `url`.
+//! - `requirements.txt` — plain text. Only lines matching `name==version`
+//!   (optionally with extras / environment markers we strip) are
+//!   considered pins; ranges, VCS URLs, `-r` includes, editable installs,
+//!   and comments are skipped.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::deps::{Ecosystem, Package};
+
+pub fn parse(path: &Path) -> Result<Vec<Package>> {
+    let fname = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    match fname {
+        "uv.lock" => parse_uv(path),
+        "poetry.lock" => parse_poetry(path),
+        "requirements.txt" => parse_requirements(path),
+        other => anyhow::bail!("unsupported pypi lockfile '{other}'"),
+    }
+}
+
+// -------- uv.lock / poetry.lock (both TOML, same shape for our needs) --------
+
+#[derive(Debug, Deserialize)]
+struct TomlLock {
+    #[serde(rename = "package", default)]
+    packages: Vec<TomlPkg>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TomlPkg {
+    name: String,
+    version: String,
+    #[serde(default)]
+    source: Option<TomlSource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum TomlSource {
+    // poetry.lock: { type = "legacy" | "git" | "file" | "url", ... }
+    // uv.lock:     { registry = "https://pypi.org/simple" } or { git = "...", ... }
+    Struct(TomlSourceStruct),
+    // Bare strings or other shapes: ignored for matching purposes.
+    #[allow(dead_code)]
+    Other(toml::Value),
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct TomlSourceStruct {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    registry: Option<String>,
+    #[serde(default)]
+    git: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+fn parse_uv(path: &Path) -> Result<Vec<Package>> {
+    parse_toml_pypi(path)
+}
+
+fn parse_poetry(path: &Path) -> Result<Vec<Package>> {
+    parse_toml_pypi(path)
+}
+
+fn parse_toml_pypi(path: &Path) -> Result<Vec<Package>> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let lock: TomlLock =
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+
+    let mut out = Vec::new();
+    for p in lock.packages {
+        if !is_pypi_source(p.source.as_ref()) {
+            continue;
+        }
+        out.push(Package {
+            ecosystem: Ecosystem::Pypi,
+            name: p.name,
+            version: p.version,
+        });
+    }
+    Ok(out)
+}
+
+fn is_pypi_source(src: Option<&TomlSource>) -> bool {
+    match src {
+        None => true, // default: assume PyPI
+        Some(TomlSource::Struct(s)) => {
+            // git/url/file deps → not on PyPI
+            if s.git.is_some() || s.url.is_some() {
+                return false;
+            }
+            match s.r#type.as_deref() {
+                Some("git") | Some("file") | Some("url") | Some("directory") => false,
+                _ => {
+                    // uv: registry = "https://pypi.org/simple" (or some mirror).
+                    // Accept anything that mentions pypi OR that has no registry
+                    // specified (poetry default).
+                    match s.registry.as_deref() {
+                        None => true,
+                        Some(r) => r.contains("pypi.org") || r.contains("simple"),
+                    }
+                }
+            }
+        }
+        Some(TomlSource::Other(_)) => true,
+    }
+}
+
+// -------- requirements.txt --------
+
+fn parse_requirements(path: &Path) -> Result<Vec<Package>> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let mut out = Vec::new();
+    for (lineno, raw) in text.lines().enumerate() {
+        if let Some((name, version)) = parse_requirement_line(raw) {
+            out.push(Package {
+                ecosystem: Ecosystem::Pypi,
+                name,
+                version,
+            });
+        } else {
+            log::trace!(
+                "{}:{} skipped (not an exact pin)",
+                path.display(),
+                lineno + 1
+            );
+        }
+    }
+    Ok(out)
+}
+
+/// Accept strict `name[extras]==X.Y.Z[; markers]`. Anything else (ranges,
+/// VCS, editable, includes, comments) is skipped — the whole point of a
+/// publish-age check is reproducibility, so ranges aren't actionable here
+/// anyway.
+fn parse_requirement_line(raw: &str) -> Option<(String, String)> {
+    // Strip comment / whitespace / line-continuation.
+    let line = raw.split('#').next()?.trim();
+    if line.is_empty() {
+        return None;
+    }
+    // Skip option flags and non-pip-installable-from-index forms.
+    if line.starts_with('-')
+        || line.starts_with("git+")
+        || line.starts_with("http://")
+        || line.starts_with("https://")
+        || line.starts_with("file://")
+    {
+        return None;
+    }
+    // Strip environment markers after `;`.
+    let body = line.split(';').next()?.trim();
+    // Must contain `==`.
+    let (lhs, rhs) = body.split_once("==")?;
+    // Strip extras [foo,bar] from LHS.
+    let name = match lhs.split_once('[') {
+        Some((head, _)) => head,
+        None => lhs,
+    };
+    // RHS may have multiple versions comma-separated (unusual) — take first.
+    let version = rhs.split(',').next()?.trim();
+
+    let name = name.trim();
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+    // Validate version loosely (must contain at least one digit).
+    if !version.chars().any(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some((name.to_string(), version.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requirements_line_parses_exact_pins() {
+        assert_eq!(
+            parse_requirement_line("requests==2.31.0"),
+            Some(("requests".into(), "2.31.0".into()))
+        );
+        assert_eq!(
+            parse_requirement_line("Django[argon2]==4.2.7"),
+            Some(("Django".into(), "4.2.7".into()))
+        );
+        assert_eq!(
+            parse_requirement_line("numpy==1.26.0 ; python_version >= '3.9'"),
+            Some(("numpy".into(), "1.26.0".into()))
+        );
+        assert_eq!(parse_requirement_line("  # a comment"), None);
+        assert_eq!(parse_requirement_line(""), None);
+        assert_eq!(parse_requirement_line("-r other.txt"), None);
+        assert_eq!(parse_requirement_line("foo>=1.0,<2.0"), None);
+        assert_eq!(
+            parse_requirement_line("git+https://github.com/x/y@v1"),
+            None
+        );
+    }
+}

--- a/crates/coronarium-core/src/deps/mod.rs
+++ b/crates/coronarium-core/src/deps/mod.rs
@@ -33,6 +33,19 @@ use cache::Cache;
 pub enum Ecosystem {
     Npm,
     Crates,
+    Pypi,
+    Nuget,
+}
+
+impl Ecosystem {
+    pub fn label(self) -> &'static str {
+        match self {
+            Ecosystem::Npm => "npm",
+            Ecosystem::Crates => "crates",
+            Ecosystem::Pypi => "pypi",
+            Ecosystem::Nuget => "nuget",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -108,10 +121,7 @@ pub fn check(args: CheckArgs<'_>) -> Result<CheckReport> {
             continue;
         }
         report.checked += 1;
-        let eco_label = match pkg.ecosystem {
-            Ecosystem::Npm => "npm",
-            Ecosystem::Crates => "crates",
-        };
+        let eco_label = pkg.ecosystem.label();
 
         let fetched = fetch_published(
             &pkg.ecosystem,
@@ -194,6 +204,8 @@ fn fetch_published(
     let result = match eco {
         Ecosystem::Npm => registry::npm::published(name, version, user_agent)?,
         Ecosystem::Crates => registry::crates::published(name, version, user_agent)?,
+        Ecosystem::Pypi => registry::pypi::published(name, version, user_agent)?,
+        Ecosystem::Nuget => registry::nuget::published(name, version, user_agent)?,
     };
     if let (Some(dt), Some(c)) = (result, cache) {
         c.put(eco, name, version, dt);

--- a/crates/coronarium-core/src/deps/registry/mod.rs
+++ b/crates/coronarium-core/src/deps/registry/mod.rs
@@ -1,5 +1,7 @@
 pub mod crates;
 pub mod npm;
+pub mod nuget;
+pub mod pypi;
 
 use std::time::Duration;
 

--- a/crates/coronarium-core/src/deps/registry/nuget.rs
+++ b/crates/coronarium-core/src/deps/registry/nuget.rs
@@ -1,0 +1,80 @@
+//! NuGet registration index client.
+//!
+//! Endpoint family: `https://api.nuget.org/v3/registration5-semver1/<name-lower>/<version>.json`.
+//! The response's `catalogEntry` is either inline (has `.published`) or a
+//! URL pointing at the catalog entry — both shapes are valid NuGet
+//! responses, so handle both.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Leaf {
+    #[serde(rename = "catalogEntry")]
+    catalog_entry: CatalogEntryRef,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CatalogEntryRef {
+    Inline(CatalogEntry),
+    Url(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct CatalogEntry {
+    #[serde(default)]
+    published: Option<String>,
+}
+
+pub fn published(name: &str, version: &str, user_agent: &str) -> Result<Option<DateTime<Utc>>> {
+    let lower = name.to_ascii_lowercase();
+    let version = version.trim_start_matches('v');
+
+    let urls = [
+        format!("https://api.nuget.org/v3/registration5-semver1/{lower}/{version}.json"),
+        format!("https://api.nuget.org/v3/registration5-gz-semver2/{lower}/{version}.json"),
+    ];
+
+    let agent = super::agent();
+    for url in &urls {
+        let resp = agent
+            .get(url)
+            .set("User-Agent", user_agent)
+            .set("Accept", "application/json")
+            .call();
+        let resp = match resp {
+            Ok(r) => r,
+            Err(ureq::Error::Status(404, _)) => continue,
+            Err(e) => return Err(e).with_context(|| format!("GET {url}")),
+        };
+
+        let leaf: Leaf = resp
+            .into_json()
+            .with_context(|| format!("parsing nuget leaf for {name}@{version}"))?;
+
+        let entry = match leaf.catalog_entry {
+            CatalogEntryRef::Inline(e) => e,
+            CatalogEntryRef::Url(catalog_url) => {
+                // Follow the indirection once.
+                let r = agent
+                    .get(&catalog_url)
+                    .set("User-Agent", user_agent)
+                    .set("Accept", "application/json")
+                    .call()
+                    .with_context(|| format!("GET {catalog_url}"))?;
+                r.into_json::<CatalogEntry>()
+                    .with_context(|| format!("parsing nuget catalog entry {catalog_url}"))?
+            }
+        };
+
+        let Some(ts) = entry.published else {
+            return Ok(None);
+        };
+        let dt = DateTime::parse_from_rfc3339(&ts)
+            .with_context(|| format!("parsing nuget timestamp {ts}"))?;
+        return Ok(Some(dt.with_timezone(&Utc)));
+    }
+    Ok(None)
+}

--- a/crates/coronarium-core/src/deps/registry/pypi.rs
+++ b/crates/coronarium-core/src/deps/registry/pypi.rs
@@ -1,0 +1,95 @@
+//! PyPI registry client.
+//!
+//! Endpoint: `GET https://pypi.org/pypi/<name>/<version>/json`.
+//!
+//! The response's `urls` array has one entry per uploaded artifact
+//! (sdist + wheels); all share essentially the same
+//! `upload_time_iso_8601`. We take the earliest as the publish time.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct VersionDoc {
+    #[serde(default)]
+    urls: Vec<UploadedFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadedFile {
+    #[serde(default)]
+    upload_time_iso_8601: Option<String>,
+    #[serde(default)]
+    upload_time: Option<String>,
+}
+
+pub fn published(name: &str, version: &str, user_agent: &str) -> Result<Option<DateTime<Utc>>> {
+    // PyPI normalises package names (PEP 503) to lowercase + `-`/`_`/`.` → `-`.
+    let normalised = normalise(name);
+    let url = format!("https://pypi.org/pypi/{normalised}/{version}/json");
+    let resp = super::agent()
+        .get(&url)
+        .set("User-Agent", user_agent)
+        .set("Accept", "application/json")
+        .call();
+    let resp = match resp {
+        Ok(r) => r,
+        Err(ureq::Error::Status(404, _)) => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("GET {url}")),
+    };
+
+    let doc: VersionDoc = resp
+        .into_json()
+        .with_context(|| format!("parsing pypi metadata for {name}@{version}"))?;
+
+    let mut earliest: Option<DateTime<Utc>> = None;
+    for u in &doc.urls {
+        let ts = u
+            .upload_time_iso_8601
+            .as_deref()
+            .or(u.upload_time.as_deref());
+        let Some(ts) = ts else {
+            continue;
+        };
+        if let Ok(dt) = DateTime::parse_from_rfc3339(ts) {
+            let dt = dt.with_timezone(&Utc);
+            if earliest.is_none_or(|e| dt < e) {
+                earliest = Some(dt);
+            }
+        }
+    }
+    Ok(earliest)
+}
+
+fn normalise(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut last_dash = false;
+    for c in name.chars() {
+        let c = c.to_ascii_lowercase();
+        let replaced = if c == '_' || c == '.' { '-' } else { c };
+        if replaced == '-' {
+            if last_dash {
+                continue;
+            }
+            last_dash = true;
+        } else {
+            last_dash = false;
+        }
+        out.push(replaced);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalise;
+
+    #[test]
+    fn pep503_normalisation() {
+        assert_eq!(normalise("Requests"), "requests");
+        assert_eq!(normalise("python_dateutil"), "python-dateutil");
+        assert_eq!(normalise("typing.extensions"), "typing-extensions");
+        assert_eq!(normalise("Django__auto"), "django-auto");
+    }
+}

--- a/tests/fixtures/package-lock.json
+++ b/tests/fixtures/package-lock.json
@@ -1,0 +1,17 @@
+{
+  "name": "coronarium-smoke-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "coronarium-smoke-fixture",
+      "version": "0.0.0"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "placeholder-not-checked-by-tool"
+    }
+  }
+}

--- a/tests/fixtures/packages.lock.json
+++ b/tests/fixtures/packages.lock.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "resolved": "13.0.1",
+        "contentHash": "placeholder-not-checked-by-tool"
+      }
+    }
+  }
+}

--- a/tests/fixtures/requirements.txt
+++ b/tests/fixtures/requirements.txt
@@ -1,0 +1,4 @@
+# Tiny fixture: old, well-known pins that will always pass a 1-day age check.
+# Used by the deps-check smoke job.
+requests==2.25.0
+Django==3.2.0


### PR DESCRIPTION
Expands coronarium deps check from {npm, cargo} to {npm, cargo, pypi, nuget}. See commit message for scope + smoke details.