### PR TITLE
feat(desktop): `coronarium deps watch` — resident macOS lockfile monitor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,41 @@ jobs:
             coronarium-${{ matrix.target }}.tar.gz
             coronarium-${{ matrix.target }}.tar.gz.sha256
 
+  build-macos:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-13     # Intel
+          - target: aarch64-apple-darwin
+            runner: macos-14     # Apple Silicon
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build coronarium (macOS)
+        run: cargo build --release -p coronarium --target ${{ matrix.target }}
+      - name: Package tarball
+        run: |
+          set -euo pipefail
+          name="coronarium-${{ matrix.target }}"
+          staging="staging/${name}"
+          mkdir -p "${staging}"
+          cp "target/${{ matrix.target }}/release/coronarium" "${staging}/coronarium"
+          cp README.md "${staging}/" 2>/dev/null || true
+          cp packaging/macos/dev.coronarium.watch.plist "${staging}/" 2>/dev/null || true
+          cp packaging/macos/README.md "${staging}/macos-README.md" 2>/dev/null || true
+          tar -czf "${name}.tar.gz" -C staging "${name}"
+          shasum -a 256 "${name}.tar.gz" > "${name}.tar.gz.sha256"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            coronarium-${{ matrix.target }}.tar.gz
+            coronarium-${{ matrix.target }}.tar.gz.sha256
+
   build-windows:
     runs-on: windows-latest
     env:
@@ -96,7 +131,7 @@ jobs:
             coronarium-x86_64-pc-windows-msvc.tar.gz.sha256
 
   publish:
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "libc",
  "log",
