### PR TITLE
feat(proxy): sparse-index rewrite for crates.io (pnpm-style auto-fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,27 +52,30 @@ rather than as a wall against script-based attacks. The only way
 to reliably *prevent* those is to check BEFORE install happens
 (see `deps check` in CI, or the planned `install-gate` wrapper).
 
-### We do not auto-fallback like pnpm's `minimumReleaseAge`
+### Auto-fallback (pnpm-style): crates.io only, via the proxy
 
-pnpm 10.x has `minimumReleaseAge` which teaches its resolver to
-**filter versions younger than the threshold out of its candidate
-set**, silently resolving to the newest in-range version that also
-meets the age requirement. This is very nice UX: builds don't
-break, they just use slightly older deps.
+pnpm 10.x's `minimumReleaseAge` teaches its resolver to **filter
+versions younger than the threshold out of its candidate set**,
+silently resolving to the newest in-range version that also meets
+the age requirement. Builds don't break; they just use slightly
+older deps.
 
-coronarium does not do this. We exit 1 on violation; the install
-itself has already happened (or won't, if the user wired us in
-pre-install). Teaching every ecosystem's resolver to filter would
-require:
-- cargo: hook the resolver (or ship a sparse-index proxy)
-- npm: ditto + peer-dep gymnastics
-- pip: pip's backtracking resolver is complex
-- nuget: newer API to intercept
+**Status (v0.15):**
+- **crates.io** — ✅ implemented via the proxy. `coronarium
+  proxy serve` rewrites `index.crates.io` sparse-index responses on
+  the fly, dropping JSONL lines whose `(name, vers)` publish time is
+  < `--min-age`. cargo's resolver sees only acceptable versions and
+  naturally picks the newest older-in-range. No error; no user
+  action required beyond running cargo through the proxy.
+- **npm / pypi / nuget** — still fail-hard. The proxy returns 403
+  on a too-young pinned fetch; the install stops. Sparse-index-like
+  rewriting for these ecosystems is the next roadmap item. The
+  blockers are format-specific (npm's registry returns one JSON doc
+  listing *all* versions; PyPI has a JSON API and a separate simple
+  index; NuGet uses versioned flat-container URLs).
 
-It's a real roadmap item (see "Roadmap" below) but it's a large
-investment. Until then: `deps check` tells you something is too
-young, and it's up to you to tighten the version range in your
-manifest.
+For ecosystems without rewriting, `deps check` (CI) or the proxy's
+hard-deny (desktop) is still the defense — just not silent.
 
 ### file block is "tripwire", not pre-open block
 
@@ -108,9 +111,10 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 2. **HTTPS registry proxy** — same idea but transparent: set
    `HTTPS_PROXY` system-wide, filter fetch traffic. No shell
    aliasing required, but MITM cert management is a UX chore.
-3. **pnpm-style auto-fallback** — the big one. Per-ecosystem
-   resolver integration, probably via sparse-index proxy for
-   cargo and an npm cache server for npm/pnpm.
+3. **pnpm-style auto-fallback for npm/pypi/nuget** — crates.io
+   already works via sparse-index rewrite (v0.15). Extend to the
+   other three: npm packument filtering, PyPI simple-index /
+   JSON-API filtering, NuGet flat-container index filtering.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,9 +486,11 @@ name = "coronarium-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "coronarium-core",
  "http",
+ "http-body-util",
  "hudsucker",
  "log",
  "rcgen",

--- a/crates/coronarium-proxy/Cargo.toml
+++ b/crates/coronarium-proxy/Cargo.toml
@@ -28,3 +28,5 @@ rcgen = { version = "0.13", default-features = false, features = ["pem", "aws_lc
 time = "0.3"
 rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12"] }
 http = "1"
+http-body-util = "0.1"
+bytes = "1"

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -6,6 +6,7 @@ pub mod decision;
 pub mod install;
 pub mod parser;
 pub mod proxy;
+pub mod rewrite;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
 pub use parser::{
@@ -13,3 +14,4 @@ pub use parser::{
     parse_for_host,
 };
 pub use proxy::{ProxyConfig, run};
+pub use rewrite::{RewriteStats, rewrite_crates_index_jsonl};

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -163,11 +163,7 @@ impl HttpHandler for CoronariumHandler {
         }
     }
 
-    async fn handle_response(
-        &mut self,
-        _ctx: &HttpContext,
-        res: Response<Body>,
-    ) -> Response<Body> {
+    async fn handle_response(&mut self, _ctx: &HttpContext, res: Response<Body>) -> Response<Body> {
         // Only rewrite the crates.io sparse index. Other hosts flow
         // through untouched so we don't risk corrupting binary tarballs
         // or metadata we haven't specifically handled.

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -21,6 +21,7 @@ use hudsucker::{
 use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
+use crate::rewrite::rewrite_crates_index_jsonl;
 
 pub struct ProxyConfig {
     pub listen: SocketAddr,
@@ -77,6 +78,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
     let handler = CoronariumHandler {
         parsers: Arc::new(default_parsers()),
         decider,
+        last_host: None,
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -110,6 +112,10 @@ fn should_intercept(host: &str, parsers: &[Box<dyn RegistryParser>]) -> bool {
 struct CoronariumHandler {
     parsers: Arc<Vec<Box<dyn RegistryParser>>>,
     decider: Arc<Decider<dyn AgeOracle>>,
+    /// Host of the in-flight request, captured in `handle_request` so
+    /// `handle_response` knows whether to rewrite the body. hudsucker
+    /// guarantees the same handler instance sees the matching pair.
+    last_host: Option<String>,
 }
 
 impl HttpHandler for CoronariumHandler {
@@ -129,8 +135,10 @@ impl HttpHandler for CoronariumHandler {
             .unwrap_or("")
             .to_string();
         if !should_intercept(&host, &self.parsers) {
+            self.last_host = None;
             return RequestOrResponse::Request(req);
         }
+        self.last_host = Some(host.clone());
         let path = req
             .uri()
             .path_and_query()
@@ -153,6 +161,65 @@ impl HttpHandler for CoronariumHandler {
             }
             ParseResult::Metadata | ParseResult::Unknown => RequestOrResponse::Request(req),
         }
+    }
+
+    async fn handle_response(
+        &mut self,
+        _ctx: &HttpContext,
+        res: Response<Body>,
+    ) -> Response<Body> {
+        // Only rewrite the crates.io sparse index. Other hosts flow
+        // through untouched so we don't risk corrupting binary tarballs
+        // or metadata we haven't specifically handled.
+        let is_sparse_index = matches!(self.last_host.as_deref(), Some("index.crates.io"));
+        if !is_sparse_index {
+            return res;
+        }
+        // 2xx only — preserve 404 / 304 / etc. as-is.
+        if !res.status().is_success() {
+            return res;
+        }
+
+        use http_body_util::BodyExt;
+        let (parts, body) = res.into_parts();
+        let collected = match body.collect().await {
+            Ok(c) => c.to_bytes(),
+            Err(e) => {
+                log::warn!("sparse-rewrite: failed to buffer response body: {e}");
+                // Best effort: return an empty body — safer than
+                // forwarding a half-read stream.
+                return Response::from_parts(parts, Body::empty());
+            }
+        };
+
+        let now = Utc::now();
+        let (rewritten, stats) = rewrite_crates_index_jsonl(&collected, &self.decider, now);
+        if stats.dropped > 0 {
+            log::info!(
+                "sparse-rewrite: dropped {} version(s), kept {} (crates.io)",
+                stats.dropped,
+                stats.kept
+            );
+        }
+
+        // Rebuild response with the new body. Strip Content-Length —
+        // hyper will set it from the new Full body, and leaving a stale
+        // length would confuse the client.
+        let mut parts = parts;
+        parts.headers.remove(http::header::CONTENT_LENGTH);
+        // If the upstream used gzip/br etc. the filter already saw
+        // plaintext (hudsucker doesn't auto-decode), so refuse to rewrite
+        // encoded bodies — punt and return original.
+        if let Some(enc) = parts.headers.get(http::header::CONTENT_ENCODING)
+            && !enc.as_bytes().eq_ignore_ascii_case(b"identity")
+        {
+            log::debug!("sparse-rewrite: skipping non-identity Content-Encoding");
+            return Response::from_parts(parts, Body::from(http_body_util::Full::new(collected)));
+        }
+        Response::from_parts(
+            parts,
+            Body::from(http_body_util::Full::new(bytes::Bytes::from(rewritten))),
+        )
     }
 }
 

--- a/crates/coronarium-proxy/src/rewrite.rs
+++ b/crates/coronarium-proxy/src/rewrite.rs
@@ -1,0 +1,293 @@
+//! Sparse-index response rewriting.
+//!
+//! The crates.io sparse index (`https://index.crates.io/<prefix>/<name>`)
+//! returns one JSON object per line, one per published version:
+//!
+//! ```text
+//! {"name":"serde","vers":"1.0.200","deps":[…],"cksum":"…","yanked":false,…}
+//! {"name":"serde","vers":"1.0.201","deps":[…],"cksum":"…","yanked":false,…}
+//! ```
+//!
+//! Cargo's resolver treats a version that *isn't in the index* as
+//! simply non-existent, and naturally falls back to older in-range
+//! versions. That is exactly the pnpm-style "auto-fallback" semantics
+//! we want for `minimumReleaseAge`: too-young versions become invisible
+//! to the resolver without any error, while older acceptable versions
+//! still resolve cleanly.
+//!
+//! This module provides a **pure** rewrite function so it can be unit
+//! tested without spinning up hyper / hudsucker.
+
+use chrono::{DateTime, Utc};
+use coronarium_core::deps::Ecosystem;
+use serde::Deserialize;
+
+use crate::decision::{AgeOracle, Decider, Decision};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteStats {
+    pub kept: usize,
+    pub dropped: usize,
+}
+
+/// Minimal subset of each index line we need to make a decision. We
+/// deserialise only `name` + `vers`; everything else is preserved
+/// byte-for-byte by keeping the original line.
+#[derive(Deserialize)]
+struct IndexLine<'a> {
+    name: &'a str,
+    vers: &'a str,
+}
+
+/// Filter a crates.io sparse-index JSONL body in place, dropping lines
+/// whose `(name, vers)` the decider rejects. Lines we can't parse are
+/// passed through unchanged — an index line we don't understand is
+/// safer to keep than to silently eat.
+pub fn rewrite_crates_index_jsonl(
+    body: &[u8],
+    decider: &Decider<dyn AgeOracle>,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, RewriteStats) {
+    let mut out = Vec::with_capacity(body.len());
+    let mut stats = RewriteStats {
+        kept: 0,
+        dropped: 0,
+    };
+
+    // Iterate over raw lines so we preserve the trailing newlines and
+    // any non-JSON junk exactly as the upstream sent them.
+    for line in split_lines_keep_terminator(body) {
+        let trimmed = trim_trailing_newline(line);
+        if trimmed.is_empty() {
+            out.extend_from_slice(line);
+            continue;
+        }
+        match serde_json::from_slice::<IndexLine>(trimmed) {
+            Ok(parsed) => {
+                let decision = decider.decide(Ecosystem::Crates, parsed.name, parsed.vers, now);
+                match decision {
+                    Decision::Allow => {
+                        out.extend_from_slice(line);
+                        stats.kept += 1;
+                    }
+                    Decision::Deny { reason } => {
+                        log::info!(
+                            "sparse-rewrite: dropping crates/{}@{} ({reason})",
+                            parsed.name,
+                            parsed.vers
+                        );
+                        stats.dropped += 1;
+                    }
+                }
+            }
+            Err(e) => {
+                log::debug!("sparse-rewrite: passing through unparseable index line: {e}");
+                out.extend_from_slice(line);
+                stats.kept += 1;
+            }
+        }
+    }
+
+    (out, stats)
+}
+
+/// Yield each `\n`-terminated slice of `buf`, *including* the terminator
+/// byte(s). The final chunk may lack a terminator.
+fn split_lines_keep_terminator(buf: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let mut i = 0;
+    std::iter::from_fn(move || {
+        if i >= buf.len() {
+            return None;
+        }
+        let start = i;
+        while i < buf.len() && buf[i] != b'\n' {
+            i += 1;
+        }
+        if i < buf.len() {
+            i += 1; // include the '\n'
+        }
+        Some(&buf[start..i])
+    })
+}
+
+fn trim_trailing_newline(line: &[u8]) -> &[u8] {
+    let mut end = line.len();
+    if end > 0 && line[end - 1] == b'\n' {
+        end -= 1;
+    }
+    if end > 0 && line[end - 1] == b'\r' {
+        end -= 1;
+    }
+    &line[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decision::Decider;
+    use anyhow::Result;
+    use chrono::TimeZone;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    /// Oracle keyed on (name, version). Unknown keys return `None`.
+    #[derive(Default)]
+    struct MapOracle {
+        by_key: HashMap<(String, String), DateTime<Utc>>,
+    }
+
+    impl MapOracle {
+        fn insert(mut self, name: &str, vers: &str, when: DateTime<Utc>) -> Self {
+            self.by_key.insert((name.into(), vers.into()), when);
+            self
+        }
+    }
+
+    impl AgeOracle for MapOracle {
+        fn published(
+            &self,
+            _: Ecosystem,
+            name: &str,
+            version: &str,
+        ) -> Result<Option<DateTime<Utc>>> {
+            Ok(self.by_key.get(&(name.into(), version.into())).copied())
+        }
+    }
+
+    fn utc(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    fn dec(oracle: MapOracle, min_age_hours: u64) -> Decider<dyn AgeOracle> {
+        Decider {
+            oracle: Box::new(oracle) as Box<dyn AgeOracle>,
+            min_age: Duration::from_secs(min_age_hours * 3600),
+            fail_on_missing: false,
+        }
+    }
+
+    #[test]
+    fn keeps_old_drops_young() {
+        let now = utc(2025, 1, 10);
+        let oracle = MapOracle::default()
+            .insert("serde", "1.0.100", now - chrono::Duration::days(30))
+            .insert("serde", "1.0.200", now - chrono::Duration::hours(2));
+        let d = dec(oracle, 168);
+
+        let body = concat!(
+            r#"{"name":"serde","vers":"1.0.100","cksum":"aaa","yanked":false}"#,
+            "\n",
+            r#"{"name":"serde","vers":"1.0.200","cksum":"bbb","yanked":false}"#,
+            "\n",
+        );
+        let (out, stats) = rewrite_crates_index_jsonl(body.as_bytes(), &d, now);
+        let out = String::from_utf8(out).unwrap();
+
+        assert!(out.contains("1.0.100"));
+        assert!(!out.contains("1.0.200"));
+        assert_eq!(stats.kept, 1);
+        assert_eq!(stats.dropped, 1);
+    }
+
+    #[test]
+    fn preserves_line_bytes_verbatim() {
+        // Notably: preserves "yanked":false ordering, cksum, etc. — the
+        // consumer relies on cksum matching the .crate tarball.
+        let now = utc(2025, 1, 10);
+        let oracle = MapOracle::default().insert("x", "1.0.0", now - chrono::Duration::days(30));
+        let d = dec(oracle, 168);
+
+        let body = r#"{"name":"x","vers":"1.0.0","cksum":"0123abcd","yanked":false,"features":{}}
+"#;
+        let (out, _) = rewrite_crates_index_jsonl(body.as_bytes(), &d, now);
+        assert_eq!(out, body.as_bytes());
+    }
+
+    #[test]
+    fn unknown_publish_date_fails_open_keeps_line() {
+        // Oracle returns None (crate has no known publish date). The
+        // decider defaults to Allow, so we keep the line.
+        let now = utc(2025, 1, 10);
+        let d = dec(MapOracle::default(), 168);
+
+        let body = r#"{"name":"mystery","vers":"0.1.0"}
+"#;
+        let (out, stats) = rewrite_crates_index_jsonl(body.as_bytes(), &d, now);
+        assert_eq!(out, body.as_bytes());
+        assert_eq!(stats.kept, 1);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn empty_body_round_trips() {
+        let now = utc(2025, 1, 10);
+        let d = dec(MapOracle::default(), 168);
+        let (out, stats) = rewrite_crates_index_jsonl(b"", &d, now);
+        assert!(out.is_empty());
+        assert_eq!(stats.kept, 0);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn unparseable_line_is_passed_through() {
+        let now = utc(2025, 1, 10);
+        let d = dec(MapOracle::default(), 168);
+        let body = b"not json at all\n";
+        let (out, stats) = rewrite_crates_index_jsonl(body, &d, now);
+        assert_eq!(out, body);
+        assert_eq!(stats.kept, 1);
+    }
+
+    #[test]
+    fn all_young_yields_empty_body_no_error() {
+        // Every version is too new. Output is empty — cargo sees "no
+        // matching versions" and errors cleanly at resolve time.
+        let now = utc(2025, 1, 10);
+        let oracle = MapOracle::default()
+            .insert("hot", "1.0.0", now - chrono::Duration::hours(1))
+            .insert("hot", "1.0.1", now - chrono::Duration::hours(2));
+        let d = dec(oracle, 168);
+
+        let body = concat!(
+            r#"{"name":"hot","vers":"1.0.0"}"#,
+            "\n",
+            r#"{"name":"hot","vers":"1.0.1"}"#,
+            "\n",
+        );
+        let (out, stats) = rewrite_crates_index_jsonl(body.as_bytes(), &d, now);
+        assert!(out.is_empty());
+        assert_eq!(stats.kept, 0);
+        assert_eq!(stats.dropped, 2);
+    }
+
+    #[test]
+    fn handles_crlf_line_endings() {
+        let now = utc(2025, 1, 10);
+        let oracle = MapOracle::default()
+            .insert("a", "1.0.0", now - chrono::Duration::days(30))
+            .insert("a", "9.9.9", now - chrono::Duration::hours(1));
+        let d = dec(oracle, 168);
+
+        let body = "{\"name\":\"a\",\"vers\":\"1.0.0\"}\r\n\
+                    {\"name\":\"a\",\"vers\":\"9.9.9\"}\r\n";
+        let (out, stats) = rewrite_crates_index_jsonl(body.as_bytes(), &d, now);
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains("1.0.0"));
+        assert!(!out.contains("9.9.9"));
+        // The kept line retains its CRLF terminator.
+        assert!(out.ends_with("\r\n"));
+        assert_eq!(stats.dropped, 1);
+    }
+
+    #[test]
+    fn final_line_without_terminator_is_still_processed() {
+        let now = utc(2025, 1, 10);
+        let oracle = MapOracle::default().insert("a", "1.0.0", now - chrono::Duration::days(30));
+        let d = dec(oracle, 168);
+
+        let body = br#"{"name":"a","vers":"1.0.0"}"#; // no trailing \n
+        let (out, stats) = rewrite_crates_index_jsonl(body, &d, now);
+        assert_eq!(out, body);
+        assert_eq!(stats.kept, 1);
+    }
+}


### PR DESCRIPTION
## Summary
- The MITM proxy now rewrites `index.crates.io` sparse-index responses, dropping too-young versions so cargo's resolver transparently falls back to older in-range versions — the first ecosystem where we match pnpm's `minimumReleaseAge` UX (no hard error, just silent fallback).
- New pure module `rewrite.rs` with 8 unit tests for keep/drop, CRLF, unparseable-line pass-through, empty body, missing trailing newline, all-young yielding empty body.
- `handle_response` buffers the body, rewrites only when the in-flight host is `index.crates.io`, leaves non-identity Content-Encoding untouched.
- CLAUDE.md updated: auto-fallback is now explicitly "crates.io ✅, others still fail-hard" — npm/pypi/nuget rewriting is the next roadmap item.

## Test plan
- [x] `cargo test -p coronarium-proxy` — 41 tests pass (8 new in `rewrite::tests`)
- [x] `cargo clippy -p coronarium-proxy --all-targets -- -D warnings` clean
- [ ] Local smoke: `cargo fetch` through the proxy with high `--min-age`, verify cargo picks an older in-range version without erroring
- [ ] CI green on macos-14 + ubuntu + windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)