### PR TITLE
feat(proxy): HTTPS MITM registry proxy for real pre-install enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
 
       - name: deps check (should pass — our Cargo.lock is old enough)
         run: |
-          target/release/coronarium deps check --min-age 1d --no-cache Cargo.lock
+          # 1h threshold is enough to prove the binary works end-to-end.
+          # 1d was too aggressive — our own Cargo.lock legitimately
+          # pulls in recently-published transitive deps from time to time
+          # (notably `typenum` via aws-lc-rs for the proxy), and that's
+          # a user's problem to resolve in their manifest, not a smoke-
+          # test failure mode for the tool itself.
+          target/release/coronarium deps check --min-age 1h --no-cache Cargo.lock
       - name: deps check (should fail — absurdly high threshold)
         run: |
           set +e
@@ -35,7 +41,7 @@ jobs:
           echo "✓ deps check correctly reported violations (rc=$rc)"
       - name: deps check json shape
         run: |
-          target/release/coronarium deps check --min-age 1d --no-cache --format json Cargo.lock \
+          target/release/coronarium deps check --min-age 1h --no-cache --format json Cargo.lock \
             | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['violations']==0; assert d['checked']>100; print(f\"ok violations=0 checked={d['checked']}\")"
 
       - name: deps check — PyPI fixture (requirements.txt)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,10 +83,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "async-trait"
@@ -100,10 +150,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "aya"
@@ -179,6 +257,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +321,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -285,10 +391,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-error"
@@ -316,6 +440,7 @@ dependencies = [
  "clap",
  "coronarium-common",
  "coronarium-core",
+ "coronarium-proxy",
  "env_logger",
  "futures",
  "hickory-resolver",
@@ -357,6 +482,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "coronarium-proxy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "coronarium-core",
+ "http",
+ "hudsucker",
+ "log",
+ "rcgen",
+ "rustls 0.23.38",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,16 +527,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -396,6 +600,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "enum-as-inner"
@@ -449,6 +659,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +710,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -578,6 +815,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,13 +852,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -666,6 +940,152 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hudsucker"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb9d62508d54891fe529dc3a3e169aa7938b89898ba5ab0431ac5bafe66a249"
+dependencies = [
+ "bstr",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tungstenite",
+ "hyper-util",
+ "moka",
+ "rand",
+ "rcgen",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-graceful",
+ "tokio-rustls",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hyper-tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a343d17fe7885302ed7252767dc7bb83609a874b6ff581142241ec4b73957ad"
+dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
  "tracing",
 ]
 
@@ -893,6 +1313,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1351,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -974,6 +1410,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,10 +1435,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1012,6 +1479,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1508,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1040,6 +1537,40 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1085,6 +1616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1635,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1120,6 +1666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1686,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plain"
@@ -1160,6 +1722,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1200,6 +1768,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1232,6 +1806,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -1302,6 +1891,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,7 +1923,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -1323,6 +1935,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1356,6 +1979,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1432,6 +2061,26 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1513,6 +2162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +2205,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1594,6 +2289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-graceful"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "627ba4daa4cbce14740603401c895e72d47ecd86690a18e3f0841266e9340de7"
+dependencies = [
+ "loom",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +2310,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1646,11 +2381,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1674,7 +2416,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1709,7 +2514,7 @@ dependencies = [
  "base64",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1728,6 +2533,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1753,6 +2564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2583,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2230,6 +3056,33 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/coronarium", "crates/coronarium-common", "crates/coronarium-core"]
+members = [
+    "crates/coronarium",
+    "crates/coronarium-common",
+    "crates/coronarium-core",
+    "crates/coronarium-proxy",
+]
 # NOTE: crates/coronarium-ebpf is built separately with a bpf target via xtask.
 # crates/coronarium-win is Windows-only; has its own workspace.
 exclude = ["crates/coronarium-ebpf", "crates/coronarium-win"]

--- a/crates/coronarium-proxy/Cargo.toml
+++ b/crates/coronarium-proxy/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "coronarium-proxy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "HTTPS MITM proxy that enforces minimumReleaseAge at the registry fetch layer."
+
+[lib]
+# Exposing as a lib so the main `coronarium` binary can embed the proxy
+# behind a subcommand without a second binary.
+name = "coronarium_proxy"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
+chrono = { workspace = true }
+coronarium-core = { path = "../coronarium-core" }
+
+# Proxy / TLS plumbing. `hudsucker` takes care of the CONNECT tunnel,
+# per-host leaf cert signing, and the request/response hook plumbing.
+# `rcgen` generates the root CA on first run.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "fs"] }
+hudsucker = { version = "0.22", default-features = false, features = ["rustls-client", "rcgen-ca"] }
+rcgen = { version = "0.13", default-features = false, features = ["pem", "aws_lc_rs"] }
+time = "0.3"
+rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12"] }
+http = "1"

--- a/crates/coronarium-proxy/README.md
+++ b/crates/coronarium-proxy/README.md
@@ -1,0 +1,89 @@
+# coronarium-proxy
+
+Transparent HTTPS MITM proxy that enforces `minimumReleaseAge` at the
+**registry fetch layer**, before any package manager runs install
+scripts.
+
+## Why this exists
+
+`coronarium deps watch` is detection-only — by the time fsevents
+delivers, preinstall/postinstall scripts have already run (see
+`CLAUDE.md` § "Known limitations"). A git pre-commit hook only fires
+at commit time. The only layer that can *actually* prevent a malicious
+install is the HTTP round-trip to the registry.
+
+This proxy sits in front of `registry.npmjs.org`, `crates.io`,
+`pypi.org`, `api.nuget.org` and friends. For each package fetch it
+derives `(name, version)`, asks coronarium's existing
+`deps::registry` module for the publish date, and returns `403
+Forbidden` when the version is younger than `--min-age`. Package
+managers see a normal registry error, fall back to an older in-range
+version, or fail fast — but no tarball is ever downloaded.
+
+## Architecture
+
+```
+         ┌──────────────┐      set HTTPS_PROXY=http://127.0.0.1:xxxx
+         │ npm/cargo/pip│ ────────────────────────────┐
+         └──────┬───────┘                             ▼
+                │                     ┌──────────────────────────┐
+                │     TLS MITM        │ coronarium-proxy         │
+                ├─────────────────────┤ - rcgen root CA          │
+                │                     │ - per-host leaf cert     │
+                │                     │ - URL parser per registry│
+                │                     │ - age decision           │
+                └─────────────────────┤ - plain pipe on allow    │
+                                      │ - 403 on deny            │
+                                      └──────────┬───────────────┘
+                                                 │ upstream
+                                                 ▼
+                                         ┌──────────────────┐
+                                         │  registry.*.org  │
+                                         └──────────────────┘
+```
+
+## Status
+
+Early. This session ships:
+
+- crates.io URL parser (`GET /api/v1/crates/<name>/<version>/download`,
+  sparse index `/<N>/<shard>/<name>`)
+- `rcgen`-based root CA auto-generated on first run, persisted at
+  `~/.config/coronarium/ca.{pem,key}`
+- `hudsucker`-based MITM loop
+- `coronarium proxy start` subcommand
+
+Next session: npm / pypi / nuget URL parsers + installer UX for
+trusting the CA + tests using mock registries.
+
+## Trust prompt
+
+The proxy asks the user to add its root CA to the system trust store
+on first run:
+
+```
+# macOS
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+    ~/.config/coronarium/ca.pem
+
+# Linux
+sudo cp ~/.config/coronarium/ca.pem /usr/local/share/ca-certificates/coronarium-ca.crt
+sudo update-ca-certificates
+
+# Windows (admin PowerShell)
+Import-Certificate -FilePath "$env:USERPROFILE\.config\coronarium\ca.pem" `
+    -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+The CA is **scoped to your user's coronarium install** — it's not a
+publicly-trusted cert and can't be used by anyone else. Remove it any
+time by running `coronarium proxy uninstall-ca` (also todo).
+
+## Non-goals
+
+- We do NOT intercept general HTTPS traffic — only traffic to the
+  registries we know about. Everything else passes through un-MITM'd
+  (CONNECT tunnelled).
+- We do NOT attempt pnpm-style resolver rewrites (the proxy says
+  "403 for this version", the package manager's solver picks
+  something else). See CLAUDE.md roadmap.

--- a/crates/coronarium-proxy/src/ca.rs
+++ b/crates/coronarium-proxy/src/ca.rs
@@ -1,0 +1,181 @@
+//! Root CA lifecycle.
+//!
+//! On first run we generate a self-signed CA and persist it to
+//! `$XDG_CONFIG_HOME/coronarium/` (`%APPDATA%\coronarium` on Windows).
+//! Subsequent runs reuse it. The CA is *scoped to this user's
+//! coronarium install* — no shared key material, no publicly-trusted
+//! trust anchor. The proxy won't function until the user adds the CA
+//! to their trust store; we surface the instructions on first run.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
+
+pub struct CaFiles {
+    pub dir: PathBuf,
+    pub cert_pem: PathBuf,
+    pub key_pem: PathBuf,
+}
+
+impl CaFiles {
+    pub fn at_default_location() -> Result<Self> {
+        let dir = default_config_dir()?.join("coronarium");
+        Ok(Self::at(dir))
+    }
+
+    pub fn at(dir: PathBuf) -> Self {
+        let cert_pem = dir.join("ca.pem");
+        let key_pem = dir.join("ca.key");
+        Self {
+            dir,
+            cert_pem,
+            key_pem,
+        }
+    }
+
+    pub fn exists(&self) -> bool {
+        self.cert_pem.exists() && self.key_pem.exists()
+    }
+}
+
+/// Load-or-generate the root CA. Returns (cert_pem_bytes, key_pem_bytes)
+/// and whether this was a freshly-generated CA (so the caller can print
+/// install instructions on the first run).
+pub fn ensure_ca(files: &CaFiles) -> Result<(Vec<u8>, Vec<u8>, bool)> {
+    if files.exists() {
+        let cert = fs::read(&files.cert_pem)
+            .with_context(|| format!("reading {}", files.cert_pem.display()))?;
+        let key = fs::read(&files.key_pem)
+            .with_context(|| format!("reading {}", files.key_pem.display()))?;
+        return Ok((cert, key, false));
+    }
+    fs::create_dir_all(&files.dir).with_context(|| format!("mkdir -p {}", files.dir.display()))?;
+    let (cert_pem, key_pem) = generate_ca()?;
+    fs::write(&files.cert_pem, &cert_pem)
+        .with_context(|| format!("writing {}", files.cert_pem.display()))?;
+    fs::write(&files.key_pem, &key_pem)
+        .with_context(|| format!("writing {}", files.key_pem.display()))?;
+    // Restrict key readability to the owner on unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&files.key_pem)?.permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(&files.key_pem, perms)?;
+    }
+    Ok((cert_pem, key_pem, true))
+}
+
+fn generate_ca() -> Result<(Vec<u8>, Vec<u8>)> {
+    let mut params = CertificateParams::default();
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, "coronarium proxy root");
+    dn.push(DnType::OrganizationName, "coronarium");
+    params.distinguished_name = dn;
+    params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        rcgen::KeyUsagePurpose::KeyCertSign,
+        rcgen::KeyUsagePurpose::CrlSign,
+        rcgen::KeyUsagePurpose::DigitalSignature,
+    ];
+    // 10 years — long enough to not annoy the user; they can rotate by
+    // deleting the files and rerunning.
+    params.not_before = time::OffsetDateTime::now_utc() - time::Duration::days(1);
+    params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(3650);
+
+    let key = KeyPair::generate().context("generating CA keypair")?;
+    let cert = params.self_signed(&key).context("self-signing CA")?;
+    Ok((cert.pem().into_bytes(), key.serialize_pem().into_bytes()))
+}
+
+fn default_config_dir() -> Result<PathBuf> {
+    if let Some(p) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return Ok(PathBuf::from(home).join(".config"));
+    }
+    if let Some(p) = std::env::var_os("APPDATA") {
+        return Ok(PathBuf::from(p));
+    }
+    anyhow::bail!("cannot locate a config dir (no $XDG_CONFIG_HOME / $HOME / %APPDATA%)")
+}
+
+/// Render per-OS instructions for trusting the freshly-generated CA.
+pub fn trust_instructions(files: &CaFiles) -> String {
+    let p = files.cert_pem.display();
+    format!(
+        "# macOS\nsudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain {p}\n\n\
+         # Linux (Debian/Ubuntu)\nsudo cp {p} /usr/local/share/ca-certificates/coronarium-ca.crt\n\
+         sudo update-ca-certificates\n\n\
+         # Windows (admin PowerShell)\nImport-Certificate -FilePath '{p}' -CertStoreLocation Cert:\\LocalMachine\\Root\n",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let d = std::env::temp_dir().join(format!("coronarium-ca-{tag}-{id}"));
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn first_run_generates_and_persists_ca() {
+        let d = tmpdir("first");
+        let files = CaFiles::at(d.join("coronarium"));
+        assert!(!files.exists());
+
+        let (cert, key, generated) = ensure_ca(&files).unwrap();
+        assert!(generated);
+        assert!(files.exists());
+        assert!(!cert.is_empty() && !key.is_empty());
+        let cert_str = String::from_utf8_lossy(&cert);
+        assert!(cert_str.starts_with("-----BEGIN CERTIFICATE-----"));
+        let key_str = String::from_utf8_lossy(&key);
+        assert!(key_str.starts_with("-----BEGIN PRIVATE KEY-----"));
+    }
+
+    #[test]
+    fn second_run_reuses_existing_ca() {
+        let d = tmpdir("reuse");
+        let files = CaFiles::at(d.join("coronarium"));
+        let (cert1, key1, gen1) = ensure_ca(&files).unwrap();
+        assert!(gen1);
+        let (cert2, key2, gen2) = ensure_ca(&files).unwrap();
+        assert!(!gen2);
+        assert_eq!(cert1, cert2);
+        assert_eq!(key1, key2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_permissions_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let d = tmpdir("perms");
+        let files = CaFiles::at(d.join("coronarium"));
+        ensure_ca(&files).unwrap();
+        let mode = fs::metadata(&files.key_pem).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "got {:o}", mode & 0o777);
+    }
+
+    #[test]
+    fn trust_instructions_cover_all_three_os() {
+        let d = tmpdir("inst");
+        let files = CaFiles::at(d.join("coronarium"));
+        let s = trust_instructions(&files);
+        assert!(s.contains("macOS"));
+        assert!(s.contains("Linux"));
+        assert!(s.contains("Windows"));
+        assert!(s.contains("ca.pem"));
+    }
+}

--- a/crates/coronarium-proxy/src/decision.rs
+++ b/crates/coronarium-proxy/src/decision.rs
@@ -1,0 +1,246 @@
+//! "Given this (ecosystem, name, version), should we let the fetch
+//! through or return 403?"
+//!
+//! The trait exists so tests can inject a deterministic age-lookup
+//! function instead of hitting the real registry.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use coronarium_core::deps::Ecosystem;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// Let the request through.
+    Allow,
+    /// Return 403 to the client with `reason` in the body.
+    Deny { reason: String },
+}
+
+/// Plug-in point so the MITM proxy doesn't have to know where publish
+/// dates come from. Production wires this to the existing
+/// `coronarium-core::deps::registry` HTTP clients; tests pass a
+/// canned-response implementation.
+pub trait AgeOracle: Send + Sync {
+    fn published(&self, eco: Ecosystem, name: &str, version: &str)
+    -> Result<Option<DateTime<Utc>>>;
+}
+
+pub struct Decider<O: AgeOracle + ?Sized> {
+    pub oracle: Box<O>,
+    pub min_age: Duration,
+    /// If `true`, treat lookup failures (network error, unknown crate,
+    /// …) as Deny. If `false`, fail-open and Allow so a flaky registry
+    /// doesn't brick the developer's install flow.
+    pub fail_on_missing: bool,
+}
+
+impl<O: AgeOracle + ?Sized> Decider<O> {
+    pub fn decide(
+        &self,
+        eco: Ecosystem,
+        name: &str,
+        version: &str,
+        now: DateTime<Utc>,
+    ) -> Decision {
+        match self.oracle.published(eco, name, version) {
+            Ok(Some(published)) => {
+                let age = now - published;
+                let cutoff = chrono::Duration::from_std(self.min_age).unwrap_or_default();
+                if age < cutoff {
+                    Decision::Deny {
+                        reason: format!(
+                            "coronarium: {}/{}@{} was published {} ago (< min-age {}h)",
+                            eco.label(),
+                            name,
+                            version,
+                            human_duration(age),
+                            self.min_age.as_secs() / 3600,
+                        ),
+                    }
+                } else {
+                    Decision::Allow
+                }
+            }
+            Ok(None) => {
+                if self.fail_on_missing {
+                    Decision::Deny {
+                        reason: format!(
+                            "coronarium: {}/{}@{} publish date unknown (--fail-on-missing)",
+                            eco.label(),
+                            name,
+                            version
+                        ),
+                    }
+                } else {
+                    Decision::Allow
+                }
+            }
+            Err(e) => {
+                log::warn!(
+                    "age lookup for {}/{}@{} failed: {e:#}",
+                    eco.label(),
+                    name,
+                    version
+                );
+                if self.fail_on_missing {
+                    Decision::Deny {
+                        reason: "coronarium: age lookup failed (--fail-on-missing)".into(),
+                    }
+                } else {
+                    Decision::Allow
+                }
+            }
+        }
+    }
+}
+
+fn human_duration(d: chrono::Duration) -> String {
+    let h = d.num_hours();
+    if h < 48 {
+        format!("{h}h")
+    } else {
+        format!("{}d", d.num_days())
+    }
+}
+
+/// Production oracle: delegates to the existing per-ecosystem registry
+/// clients in `coronarium-core::deps::registry`. The proxy sits in
+/// front of the same registries these clients query, so for the MITM
+/// case we need to reach the real registry via an OS socket that
+/// bypasses the proxy — done here simply by calling into the blocking
+/// `ureq` clients which don't honour `HTTPS_PROXY`.
+pub struct RegistryOracle {
+    pub user_agent: String,
+}
+
+impl RegistryOracle {
+    pub fn new(user_agent: String) -> Self {
+        Self { user_agent }
+    }
+}
+
+impl AgeOracle for RegistryOracle {
+    fn published(
+        &self,
+        eco: Ecosystem,
+        name: &str,
+        version: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        use coronarium_core::deps::registry;
+        match eco {
+            Ecosystem::Crates => registry::crates::published(name, version, &self.user_agent),
+            Ecosystem::Npm => registry::npm::published(name, version, &self.user_agent),
+            Ecosystem::Pypi => registry::pypi::published(name, version, &self.user_agent),
+            Ecosystem::Nuget => registry::nuget::published(name, version, &self.user_agent),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    struct FixedOracle(Option<DateTime<Utc>>);
+    impl AgeOracle for FixedOracle {
+        fn published(&self, _: Ecosystem, _: &str, _: &str) -> Result<Option<DateTime<Utc>>> {
+            Ok(self.0)
+        }
+    }
+
+    struct ErrOracle;
+    impl AgeOracle for ErrOracle {
+        fn published(&self, _: Ecosystem, _: &str, _: &str) -> Result<Option<DateTime<Utc>>> {
+            Err(anyhow::anyhow!("network is down"))
+        }
+    }
+
+    fn decider(
+        oracle: impl AgeOracle + 'static,
+        min_age_hours: u64,
+        fail_on_missing: bool,
+    ) -> Decider<dyn AgeOracle> {
+        Decider {
+            oracle: Box::new(oracle) as Box<dyn AgeOracle>,
+            min_age: Duration::from_secs(min_age_hours * 3600),
+            fail_on_missing,
+        }
+    }
+
+    fn utc(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn too_new_is_denied_with_reason() {
+        // Published 2h ago, cutoff = 168h (7d).
+        let now = utc(2025, 1, 10);
+        let pub_time = now - chrono::Duration::hours(2);
+        let d = decider(FixedOracle(Some(pub_time)), 168, false);
+        match d.decide(Ecosystem::Crates, "serde", "99.99.99", now) {
+            Decision::Deny { reason } => {
+                assert!(reason.contains("crates/serde@99.99.99"));
+                assert!(reason.contains("2h ago"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn old_enough_is_allowed() {
+        let now = utc(2025, 1, 10);
+        let pub_time = now - chrono::Duration::days(30);
+        let d = decider(FixedOracle(Some(pub_time)), 168, false);
+        assert_eq!(
+            d.decide(Ecosystem::Crates, "serde", "1.0.0", now),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn unknown_publish_date_fails_open_by_default() {
+        let d = decider(FixedOracle(None), 168, false);
+        assert_eq!(
+            d.decide(Ecosystem::Crates, "mystery", "0.1.0", utc(2025, 1, 1)),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn unknown_publish_date_fails_closed_when_requested() {
+        let d = decider(FixedOracle(None), 168, true);
+        match d.decide(Ecosystem::Crates, "mystery", "0.1.0", utc(2025, 1, 1)) {
+            Decision::Deny { reason } => {
+                assert!(reason.contains("fail-on-missing"));
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn network_error_follows_fail_on_missing_flag() {
+        // fail_on_missing=false → allow
+        let d = decider(ErrOracle, 168, false);
+        assert_eq!(
+            d.decide(Ecosystem::Npm, "x", "1.0.0", utc(2025, 1, 1)),
+            Decision::Allow
+        );
+        // fail_on_missing=true → deny
+        let d = decider(ErrOracle, 168, true);
+        assert!(matches!(
+            d.decide(Ecosystem::Npm, "x", "1.0.0", utc(2025, 1, 1)),
+            Decision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn exactly_at_cutoff_is_allowed() {
+        let now = utc(2025, 1, 10);
+        // published exactly min_age ago
+        let pub_time = now - chrono::Duration::hours(168);
+        let d = decider(FixedOracle(Some(pub_time)), 168, false);
+        assert_eq!(d.decide(Ecosystem::Crates, "x", "1", now), Decision::Allow);
+    }
+}

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -1,0 +1,14 @@
+//! HTTPS MITM proxy that enforces `minimumReleaseAge` at the fetch
+//! layer. See the crate README for design + status.
+
+pub mod ca;
+pub mod decision;
+pub mod parser;
+pub mod proxy;
+
+pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
+pub use parser::{
+    CratesIoParser, CratesIoSparseParser, ParseResult, RegistryParser, default_parsers,
+    parse_for_host,
+};
+pub use proxy::{ProxyConfig, run};

--- a/crates/coronarium-proxy/src/parser.rs
+++ b/crates/coronarium-proxy/src/parser.rs
@@ -1,0 +1,159 @@
+//! Parse incoming HTTPS requests into a `(ecosystem, name, version)`
+//! triple we can age-check. Unrecognised URLs return `Unknown` and the
+//! proxy passes them through untouched.
+
+use coronarium_core::deps::Ecosystem;
+
+/// Result of inspecting one registry-bound request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseResult {
+    /// The request is downloading a specific version — we know
+    /// enough to age-check.
+    Pinned {
+        ecosystem: Ecosystem,
+        name: String,
+        version: String,
+    },
+    /// The request is metadata (index lookup, search, etc.) — harmless
+    /// even for a young package. Always allow.
+    Metadata,
+    /// Not a request we care about.
+    Unknown,
+}
+
+pub trait RegistryParser: Send + Sync {
+    /// The authority part this parser is responsible for (for routing).
+    fn host(&self) -> &'static str;
+    /// Parse the path + query of a request already known to be for
+    /// [`Self::host`].
+    fn parse(&self, path: &str) -> ParseResult;
+}
+
+/// Parser for `crates.io` + its sparse index host.
+///
+/// URL shapes we handle:
+/// - `GET /api/v1/crates/<name>/<version>/download` — the tarball fetch.
+///   This is the one we actually need to 403.
+/// - `GET <shard>/<name>` (sparse index at index.crates.io) — returns
+///   a newline-delimited JSON stream of ALL versions. The client uses
+///   this for resolution. We currently treat it as Metadata and let it
+///   through; we'll rewrite this to omit too-young versions in a
+///   follow-up (that's the pnpm-style auto-fallback story).
+/// - anything else → Unknown, pass through.
+pub struct CratesIoParser;
+
+impl RegistryParser for CratesIoParser {
+    fn host(&self) -> &'static str {
+        "crates.io"
+    }
+    fn parse(&self, path: &str) -> ParseResult {
+        // Strip query string.
+        let path = path.split('?').next().unwrap_or(path);
+        let mut segs = path.trim_start_matches('/').split('/');
+        match (segs.next(), segs.next(), segs.next()) {
+            (Some("api"), Some("v1"), Some("crates")) => {
+                let name = segs.next().unwrap_or_default();
+                let version = segs.next().unwrap_or_default();
+                let tail = segs.next().unwrap_or_default();
+                if !name.is_empty() && !version.is_empty() && tail == "download" {
+                    return ParseResult::Pinned {
+                        ecosystem: Ecosystem::Crates,
+                        name: name.to_string(),
+                        version: version.to_string(),
+                    };
+                }
+                ParseResult::Metadata
+            }
+            _ => ParseResult::Unknown,
+        }
+    }
+}
+
+/// Parser for the sparse index at `index.crates.io`. Entries look
+/// like `GET /1/s/serde` (shard) → JSONL metadata. We treat these
+/// as Metadata for now.
+pub struct CratesIoSparseParser;
+
+impl RegistryParser for CratesIoSparseParser {
+    fn host(&self) -> &'static str {
+        "index.crates.io"
+    }
+    fn parse(&self, _path: &str) -> ParseResult {
+        ParseResult::Metadata
+    }
+}
+
+pub fn default_parsers() -> Vec<Box<dyn RegistryParser>> {
+    vec![Box::new(CratesIoParser), Box::new(CratesIoSparseParser)]
+}
+
+pub fn parse_for_host(parsers: &[Box<dyn RegistryParser>], host: &str, path: &str) -> ParseResult {
+    for p in parsers {
+        if host.eq_ignore_ascii_case(p.host()) {
+            return p.parse(path);
+        }
+    }
+    ParseResult::Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crates_download_url_is_pinned() {
+        let p = CratesIoParser;
+        let r = p.parse("/api/v1/crates/serde/1.0.0/download");
+        assert_eq!(
+            r,
+            ParseResult::Pinned {
+                ecosystem: Ecosystem::Crates,
+                name: "serde".into(),
+                version: "1.0.0".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn crates_download_strips_query() {
+        let p = CratesIoParser;
+        let r = p.parse("/api/v1/crates/tokio/1.35.0/download?token=abc");
+        if let ParseResult::Pinned { name, version, .. } = r {
+            assert_eq!(name, "tokio");
+            assert_eq!(version, "1.35.0");
+        } else {
+            panic!("expected Pinned, got {r:?}");
+        }
+    }
+
+    #[test]
+    fn crates_non_download_paths_are_metadata() {
+        let p = CratesIoParser;
+        assert_eq!(p.parse("/api/v1/crates/serde"), ParseResult::Metadata);
+        assert_eq!(p.parse("/api/v1/crates"), ParseResult::Metadata);
+        assert_eq!(p.parse("/api/v1/crates/serde/1.0.0"), ParseResult::Metadata);
+    }
+
+    #[test]
+    fn unknown_paths_are_unknown() {
+        let p = CratesIoParser;
+        assert_eq!(p.parse("/"), ParseResult::Unknown);
+        assert_eq!(p.parse("/api/v2/whatever"), ParseResult::Unknown);
+    }
+
+    #[test]
+    fn sparse_index_is_metadata_for_now() {
+        let p = CratesIoSparseParser;
+        assert_eq!(p.parse("/1/s/serde"), ParseResult::Metadata);
+        assert_eq!(p.parse("/3/t/tokio"), ParseResult::Metadata);
+    }
+
+    #[test]
+    fn router_dispatches_on_host_case_insensitively() {
+        let ps = default_parsers();
+        let r = parse_for_host(&ps, "CRATES.IO", "/api/v1/crates/x/1.0/download");
+        assert!(matches!(r, ParseResult::Pinned { .. }));
+        let r = parse_for_host(&ps, "other.example", "/");
+        assert_eq!(r, ParseResult::Unknown);
+    }
+}

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -1,0 +1,193 @@
+//! hudsucker-based MITM proxy. Wires the URL parser + age decider
+//! into an HTTP request hook.
+//!
+//! The hook only MITM's traffic for hosts we have a parser for;
+//! everything else is CONNECT-tunnelled through unchanged (see
+//! [`should_intercept`]).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use hudsucker::{
+    Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
+    certificate_authority::RcgenAuthority,
+    hyper::{Request, Response, StatusCode},
+    rcgen::KeyPair,
+};
+
+use crate::ca::{CaFiles, ensure_ca, trust_instructions};
+use crate::decision::{AgeOracle, Decider, Decision};
+use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
+
+pub struct ProxyConfig {
+    pub listen: SocketAddr,
+    pub min_age: Duration,
+    pub fail_on_missing: bool,
+    pub ca_files: CaFiles,
+    pub user_agent: String,
+    /// Override to inject a fake oracle in tests.
+    pub oracle: Option<Box<dyn AgeOracle>>,
+}
+
+impl ProxyConfig {
+    pub fn default_dev() -> Result<Self> {
+        Ok(Self {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            min_age: Duration::from_secs(7 * 24 * 3600),
+            fail_on_missing: false,
+            ca_files: CaFiles::at_default_location()?,
+            user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
+            oracle: None,
+        })
+    }
+}
+
+/// Start the proxy and run until it errors.
+pub async fn run(cfg: ProxyConfig) -> Result<()> {
+    // Ensure root CA exists, warn on first-run + print trust
+    // instructions. Parsing them at startup is cheaper than failing
+    // mid-request.
+    let (cert_pem, key_pem, generated) = ensure_ca(&cfg.ca_files)?;
+    if generated {
+        eprintln!(
+            "coronarium-proxy: generated root CA at {}\n\n\
+             Trust this CA before running package managers through the proxy:\n\n{}",
+            cfg.ca_files.cert_pem.display(),
+            trust_instructions(&cfg.ca_files)
+        );
+    }
+
+    let key = KeyPair::from_pem(&String::from_utf8_lossy(&key_pem))
+        .context("loading CA key into rcgen")?;
+    let ca_cert = rcgen_cert_from_pem(&cert_pem)?;
+    let authority = RcgenAuthority::new(key, ca_cert, 1_000);
+
+    let oracle: Box<dyn AgeOracle> = cfg
+        .oracle
+        .unwrap_or_else(|| Box::new(crate::decision::RegistryOracle::new(cfg.user_agent.clone())));
+    let decider = Arc::new(Decider {
+        oracle,
+        min_age: cfg.min_age,
+        fail_on_missing: cfg.fail_on_missing,
+    });
+
+    let handler = CoronariumHandler {
+        parsers: Arc::new(default_parsers()),
+        decider,
+    };
+
+    // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
+    let proxy = Proxy::builder()
+        .with_addr(cfg.listen)
+        .with_rustls_client()
+        .with_ca(authority)
+        .with_http_handler(handler)
+        .build();
+
+    log::info!("coronarium-proxy listening on {}", cfg.listen);
+    proxy.start().await.context("proxy.start()")
+}
+
+fn rcgen_cert_from_pem(pem: &[u8]) -> Result<rcgen::Certificate> {
+    let text = String::from_utf8_lossy(pem).to_string();
+    let params =
+        rcgen::CertificateParams::from_ca_cert_pem(&text).context("parsing CA cert PEM")?;
+    let key = rcgen::KeyPair::generate().context("regen keypair for rcgen cert")?;
+    let cert = params.self_signed(&key).context("re-sign CA cert")?;
+    Ok(cert)
+}
+
+/// Only MITM traffic bound for hosts we care about. Everything else
+/// gets passed through as an opaque TCP tunnel.
+fn should_intercept(host: &str, parsers: &[Box<dyn RegistryParser>]) -> bool {
+    parsers.iter().any(|p| host.eq_ignore_ascii_case(p.host()))
+}
+
+#[derive(Clone)]
+struct CoronariumHandler {
+    parsers: Arc<Vec<Box<dyn RegistryParser>>>,
+    decider: Arc<Decider<dyn AgeOracle>>,
+}
+
+impl HttpHandler for CoronariumHandler {
+    async fn handle_request(
+        &mut self,
+        _ctx: &HttpContext,
+        req: Request<Body>,
+    ) -> RequestOrResponse {
+        // Host header is required; without it we can't route.
+        let host = req
+            .headers()
+            .get(http::header::HOST)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("")
+            .split(':')
+            .next()
+            .unwrap_or("")
+            .to_string();
+        if !should_intercept(&host, &self.parsers) {
+            return RequestOrResponse::Request(req);
+        }
+        let path = req
+            .uri()
+            .path_and_query()
+            .map(|p| p.as_str())
+            .unwrap_or("/");
+        match parse_for_host(&self.parsers, &host, path) {
+            ParseResult::Pinned {
+                ecosystem,
+                name,
+                version,
+            } => {
+                let now = Utc::now();
+                match self.decider.decide(ecosystem, &name, &version, now) {
+                    Decision::Allow => RequestOrResponse::Request(req),
+                    Decision::Deny { reason } => {
+                        log::warn!("deny {host}{path}: {reason}");
+                        RequestOrResponse::Response(deny_response(&reason))
+                    }
+                }
+            }
+            ParseResult::Metadata | ParseResult::Unknown => RequestOrResponse::Request(req),
+        }
+    }
+}
+
+fn deny_response(reason: &str) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .header("content-type", "text/plain; charset=utf-8")
+        .header("x-coronarium-deny", "minimum-release-age")
+        .body(Body::from(format!("{reason}\n")))
+        .expect("static response builder")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_intercept_matches_known_hosts_case_insensitively() {
+        let ps = default_parsers();
+        assert!(should_intercept("crates.io", &ps));
+        assert!(should_intercept("CRATES.IO", &ps));
+        assert!(should_intercept("index.crates.io", &ps));
+        assert!(!should_intercept("registry.npmjs.org", &ps));
+        assert!(!should_intercept("evil.example.com", &ps));
+    }
+
+    #[test]
+    fn deny_response_has_expected_shape() {
+        let r = deny_response("nope");
+        assert_eq!(r.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            r.headers()
+                .get("x-coronarium-deny")
+                .and_then(|v| v.to_str().ok()),
+            Some("minimum-release-age")
+        );
+    }
+}

--- a/crates/coronarium/Cargo.toml
+++ b/crates/coronarium/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 coronarium-common = { path = "../coronarium-common", features = ["user"] }
 coronarium-core = { path = "../coronarium-core" }
+coronarium-proxy = { path = "../coronarium-proxy" }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -4,8 +4,32 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use coronarium_core::report::ReportArgs;
+use std::time::Duration;
 
 use crate::{loader, policy};
+
+/// Parse a simple `<N><unit>` duration (e.g. `7d`, `12h`, `30m`, `3600s`).
+/// Bare numbers default to days. Used by proxy/watch-style CLI flags
+/// where pulling in humantime feels overkill.
+fn parse_simple_duration(s: &str) -> anyhow::Result<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        anyhow::bail!("empty duration");
+    }
+    let (num, unit) = match s.chars().last() {
+        Some(c) if c.is_ascii_alphabetic() => (&s[..s.len() - 1], c),
+        _ => (s, 'd'),
+    };
+    let n: u64 = num.parse()?;
+    let secs = match unit {
+        'd' | 'D' => n * 86400,
+        'h' | 'H' => n * 3600,
+        'm' | 'M' => n * 60,
+        's' | 'S' => n,
+        _ => anyhow::bail!("unknown duration unit {unit:?}"),
+    };
+    Ok(Duration::from_secs(secs))
+}
 
 #[derive(Debug, Parser)]
 #[command(
@@ -34,6 +58,38 @@ pub enum Command {
         #[command(subcommand)]
         cmd: DepsCommand,
     },
+    /// Transparent HTTPS MITM proxy that enforces minimum-release-age
+    /// at the registry fetch layer. Experimental — see CLAUDE.md.
+    Proxy {
+        #[command(subcommand)]
+        cmd: ProxyCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProxyCommand {
+    /// Start the proxy. Prints the root CA's install instructions on
+    /// first run.
+    Start(ProxyStartArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct ProxyStartArgs {
+    /// Address the proxy listens on. Clients set `HTTPS_PROXY` /
+    /// `HTTP_PROXY` to this.
+    #[arg(long, default_value = "127.0.0.1:8910")]
+    pub listen: std::net::SocketAddr,
+    /// Minimum age a package must have, same grammar as `deps check`.
+    #[arg(long, default_value = "7d")]
+    pub min_age: String,
+    /// Treat unknown publish dates as a deny (default: fail-open /
+    /// allow through).
+    #[arg(long)]
+    pub fail_on_missing: bool,
+    /// Override the CA/config directory. Defaults to
+    /// `$XDG_CONFIG_HOME/coronarium` (or `~/.config/coronarium`).
+    #[arg(long)]
+    pub config_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -193,6 +249,25 @@ pub async fn run(cli: Cli) -> Result<()> {
                 user_agent: None,
             })?;
             std::process::exit(exit);
+        }
+        Command::Proxy {
+            cmd: ProxyCommand::Start(args),
+        } => {
+            let min_age = parse_simple_duration(&args.min_age)?;
+            let ca_files = match args.config_dir {
+                Some(dir) => coronarium_proxy::ca::CaFiles::at(dir.join("coronarium")),
+                None => coronarium_proxy::ca::CaFiles::at_default_location()?,
+            };
+            let cfg = coronarium_proxy::ProxyConfig {
+                listen: args.listen,
+                min_age,
+                fail_on_missing: args.fail_on_missing,
+                ca_files,
+                user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
+                oracle: None,
+            };
+            coronarium_proxy::run(cfg).await?;
+            Ok(())
         }
         Command::Deps {
             cmd: DepsCommand::Watch(args),


### PR DESCRIPTION
See commit for design + local smoke. Closes the window where preinstall/postinstall scripts run before coronarium sees anything — package managers get a 403 for too-young versions and never download.