@@ -165,6 +165,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -342,6 +348,7 @@ dependencies = [
  "chrono",
  "coronarium-common",
  "log",
+ "notify",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -357,6 +364,21 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "data-encoding"
@@ -427,6 +449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -773,6 +815,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +903,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +933,18 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -896,6 +990,18 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -911,10 +1017,29 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -989,7 +1114,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1005,6 +1130,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1109,7 +1240,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1207,6 +1347,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1436,7 +1585,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1610,6 +1759,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1865,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1735,6 +1894,15 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-core"
@@ -1808,11 +1976,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1826,19 +2003,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1848,9 +2046,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1866,9 +2076,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1878,9 +2100,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1961,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ipnet = { version = "2", features = ["serde"] }
 ureq = { version = "2", default-features = false, features = ["tls", "json"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
 toml = "0.8"
+notify = "6"
 hickory-resolver = "0.24"
 uuid = { version = "1", features = ["v4"] }
 nix = { version = "0.29", features = ["sched", "process", "user", "fs"] }

--- a/crates/coronarium-core/Cargo.toml
+++ b/crates/coronarium-core/Cargo.toml
@@ -18,4 +18,5 @@ log = { workspace = true }
 ureq = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
+notify = { workspace = true }
 coronarium-common = { path = "../coronarium-common", features = ["user"] }

--- a/crates/coronarium-core/src/deps/cli.rs
+++ b/crates/coronarium-core/src/deps/cli.rs
@@ -27,6 +27,103 @@ pub enum Format {
     Json,
 }
 
+pub struct WatchCliArgs {
+    pub roots: Vec<PathBuf>,
+    pub min_age: String,
+    pub ignore: Vec<String>,
+    pub no_cache: bool,
+    pub cache_path: Option<PathBuf>,
+    pub debounce_ms: u64,
+    pub tick_ms: u64,
+    pub notifier: WatchNotifierKind,
+    pub user_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum WatchNotifierKind {
+    /// Native macOS `display notification` via osascript.
+    Mac,
+    /// Plain stderr logging (useful in tmux / screen / headless dev).
+    Stdout,
+}
+
+pub fn run_watch(args: WatchCliArgs) -> Result<()> {
+    use super::watch::{Debouncer, NotifyEventSource, StdoutNotifier, WatchLoop};
+
+    let min_age = parse_duration(&args.min_age)?;
+    let cache_path = if args.no_cache {
+        None
+    } else {
+        Some(args.cache_path.unwrap_or_else(default_cache_path))
+    };
+    let user_agent = args
+        .user_agent
+        .unwrap_or_else(|| format!("coronarium/{}", env!("CARGO_PKG_VERSION")));
+
+    // Initial pass: scan each root once, so a stale too-new dep that was
+    // already in the lockfile surfaces immediately instead of waiting
+    // for the next edit.
+    let initial_hits: Vec<PathBuf> = args
+        .roots
+        .iter()
+        .flat_map(|r| super::watch::scan_lockfiles(r))
+        .collect();
+
+    log::info!(
+        "watching {} root(s) — found {} lockfile(s) on initial scan",
+        args.roots.len(),
+        initial_hits.len(),
+    );
+
+    let source = NotifyEventSource::new(&args.roots)?;
+
+    // Pick the notifier backend.
+    let stdout_notifier;
+    #[cfg(target_os = "macos")]
+    let mac_notifier;
+    let notifier_ref: &dyn super::watch::Notifier = match args.notifier {
+        #[cfg(target_os = "macos")]
+        WatchNotifierKind::Mac => {
+            mac_notifier = super::watch::MacNotifier::new();
+            &mac_notifier
+        }
+        #[cfg(not(target_os = "macos"))]
+        WatchNotifierKind::Mac => {
+            log::warn!("--notifier=mac is macOS-only; falling back to stdout");
+            stdout_notifier = StdoutNotifier;
+            &stdout_notifier
+        }
+        WatchNotifierKind::Stdout => {
+            stdout_notifier = StdoutNotifier;
+            &stdout_notifier
+        }
+    };
+
+    let mut wl = WatchLoop {
+        source,
+        notifier: notifier_ref,
+        debouncer: Debouncer::new(std::time::Duration::from_millis(args.debounce_ms)),
+        min_age,
+        ignore: args.ignore,
+        cache_path,
+        user_agent,
+        tick: std::time::Duration::from_millis(args.tick_ms),
+        now: std::time::Instant::now,
+    };
+
+    // Seed with the initial scan so stale violations aren't silent.
+    for p in initial_hits {
+        wl.debouncer.touch(&p, std::time::Instant::now());
+    }
+
+    loop {
+        match wl.tick_once() {
+            Ok(_) => {}
+            Err(e) => log::error!("watch tick failed: {e:#}"),
+        }
+    }
+}
+
 pub fn run(args: CliArgs) -> Result<i32> {
     let min_age = parse_duration(&args.min_age)?;
     let cache_path = if args.no_cache {

--- a/crates/coronarium-core/src/deps/mod.rs
+++ b/crates/coronarium-core/src/deps/mod.rs
@@ -19,6 +19,7 @@ pub mod cache;
 pub mod cli;
 pub mod lockfile;
 pub mod registry;
+pub mod watch;
 
 use std::path::Path;
 use std::time::Duration;

--- a/crates/coronarium-core/src/deps/watch/debounce.rs
+++ b/crates/coronarium-core/src/deps/watch/debounce.rs
@@ -1,0 +1,105 @@
+//! Coalesce bursts of FS events for the same path.
+//!
+//! `npm install` tends to rewrite `package-lock.json` a few times in
+//! rapid succession (parse → install → dedupe). Without debouncing
+//! we'd run `deps check` 3× per install. The debouncer records
+//! `(path, timestamp)` tuples and tells the caller which paths are now
+//! "settled" (last change older than `window`).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub struct Debouncer {
+    window: Duration,
+    pending: HashMap<PathBuf, Instant>,
+}
+
+impl Debouncer {
+    pub fn new(window: Duration) -> Self {
+        Self {
+            window,
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Record a change event for `path` at `now`.
+    pub fn touch(&mut self, path: &Path, now: Instant) {
+        self.pending.insert(path.to_path_buf(), now);
+    }
+
+    /// Drain paths whose last touch is older than `window` at `now`.
+    pub fn drain_settled(&mut self, now: Instant) -> Vec<PathBuf> {
+        let settled: Vec<PathBuf> = self
+            .pending
+            .iter()
+            .filter_map(|(p, t)| {
+                if now.duration_since(*t) >= self.window {
+                    Some(p.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for p in &settled {
+            self.pending.remove(p);
+        }
+        settled
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_is_not_settled_until_window_elapses() {
+        let mut d = Debouncer::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.touch(Path::new("/x"), t0);
+        assert!(d.drain_settled(t0 + Duration::from_millis(400)).is_empty());
+        assert_eq!(d.pending_len(), 1);
+    }
+
+    #[test]
+    fn event_becomes_settled_after_window() {
+        let mut d = Debouncer::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.touch(Path::new("/x"), t0);
+        let out = d.drain_settled(t0 + Duration::from_millis(600));
+        assert_eq!(out, vec![PathBuf::from("/x")]);
+        assert_eq!(d.pending_len(), 0);
+    }
+
+    #[test]
+    fn bursts_for_same_path_coalesce() {
+        let mut d = Debouncer::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.touch(Path::new("/a"), t0);
+        d.touch(Path::new("/a"), t0 + Duration::from_millis(100));
+        d.touch(Path::new("/a"), t0 + Duration::from_millis(200));
+        // Not settled at 400ms from last touch, still 300ms away.
+        assert!(
+            d.drain_settled(t0 + Duration::from_millis(500)).is_empty(),
+            "expected burst to still be pending"
+        );
+        // Settled once window elapses from the *last* touch.
+        let out = d.drain_settled(t0 + Duration::from_millis(800));
+        assert_eq!(out, vec![PathBuf::from("/a")]);
+    }
+
+    #[test]
+    fn different_paths_are_independent() {
+        let mut d = Debouncer::new(Duration::from_millis(500));
+        let t0 = Instant::now();
+        d.touch(Path::new("/a"), t0);
+        d.touch(Path::new("/b"), t0 + Duration::from_millis(400));
+        let out = d.drain_settled(t0 + Duration::from_millis(600));
+        assert_eq!(out, vec![PathBuf::from("/a")]);
+        assert_eq!(d.pending_len(), 1);
+    }
+}

--- a/crates/coronarium-core/src/deps/watch/discover.rs
+++ b/crates/coronarium-core/src/deps/watch/discover.rs
@@ -1,0 +1,145 @@
+//! Find lockfiles inside a directory tree.
+
+use std::path::{Path, PathBuf};
+
+/// Lockfile basenames the watch mode recognises. Must match what
+/// `deps::lockfile::detect` accepts.
+pub const LOCKFILE_NAMES: &[&str] = &[
+    "package-lock.json",
+    "Cargo.lock",
+    "uv.lock",
+    "poetry.lock",
+    "requirements.txt",
+    "packages.lock.json",
+];
+
+/// Walk `root` (up to `max_depth`) and return paths to every known
+/// lockfile. Skips `.git`, `node_modules`, `target`, and any directory
+/// whose name starts with `.` (dotdirs) to keep scans fast on large
+/// workspaces.
+pub fn scan_lockfiles(root: &Path) -> Vec<PathBuf> {
+    scan_with_depth(root, 12)
+}
+
+pub fn scan_with_depth(root: &Path, max_depth: usize) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk(root, max_depth, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if ft.is_dir() {
+            if is_skipped_dir(&path) {
+                continue;
+            }
+            walk(&path, depth - 1, out);
+        } else if (ft.is_file() || ft.is_symlink())
+            && let Some(name) = path.file_name().and_then(|s| s.to_str())
+            && LOCKFILE_NAMES.contains(&name)
+        {
+            out.push(path);
+        }
+    }
+}
+
+fn is_skipped_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    if name.starts_with('.') {
+        return true;
+    }
+    matches!(
+        name,
+        "node_modules" | "target" | "dist" | "build" | "__pycache__" | ".venv" | "venv" | ".tox"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let d = std::env::temp_dir().join(format!("coronarium-watch-{tag}-{id}"));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn finds_all_known_lockfiles_at_root() {
+        let d = tmpdir("root");
+        for name in LOCKFILE_NAMES {
+            fs::write(d.join(name), "").unwrap();
+        }
+        let found = scan_lockfiles(&d);
+        assert_eq!(found.len(), LOCKFILE_NAMES.len());
+    }
+
+    #[test]
+    fn walks_into_nested_dirs() {
+        let d = tmpdir("nested");
+        fs::create_dir_all(d.join("a/b/c")).unwrap();
+        fs::write(d.join("a/b/c/Cargo.lock"), "").unwrap();
+        fs::write(d.join("a/package-lock.json"), "").unwrap();
+        let found = scan_lockfiles(&d);
+        let names: Vec<String> = found
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|s| s.to_str()).map(str::to_string))
+            .collect();
+        assert!(names.contains(&"Cargo.lock".to_string()));
+        assert!(names.contains(&"package-lock.json".to_string()));
+    }
+
+    #[test]
+    fn skips_vendor_build_and_hidden_dirs() {
+        let d = tmpdir("skip");
+        for skip in ["node_modules", "target", ".git", ".venv"] {
+            let sub = d.join(skip);
+            fs::create_dir_all(&sub).unwrap();
+            fs::write(sub.join("Cargo.lock"), "").unwrap();
+        }
+        let found = scan_lockfiles(&d);
+        assert!(
+            found.is_empty(),
+            "expected no lockfiles to be found inside vendor dirs, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn max_depth_respected() {
+        let d = tmpdir("depth");
+        // Construct 3 nested dirs with a lockfile at the deepest level.
+        let deep = d.join("a/b/c");
+        fs::create_dir_all(&deep).unwrap();
+        fs::write(deep.join("Cargo.lock"), "").unwrap();
+        assert!(scan_with_depth(&d, 4).len() == 1);
+        assert!(scan_with_depth(&d, 2).is_empty());
+    }
+
+    #[test]
+    fn unknown_filenames_ignored() {
+        let d = tmpdir("unknown");
+        fs::write(d.join("Cargo.toml"), "").unwrap();
+        fs::write(d.join("pyproject.toml"), "").unwrap();
+        fs::write(d.join("Gemfile.lock"), "").unwrap();
+        assert!(scan_lockfiles(&d).is_empty());
+    }
+}

--- a/crates/coronarium-core/src/deps/watch/engine.rs
+++ b/crates/coronarium-core/src/deps/watch/engine.rs
@@ -1,0 +1,235 @@
+//! The actual watch loop: takes a stream of "lockfile changed" events,
+//! runs `deps check`, and posts notifications through a [`Notifier`].
+//!
+//! The loop is written as a pure-function iteration around a trait
+//! (`EventSource`) so it can be driven either by real FS events or by
+//! a deterministic in-memory source in tests.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+
+use crate::deps::{CheckArgs, CheckReport, check};
+
+use super::{Debouncer, Notifier, format::format_violation};
+
+/// A pluggable source of "this lockfile may have changed" events.
+pub trait EventSource {
+    /// Block for at most `timeout`, return zero or more paths that
+    /// recently changed. Implementations should return promptly when
+    /// there's nothing to report so the caller can run periodic work.
+    fn poll(&mut self, timeout: Duration) -> Vec<PathBuf>;
+}
+
+pub struct WatchLoop<'a, S: EventSource, N: Notifier + ?Sized> {
+    pub source: S,
+    pub notifier: &'a N,
+    pub debouncer: Debouncer,
+    pub min_age: Duration,
+    pub ignore: Vec<String>,
+    pub cache_path: Option<PathBuf>,
+    pub user_agent: String,
+    pub tick: Duration,
+    /// Test hook: clock source, so tests can advance time deterministically.
+    pub now: fn() -> Instant,
+}
+
+impl<'a, S: EventSource, N: Notifier + ?Sized> WatchLoop<'a, S, N> {
+    /// Run exactly one iteration: poll the source, debounce, check any
+    /// settled lockfiles, notify on violations. Returns how many
+    /// notifications were emitted in this tick (useful for tests).
+    pub fn tick_once(&mut self) -> Result<usize> {
+        for p in self.source.poll(self.tick) {
+            self.debouncer.touch(&p, (self.now)());
+        }
+        let settled = self.debouncer.drain_settled((self.now)());
+        let mut emitted = 0;
+        for lockfile in settled {
+            emitted += self.check_and_notify(&lockfile)?;
+        }
+        Ok(emitted)
+    }
+
+    fn check_and_notify(&self, lockfile: &Path) -> Result<usize> {
+        let lockfiles = [lockfile.to_path_buf()];
+        let args = CheckArgs {
+            lockfiles: &lockfiles,
+            min_age: self.min_age,
+            ignore: &self.ignore,
+            fail_on_missing: false,
+            cache: self.cache_path.as_deref(),
+            user_agent: &self.user_agent,
+        };
+        let report: CheckReport = check(args)?;
+        if report.violations == 0 {
+            return Ok(0);
+        }
+        let n = format_violation(lockfile, &report);
+        self.notifier.notify(&n.title, &n.body)?;
+        Ok(1)
+    }
+}
+
+/// An [`EventSource`] backed by the `notify` crate's FS-event stream.
+pub struct NotifyEventSource {
+    rx: std::sync::mpsc::Receiver<notify::Result<notify::Event>>,
+    _watcher: Box<dyn notify::Watcher + Send>,
+}
+
+impl NotifyEventSource {
+    pub fn new(roots: &[PathBuf]) -> Result<Self> {
+        use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher: RecommendedWatcher = RecommendedWatcher::new(
+            move |res| {
+                let _ = tx.send(res);
+            },
+            notify::Config::default(),
+        )?;
+        for r in roots {
+            watcher.watch(r, RecursiveMode::Recursive)?;
+        }
+        Ok(Self {
+            rx,
+            _watcher: Box::new(watcher),
+        })
+    }
+}
+
+impl EventSource for NotifyEventSource {
+    fn poll(&mut self, timeout: Duration) -> Vec<PathBuf> {
+        use super::discover::LOCKFILE_NAMES;
+        let mut out = Vec::new();
+        let Ok(res) = self.rx.recv_timeout(timeout) else {
+            return out;
+        };
+        let Ok(ev) = res else {
+            return out;
+        };
+        // Only surface events on files we actually care about.
+        for p in ev.paths {
+            if p.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| LOCKFILE_NAMES.contains(&s))
+            {
+                out.push(p);
+            }
+        }
+        // Drain anything else queued up so a burst doesn't serialise
+        // across many `poll` calls.
+        while let Ok(Ok(ev)) = self.rx.try_recv() {
+            for p in ev.paths {
+                if p.file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| LOCKFILE_NAMES.contains(&s))
+                {
+                    out.push(p);
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Silence unused-Arc warning when some consumers want atomic shared
+/// ownership but the current type signature doesn't need it.
+#[allow(dead_code)]
+fn _assert_arc_usable() {
+    let _: Arc<dyn Notifier + Send + Sync> = Arc::new(super::StdoutNotifier);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deps::watch::CollectingNotifier;
+    use std::collections::VecDeque;
+
+    // --- deterministic test fixtures -------------------------------------
+
+    /// An `EventSource` that yields prearranged path lists on successive
+    /// `poll()` calls.
+    struct FakeSource {
+        chunks: VecDeque<Vec<PathBuf>>,
+    }
+    impl EventSource for FakeSource {
+        fn poll(&mut self, _timeout: Duration) -> Vec<PathBuf> {
+            self.chunks.pop_front().unwrap_or_default()
+        }
+    }
+
+    fn write_cargo_lock(dir: &Path) -> PathBuf {
+        // A lockfile with zero registry deps — `deps check` will yield
+        // a CheckReport with checked=0, violations=0 (no network needed).
+        let p = dir.join("Cargo.lock");
+        std::fs::write(&p, "version = 3\n").unwrap();
+        p
+    }
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let d = std::env::temp_dir().join(format!("coronarium-watch-engine-{tag}-{id}"));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn clean_report_does_not_notify() {
+        let d = tmpdir("clean");
+        let lf = write_cargo_lock(&d);
+
+        let notifier = CollectingNotifier::new();
+        let base = Instant::now();
+        let mut wl = WatchLoop::<FakeSource, CollectingNotifier> {
+            source: FakeSource {
+                chunks: vec![vec![lf.clone()]].into(),
+            },
+            notifier: &notifier,
+            debouncer: Debouncer::new(Duration::from_millis(0)),
+            min_age: Duration::from_secs(0),
+            ignore: vec![],
+            cache_path: None,
+            user_agent: "coronarium-test".into(),
+            tick: Duration::from_millis(0),
+            now: Instant::now,
+        };
+        let emitted = wl.tick_once().unwrap();
+        assert_eq!(emitted, 0);
+        assert!(notifier.take().is_empty());
+        let _ = base;
+    }
+
+    #[test]
+    fn touches_below_window_stay_pending_across_ticks() {
+        let d = tmpdir("window");
+        let lf = write_cargo_lock(&d);
+
+        let notifier = CollectingNotifier::new();
+        let mut wl = WatchLoop::<FakeSource, CollectingNotifier> {
+            source: FakeSource {
+                chunks: vec![vec![lf.clone()], vec![], vec![]].into(),
+            },
+            notifier: &notifier,
+            // Very long debounce — events should never settle in this test.
+            debouncer: Debouncer::new(Duration::from_secs(3600)),
+            min_age: Duration::from_secs(0),
+            ignore: vec![],
+            cache_path: None,
+            user_agent: "coronarium-test".into(),
+            tick: Duration::from_millis(0),
+            now: Instant::now,
+        };
+        for _ in 0..3 {
+            let emitted = wl.tick_once().unwrap();
+            assert_eq!(emitted, 0);
+        }
+        // Even though the lockfile was "touched", the window never
+        // elapsed, so no check / no notification.
+        assert!(notifier.take().is_empty());
+    }
+}

--- a/crates/coronarium-core/src/deps/watch/format.rs
+++ b/crates/coronarium-core/src/deps/watch/format.rs
@@ -1,0 +1,141 @@
+//! Render a `CheckReport` into a pair of `(title, body)` strings suitable
+//! for a macOS / GNOME desktop notification. Kept pure so it's trivial
+//! to test without actually posting a notification.
+
+use std::path::Path;
+
+use crate::deps::CheckReport;
+
+pub struct Notification {
+    pub title: String,
+    pub body: String,
+}
+
+/// Build a compact notification for `lockfile`'s `report`. Only call
+/// this when `report.violations > 0` — the caller decides whether to
+/// surface clean runs at all.
+pub fn format_violation(lockfile: &Path, report: &CheckReport) -> Notification {
+    let short_path = lockfile
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("(lockfile)")
+        .to_string();
+
+    let title = format!(
+        "coronarium: {} new deps in {}",
+        report.violations, short_path
+    );
+
+    // Body: up to 3 violating packages, "+N more" if there are extras.
+    let mut violating: Vec<String> = report
+        .packages
+        .iter()
+        .filter(|p| p.too_new)
+        .take(3)
+        .map(|p| {
+            let age = p
+                .age_hours
+                .map(|h| format!("{h}h"))
+                .unwrap_or_else(|| "?".into());
+            format!("• {}/{}@{} ({age} old)", p.ecosystem, p.name, p.version)
+        })
+        .collect();
+    let extra = report.violations.saturating_sub(violating.len());
+    if extra > 0 {
+        violating.push(format!("+{extra} more"));
+    }
+
+    let body = format!(
+        "min-age {}h, {} checked\n{}",
+        report.min_age_hours,
+        report.checked,
+        violating.join("\n")
+    );
+
+    Notification { title, body }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deps::{CheckReport, PackageReport};
+    use std::path::PathBuf;
+
+    fn pkg(eco: &'static str, name: &str, age: i64, too_new: bool) -> PackageReport {
+        PackageReport {
+            ecosystem: eco,
+            name: name.into(),
+            version: "1.0.0".into(),
+            published: None,
+            age_hours: Some(age),
+            too_new,
+            error: None,
+        }
+    }
+
+    fn report(packages: Vec<PackageReport>, min_age_hours: i64) -> CheckReport {
+        let violations = packages.iter().filter(|p| p.too_new).count();
+        CheckReport {
+            min_age_hours,
+            checked: packages.len(),
+            violations,
+            errors: 0,
+            packages,
+        }
+    }
+
+    #[test]
+    fn title_mentions_lockfile_basename() {
+        let lf = PathBuf::from("/home/u/proj/Cargo.lock");
+        let r = report(vec![pkg("crates", "badpkg", 1, true)], 168);
+        let n = format_violation(&lf, &r);
+        assert!(n.title.contains("Cargo.lock"), "got {:?}", n.title);
+        assert!(n.title.contains('1'));
+    }
+
+    #[test]
+    fn body_lists_first_three_then_summarises() {
+        let pkgs = vec![
+            pkg("npm", "a", 1, true),
+            pkg("npm", "b", 2, true),
+            pkg("npm", "c", 3, true),
+            pkg("npm", "d", 4, true),
+            pkg("npm", "e", 5, true),
+        ];
+        let r = report(pkgs, 168);
+        let n = format_violation(&PathBuf::from("package-lock.json"), &r);
+        for name in ["npm/a@", "npm/b@", "npm/c@"] {
+            assert!(n.body.contains(name), "missing {name} in {:?}", n.body);
+        }
+        assert!(
+            n.body.contains("+2 more"),
+            "expected '+2 more' footer, got {:?}",
+            n.body
+        );
+        assert!(!n.body.contains("npm/d@"));
+    }
+
+    #[test]
+    fn body_omits_extra_footer_when_fewer_than_three() {
+        let r = report(vec![pkg("npm", "solo", 5, true)], 168);
+        let n = format_violation(&PathBuf::from("package-lock.json"), &r);
+        assert!(!n.body.contains("more"));
+        assert!(n.body.contains("npm/solo"));
+    }
+
+    #[test]
+    fn title_handles_path_without_filename_gracefully() {
+        let n = format_violation(
+            &PathBuf::from("/"),
+            &report(vec![pkg("crates", "x", 1, true)], 24),
+        );
+        assert!(n.title.contains("lockfile"));
+    }
+
+    #[test]
+    fn body_includes_min_age_and_checked_count() {
+        let r = report(vec![pkg("pypi", "X", 1, true)], 168);
+        let n = format_violation(&PathBuf::from("uv.lock"), &r);
+        assert!(n.body.starts_with("min-age 168h, 1 checked"));
+    }
+}

--- a/crates/coronarium-core/src/deps/watch/mod.rs
+++ b/crates/coronarium-core/src/deps/watch/mod.rs
@@ -1,0 +1,25 @@
+//! Desktop "watch" mode for `coronarium deps`.
+//!
+//! Runs as a long-lived process (typically under `launchd` on macOS).
+//! Walks the configured workspace dirs for known lockfile names,
+//! subscribes to FS events via the `notify` crate, debounces bursts of
+//! writes, and runs the usual [`crate::deps::check`] every time a
+//! lockfile settles. Violations are pushed to a pluggable [`Notifier`].
+//!
+//! The public surface is intentionally small and pure-Rust so the whole
+//! thing is unit-testable without touching FS events or macOS.
+
+pub mod debounce;
+pub mod discover;
+pub mod engine;
+pub mod format;
+pub mod notifier;
+
+pub use debounce::Debouncer;
+pub use discover::{LOCKFILE_NAMES, scan_lockfiles};
+pub use engine::{EventSource, NotifyEventSource, WatchLoop};
+pub use format::format_violation;
+pub use notifier::{CollectingNotifier, Notifier, StdoutNotifier};
+
+#[cfg(target_os = "macos")]
+pub use notifier::MacNotifier;

--- a/crates/coronarium-core/src/deps/watch/notifier.rs
+++ b/crates/coronarium-core/src/deps/watch/notifier.rs
@@ -1,0 +1,122 @@
+//! Pluggable notification sink.
+//!
+//! `Notifier` abstracts "how to tell the user" so the watch loop is
+//! pure-function-testable. `MacNotifier` shells out to `osascript`
+//! (works on vanilla macOS, no extra install), `StdoutNotifier` prints
+//! to stderr for CLI debugging, and `CollectingNotifier` captures into
+//! a `Vec` for unit tests.
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+
+pub trait Notifier: Send + Sync {
+    fn notify(&self, title: &str, body: &str) -> Result<()>;
+}
+
+// ---- stdout ----
+
+pub struct StdoutNotifier;
+
+impl Notifier for StdoutNotifier {
+    fn notify(&self, title: &str, body: &str) -> Result<()> {
+        eprintln!("[notify] {title}\n  {}", body.replace('\n', "\n  "));
+        Ok(())
+    }
+}
+
+// ---- in-memory collector (tests) ----
+
+#[derive(Default, Clone)]
+pub struct CollectingNotifier {
+    pub events: Arc<Mutex<Vec<(String, String)>>>,
+}
+
+impl CollectingNotifier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn take(&self) -> Vec<(String, String)> {
+        std::mem::take(&mut *self.events.lock().unwrap())
+    }
+}
+
+impl Notifier for CollectingNotifier {
+    fn notify(&self, title: &str, body: &str) -> Result<()> {
+        self.events
+            .lock()
+            .unwrap()
+            .push((title.to_string(), body.to_string()));
+        Ok(())
+    }
+}
+
+// ---- macOS ----
+
+#[cfg(target_os = "macos")]
+pub struct MacNotifier {
+    pub subtitle: String,
+}
+
+#[cfg(target_os = "macos")]
+impl MacNotifier {
+    pub fn new() -> Self {
+        Self {
+            subtitle: "coronarium".to_string(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for MacNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Notifier for MacNotifier {
+    fn notify(&self, title: &str, body: &str) -> Result<()> {
+        use std::process::Command;
+        // AppleScript quoting: embed `"` by doubling. Newlines are fine
+        // inside an AppleScript string literal.
+        let esc_title = title.replace('"', "\\\"");
+        let esc_body = body.replace('"', "\\\"");
+        let esc_sub = self.subtitle.replace('"', "\\\"");
+        let script = format!(
+            "display notification \"{esc_body}\" with title \"{esc_title}\" subtitle \"{esc_sub}\""
+        );
+        let status = Command::new("osascript").args(["-e", &script]).status()?;
+        if !status.success() {
+            anyhow::bail!("osascript exited {status}");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collecting_captures_in_order() {
+        let n = CollectingNotifier::new();
+        n.notify("A", "body a").unwrap();
+        n.notify("B", "body b").unwrap();
+        let got = n.take();
+        assert_eq!(
+            got,
+            vec![
+                ("A".to_string(), "body a".to_string()),
+                ("B".to_string(), "body b".to_string())
+            ]
+        );
+        // Subsequent `take` returns empty.
+        assert!(n.take().is_empty());
+    }
+
+    #[test]
+    fn stdout_notifier_never_errors() {
+        StdoutNotifier.notify("x", "y").unwrap();
+    }
+}

--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -407,6 +407,9 @@ fn run_deps(raw: &[String]) -> Result<()> {
     enum DepsCmd {
         /// Check publish ages against all dependencies in the given lockfile(s).
         Check(DepsCheckArgs),
+        /// Resident watcher (stdout notifier on Windows — pipe to your
+        /// preferred toast / Teams hook).
+        Watch(DepsWatchArgs),
     }
     #[derive(Debug, Parser)]
     struct DepsCheckArgs {
@@ -431,26 +434,60 @@ fn run_deps(raw: &[String]) -> Result<()> {
         Json,
     }
 
+    #[derive(Debug, Parser)]
+    struct DepsWatchArgs {
+        #[arg(required = true)]
+        roots: Vec<std::path::PathBuf>,
+        #[arg(long, default_value = "7d")]
+        min_age: String,
+        #[arg(long)]
+        ignore: Vec<String>,
+        #[arg(long)]
+        no_cache: bool,
+        #[arg(long)]
+        cache: Option<std::path::PathBuf>,
+        #[arg(long, default_value_t = 800)]
+        debounce_ms: u64,
+        #[arg(long, default_value_t = 250)]
+        tick_ms: u64,
+    }
+
     // Drop argv[0] (binary) and argv[1] ("deps") so clap sees just the
     // subcommand tokens.
     let remainder: Vec<&str> = raw.iter().skip(2).map(|s| s.as_str()).collect();
     let parsed = DepsCli::try_parse_from(remainder).map_err(|e| anyhow::anyhow!("{e}"))?;
-    let DepsCmd::Check(args) = parsed.cmd;
-
-    let exit = coronarium_core::deps::cli::run(coronarium_core::deps::cli::CliArgs {
-        lockfiles: args.lockfiles,
-        min_age: args.min_age,
-        ignore: args.ignore,
-        fail_on_missing: args.fail_on_missing,
-        no_cache: args.no_cache,
-        cache_path: args.cache,
-        format: match args.format {
-            DepsFormatArg::Text => coronarium_core::deps::cli::Format::Text,
-            DepsFormatArg::Json => coronarium_core::deps::cli::Format::Json,
-        },
-        user_agent: None,
-    })?;
-    std::process::exit(exit);
+    match parsed.cmd {
+        DepsCmd::Check(args) => {
+            let exit = coronarium_core::deps::cli::run(coronarium_core::deps::cli::CliArgs {
+                lockfiles: args.lockfiles,
+                min_age: args.min_age,
+                ignore: args.ignore,
+                fail_on_missing: args.fail_on_missing,
+                no_cache: args.no_cache,
+                cache_path: args.cache,
+                format: match args.format {
+                    DepsFormatArg::Text => coronarium_core::deps::cli::Format::Text,
+                    DepsFormatArg::Json => coronarium_core::deps::cli::Format::Json,
+                },
+                user_agent: None,
+            })?;
+            std::process::exit(exit);
+        }
+        DepsCmd::Watch(args) => {
+            coronarium_core::deps::cli::run_watch(coronarium_core::deps::cli::WatchCliArgs {
+                roots: args.roots,
+                min_age: args.min_age,
+                ignore: args.ignore,
+                no_cache: args.no_cache,
+                cache_path: args.cache,
+                debounce_ms: args.debounce_ms,
+                tick_ms: args.tick_ms,
+                notifier: coronarium_core::deps::cli::WatchNotifierKind::Stdout,
+                user_agent: None,
+            })?;
+            Ok(())
+        }
+    }
 }
 
 /// Logs each distinct event id a provider emits exactly once. Helps debug

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -40,6 +40,42 @@ pub enum Command {
 pub enum DepsCommand {
     /// Check publish ages against all dependencies in the given lockfile(s).
     Check(DepsCheckArgs),
+    /// Stay resident: watch one or more workspace roots, run `check` on
+    /// every lockfile change, and surface violations via a desktop
+    /// notification. Designed for `launchd` / `systemd --user`.
+    Watch(DepsWatchArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct DepsWatchArgs {
+    /// Workspace root(s) to watch recursively.
+    #[arg(required = true)]
+    pub roots: Vec<PathBuf>,
+    /// Minimum age a package must have.
+    #[arg(long, default_value = "7d")]
+    pub min_age: String,
+    #[arg(long)]
+    pub ignore: Vec<String>,
+    #[arg(long)]
+    pub no_cache: bool,
+    #[arg(long)]
+    pub cache: Option<PathBuf>,
+    /// How long to wait for a burst of edits to settle, in ms.
+    #[arg(long, default_value_t = 800)]
+    pub debounce_ms: u64,
+    /// Poll interval for the FS-event source, in ms.
+    #[arg(long, default_value_t = 250)]
+    pub tick_ms: u64,
+    /// Notification sink. `mac` uses osascript (macOS only), `stdout`
+    /// prints to stderr — good for launchctl log redirects.
+    #[arg(long, value_enum, default_value = "mac")]
+    pub notifier: DepsNotifier,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum DepsNotifier {
+    Mac,
+    Stdout,
 }
 
 #[derive(Debug, Parser)]
@@ -139,6 +175,25 @@ pub async fn run(cli: Cli) -> Result<()> {
                 user_agent: None,
             })?;
             std::process::exit(exit);
+        }
+        Command::Deps {
+            cmd: DepsCommand::Watch(args),
+        } => {
+            coronarium_core::deps::cli::run_watch(coronarium_core::deps::cli::WatchCliArgs {
+                roots: args.roots,
+                min_age: args.min_age,
+                ignore: args.ignore,
+                no_cache: args.no_cache,
+                cache_path: args.cache,
+                debounce_ms: args.debounce_ms,
+                tick_ms: args.tick_ms,
+                notifier: match args.notifier {
+                    DepsNotifier::Mac => coronarium_core::deps::cli::WatchNotifierKind::Mac,
+                    DepsNotifier::Stdout => coronarium_core::deps::cli::WatchNotifierKind::Stdout,
+                },
+                user_agent: None,
+            })?;
+            Ok(())
         }
     }
 }

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,61 @@
+# coronarium on macOS
+
+A resident-watch mode that monitors lockfiles in your workspace and
+pops a macOS notification whenever a new dependency is too young to
+trust. Works across npm, cargo, pypi, and nuget.
+
+## Install
+
+```bash
+brew install --no-quarantine bokuweb/tap/coronarium   # once that tap exists
+# or, for now:
+curl -fsSL https://github.com/bokuweb/coronarium/releases/latest/download/coronarium-aarch64-apple-darwin.tar.gz \
+  | tar -xz -C /tmp \
+  && sudo mv /tmp/coronarium-aarch64-apple-darwin/coronarium /usr/local/bin/
+```
+
+## Run it once (no daemon)
+
+```bash
+coronarium deps watch --min-age 7d ~/code
+```
+
+Leave it running in a tmux window. Every lockfile rewrite in
+`~/code/**/{package-lock.json,Cargo.lock,uv.lock,poetry.lock,requirements.txt,packages.lock.json}`
+triggers a check; violations pop a macOS notification.
+
+## Run it at login (launchd)
+
+1. Copy and edit the plist:
+
+   ```bash
+   cp packaging/macos/dev.coronarium.watch.plist ~/Library/LaunchAgents/
+   # Edit the ProgramArguments paths to match your setup.
+   ```
+
+2. Load it:
+
+   ```bash
+   launchctl load ~/Library/LaunchAgents/dev.coronarium.watch.plist
+   launchctl start dev.coronarium.watch
+   ```
+
+3. Verify:
+
+   ```bash
+   launchctl list | grep coronarium
+   tail -f /tmp/coronarium-watch.log
+   ```
+
+4. Unload when you're done:
+
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/dev.coronarium.watch.plist
+   ```
+
+## Notification permissions
+
+The first time `coronarium` posts a notification, macOS asks whether
+to allow "Script Editor" (osascript's signed bundle) to deliver
+notifications. Click **Allow**. You can later revoke / tweak the
+setting in *System Settings → Notifications → Script Editor*.

--- a/packaging/macos/dev.coronarium.watch.plist
+++ b/packaging/macos/dev.coronarium.watch.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.coronarium.watch</string>
+
+  <!-- EDIT: absolute path to the installed `coronarium` binary and the
+       directory/directories you want watched. Multiple roots can be
+       added as additional <string> entries in ProgramArguments. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/coronarium</string>
+    <string>deps</string>
+    <string>watch</string>
+    <string>--min-age</string>
+    <string>7d</string>
+    <string>--notifier</string>
+    <string>mac</string>
+    <string>/Users/YOU/code</string>
+  </array>
+
+  <!-- Start on login and restart automatically if it ever crashes. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+
+  <!-- Log to ~/Library/Logs so Console.app picks them up. -->
+  <key>StandardOutPath</key>
+  <string>/tmp/coronarium-watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/coronarium-watch.log</string>
+
+  <!-- So osascript can post notifications. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>RUST_LOG</key>
+    <string>info</string>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Test-first implementation of a long-lived watch mode. See commit for architecture + smoke.