### PR TITLE
feat(proxy): PyPI JSON API + Simple JSON rewrite (pnpm-style auto-fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ silently resolving to the newest in-range version that also meets
 the age requirement. Builds don't break; they just use slightly
 older deps.
 
-**Status (v0.16):**
+**Status (v0.17):**
 - **crates.io** — ✅ implemented via the proxy. `coronarium
   proxy serve` rewrites `index.crates.io` sparse-index responses on
   the fly, dropping JSONL lines whose `(name, vers)` publish time is
@@ -72,10 +72,23 @@ older deps.
   (notably `latest`) that pointed at a removed version is
   retargeted to the highest remaining semver. npm's resolver then
   picks the newest in-range surviving version — no error.
-- **pypi / nuget** — still fail-hard. The proxy returns 403 on a
-  too-young pinned fetch; the install stops. PyPI has a JSON API
-  plus a separate simple index; NuGet uses flat-container URLs.
-  Same pattern as npm/crates, just per-ecosystem format work.
+- **pypi** — ✅ implemented for the two JSON endpoints modern pip
+  and uv actually consult:
+  - Warehouse JSON API (`pypi.org/pypi/<pkg>/json`) — drops version
+    keys from `releases` whose earliest `upload_time_iso_8601` is
+    too young, plus stripping the `urls` shortcut.
+  - PEP 691 Simple JSON (`pypi.org/simple/<pkg>/` with
+    `Accept: application/vnd.pypi.simple.v1+json`) — drops
+    too-young `files[]`, prunes `versions[]` to only those with
+    surviving files.
+
+  The legacy HTML Simple index (PEP 503) carries no upload time in
+  the response; it passes through unchanged. pip fall-back to
+  tarball-level `files.pythonhosted.org` deny still catches those
+  installs fail-hard.
+- **nuget** — still fail-hard. NuGet uses versioned flat-container
+  URLs (`api.nuget.org/v3-flatcontainer/<id>/index.json`); same
+  pattern as the others, just one more ecosystem to wire.
 
 For ecosystems without rewriting, `deps check` (CI) or the proxy's
 hard-deny (desktop) is still the defense — just not silent.
@@ -114,10 +127,9 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 2. **HTTPS registry proxy** — same idea but transparent: set
    `HTTPS_PROXY` system-wide, filter fetch traffic. No shell
    aliasing required, but MITM cert management is a UX chore.
-3. **pnpm-style auto-fallback for pypi/nuget** — crates.io (v0.15)
-   and npm (v0.16) already work. Extend to the remaining two:
-   PyPI simple-index / JSON-API filtering, NuGet flat-container
-   index filtering.
+3. **pnpm-style auto-fallback for nuget** — crates.io (v0.15),
+   npm (v0.16) and pypi (v0.17) already work. NuGet's
+   flat-container index is the last of the four to wire.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -8,6 +8,7 @@ pub mod parser;
 pub mod proxy;
 pub mod rewrite;
 pub mod rewrite_npm;
+pub mod rewrite_pypi;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
 pub use parser::{
@@ -17,3 +18,4 @@ pub use parser::{
 pub use proxy::{ProxyConfig, run};
 pub use rewrite::{RewriteStats, rewrite_crates_index_jsonl};
 pub use rewrite_npm::{NpmRewriteStats, rewrite_npm_packument};
+pub use rewrite_pypi::{PypiRewriteStats, rewrite_pypi_json_api, rewrite_pypi_simple_json};

--- a/crates/coronarium-proxy/src/parser.rs
+++ b/crates/coronarium-proxy/src/parser.rs
@@ -207,6 +207,27 @@ impl RegistryParser for PypiParser {
     }
 }
 
+// ---------------- PyPI metadata host (pypi.org) ----------------
+
+/// Parser for `pypi.org`, the PyPI **metadata** host.
+///
+/// Every request to `pypi.org` is metadata (JSON API, Simple index
+/// HTML/JSON, project pages). The tarballs themselves live on
+/// `files.pythonhosted.org` and are handled by [`PypiParser`]. This
+/// parser exists purely so `should_intercept` returns `true` for
+/// `pypi.org` and the proxy MITMs the TLS so we can rewrite metadata
+/// responses. It never produces a `Pinned` result.
+pub struct PypiOrgParser;
+
+impl RegistryParser for PypiOrgParser {
+    fn host(&self) -> &'static str {
+        "pypi.org"
+    }
+    fn parse(&self, _path: &str) -> ParseResult {
+        ParseResult::Metadata
+    }
+}
+
 // ---------------- NuGet (api.nuget.org) ----------------
 
 /// Parser for `api.nuget.org`. Tarball download URL:
@@ -249,6 +270,7 @@ pub fn default_parsers() -> Vec<Box<dyn RegistryParser>> {
         Box::new(CratesIoSparseParser),
         Box::new(NpmParser),
         Box::new(PypiParser),
+        Box::new(PypiOrgParser),
         Box::new(NugetParser),
     ]
 }

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -23,6 +23,7 @@ use crate::decision::{AgeOracle, Decider, Decision};
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
 use crate::rewrite::rewrite_crates_index_jsonl;
 use crate::rewrite_npm::rewrite_npm_packument;
+use crate::rewrite_pypi::{rewrite_pypi_json_api, rewrite_pypi_simple_json};
 
 pub struct ProxyConfig {
     pub listen: SocketAddr,
@@ -229,6 +230,49 @@ impl HttpHandler for CoronariumHandler {
                 }
                 out
             }
+            RewriteTarget::PypiJsonApi => {
+                let (out, stats) = rewrite_pypi_json_api(&collected, self.decider.min_age, now);
+                if stats.dropped > 0 {
+                    log::info!(
+                        "pypi-rewrite(json): dropped {} version(s), kept {}",
+                        stats.dropped,
+                        stats.kept
+                    );
+                }
+                out
+            }
+            RewriteTarget::PypiSimpleJson => {
+                // PEP 691 Simple JSON and PEP 503 HTML share the
+                // `/simple/<pkg>/` path — distinguish by Content-Type.
+                // Anything other than `application/vnd.pypi.simple.v1+json`
+                // (the only JSON shape we currently handle) passes through.
+                let is_simple_json = parts
+                    .headers
+                    .get(http::header::CONTENT_TYPE)
+                    .and_then(|h| h.to_str().ok())
+                    .map(|ct| {
+                        let ct = ct.to_ascii_lowercase();
+                        ct.contains("application/vnd.pypi.simple.v1+json")
+                            || ct.contains("application/vnd.pypi.simple.latest+json")
+                    })
+                    .unwrap_or(false);
+                if !is_simple_json {
+                    log::debug!("pypi-rewrite(simple): pass-through (non-JSON Content-Type)");
+                    return Response::from_parts(
+                        parts,
+                        Body::from(http_body_util::Full::new(collected)),
+                    );
+                }
+                let (out, stats) = rewrite_pypi_simple_json(&collected, self.decider.min_age, now);
+                if stats.dropped > 0 {
+                    log::info!(
+                        "pypi-rewrite(simple): dropped {} file(s), kept {}",
+                        stats.dropped,
+                        stats.kept
+                    );
+                }
+                out
+            }
         };
 
         // Strip Content-Length so hyper recomputes it from the new body.
@@ -244,6 +288,8 @@ impl HttpHandler for CoronariumHandler {
 enum RewriteTarget {
     CratesSparse,
     NpmPackument,
+    PypiJsonApi,
+    PypiSimpleJson,
 }
 
 /// Match the in-flight `(host, path)` to a rewriter. Returning `None`
@@ -262,7 +308,37 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
     if host.eq_ignore_ascii_case("registry.npmjs.org") && is_npm_packument_path(path) {
         return Some(RewriteTarget::NpmPackument);
     }
+    if host.eq_ignore_ascii_case("pypi.org") {
+        if is_pypi_json_api_path(path) {
+            return Some(RewriteTarget::PypiJsonApi);
+        }
+        if is_pypi_simple_path(path) {
+            // We can't distinguish HTML vs JSON by path alone — the
+            // client's Accept header decides, and the upstream
+            // response's Content-Type confirms. The handler inspects
+            // Content-Type at rewrite time and skips HTML bodies.
+            return Some(RewriteTarget::PypiSimpleJson);
+        }
+    }
     None
+}
+
+/// `GET /pypi/<pkg>/json` — the Warehouse legacy JSON API.
+fn is_pypi_json_api_path(path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    // Accept both `/pypi/<pkg>/json` and `/pypi/<pkg>/<version>/json`.
+    path.starts_with("/pypi/") && path.trim_end_matches('/').ends_with("/json")
+}
+
+/// `GET /simple/<pkg>/` — PEP 503 simple index (HTML) or PEP 691 JSON.
+fn is_pypi_simple_path(path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    if let Some(rest) = path.strip_prefix("/simple/") {
+        let rest = rest.trim_end_matches('/');
+        !rest.is_empty() && !rest.contains('/')
+    } else {
+        false
+    }
 }
 
 fn is_npm_packument_path(path: &str) -> bool {
@@ -313,11 +389,12 @@ mod tests {
             "index.crates.io",
             "registry.npmjs.org",
             "files.pythonhosted.org",
+            "pypi.org",
             "api.nuget.org",
         ] {
             assert!(should_intercept(host, &ps), "should intercept {host}");
         }
-        for host in ["evil.example.com", "pypi.org", "www.nuget.org"] {
+        for host in ["evil.example.com", "www.nuget.org"] {
             assert!(!should_intercept(host, &ps), "should NOT intercept {host}");
         }
     }
@@ -345,6 +422,25 @@ mod tests {
     }
 
     #[test]
+    fn pypi_json_api_path_matches_warehouse_shape() {
+        assert!(is_pypi_json_api_path("/pypi/requests/json"));
+        assert!(is_pypi_json_api_path("/pypi/requests/json/"));
+        assert!(is_pypi_json_api_path("/pypi/requests/2.32.4/json"));
+        assert!(!is_pypi_json_api_path("/simple/requests/"));
+        assert!(!is_pypi_json_api_path("/pypi/requests/"));
+        assert!(!is_pypi_json_api_path("/"));
+    }
+
+    #[test]
+    fn pypi_simple_path_matches_index_shape() {
+        assert!(is_pypi_simple_path("/simple/requests/"));
+        assert!(is_pypi_simple_path("/simple/requests"));
+        assert!(!is_pypi_simple_path("/simple/requests/2.32.4/"));
+        assert!(!is_pypi_simple_path("/simple/"));
+        assert!(!is_pypi_simple_path("/pypi/requests/json"));
+    }
+
+    #[test]
     fn classify_response_routes_to_correct_rewriter() {
         assert_eq!(
             classify_response(Some("index.crates.io"), Some("/anything")),
@@ -362,6 +458,16 @@ mod tests {
             ),
             None
         );
+        // PyPI endpoints
+        assert_eq!(
+            classify_response(Some("pypi.org"), Some("/pypi/requests/json")),
+            Some(RewriteTarget::PypiJsonApi)
+        );
+        assert_eq!(
+            classify_response(Some("pypi.org"), Some("/simple/requests/")),
+            Some(RewriteTarget::PypiSimpleJson)
+        );
+        assert_eq!(classify_response(Some("pypi.org"), Some("/")), None);
         // unrecognised host
         assert_eq!(
             classify_response(Some("evil.example.com"), Some("/foo")),

--- a/crates/coronarium-proxy/src/rewrite_pypi.rs
+++ b/crates/coronarium-proxy/src/rewrite_pypi.rs
@@ -1,0 +1,388 @@
+//! PyPI metadata rewriters — the pypi.org counterpart to
+//! [`crate::rewrite`] (crates.io) and [`crate::rewrite_npm`] (npm).
+//!
+//! PyPI serves two metadata shapes we care about:
+//!
+//! 1. **Warehouse JSON API**: `GET /pypi/<pkg>/json` — returns
+//!    `releases: { "X.Y.Z": [<file>, …], … }`. Each file carries
+//!    `upload_time_iso_8601`. We drop entire version keys whose
+//!    earliest file upload time is too young.
+//!
+//! 2. **Simple index (PEP 691 JSON)**: `GET /simple/<pkg>/` with
+//!    `Accept: application/vnd.pypi.simple.v1+json` — returns
+//!    `files: [{ "filename", "upload-time", "hashes", … }, …]` plus
+//!    a top-level `versions: [...]` listing. We filter `files[]`
+//!    per-file on `upload-time`.
+//!
+//! The Simple index HTML (PEP 503) is a separate story: it has no
+//! upload time in the response, so we'd need an out-of-band lookup.
+//! Modern pip/uv prefer the JSON endpoints anyway, so we leave HTML
+//! as pass-through for now (the `files.pythonhosted.org` tarball
+//! deny still catches too-young fetches there, just fail-hard).
+//!
+//! Pure + synchronous; unit tests cover every branch.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PypiRewriteStats {
+    pub kept: usize,
+    pub dropped: usize,
+}
+
+/// Rewrite a Warehouse JSON API body (`/pypi/<pkg>/json`). Drops
+/// version keys from `releases` whose earliest `upload_time_iso_8601`
+/// is younger than `min_age`.
+pub fn rewrite_pypi_json_api(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, PypiRewriteStats) {
+    let mut stats = PypiRewriteStats::default();
+    let mut doc: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("pypi-rewrite(json): pass-through, parse failed: {e}");
+            return (body.to_vec(), stats);
+        }
+    };
+    let Some(obj) = doc.as_object_mut() else {
+        return (body.to_vec(), stats);
+    };
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+
+    if let Some(releases) = obj.get_mut("releases").and_then(Value::as_object_mut) {
+        // Collect too-young version keys first to avoid borrow conflicts.
+        let too_young: Vec<String> = releases
+            .iter()
+            .filter_map(|(vers, files)| {
+                let files = files.as_array()?;
+                let earliest = earliest_upload_time_json_api(files)?;
+                if (now - earliest) < cutoff {
+                    Some(vers.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        stats.dropped = too_young.len();
+        for v in &too_young {
+            releases.remove(v);
+        }
+        stats.kept = releases.len();
+    }
+
+    // Also blank `urls` (the "latest release's files" shortcut) if any
+    // of its files were published too recently. pip/uv sometimes look
+    // at `urls` directly when no version is specified.
+    if let Some(urls) = obj.get_mut("urls").and_then(Value::as_array_mut) {
+        urls.retain(|f| {
+            f.get("upload_time_iso_8601")
+                .and_then(Value::as_str)
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| (now - dt.with_timezone(&Utc)) >= cutoff)
+                .unwrap_or(true) // keep entries we can't parse
+        });
+    }
+
+    let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
+    (out, stats)
+}
+
+fn earliest_upload_time_json_api(files: &[Value]) -> Option<DateTime<Utc>> {
+    files
+        .iter()
+        .filter_map(|f| {
+            f.get("upload_time_iso_8601")
+                .and_then(Value::as_str)
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+        })
+        .min()
+}
+
+/// Rewrite a PEP 691 Simple index JSON body (`/simple/<pkg>/` with
+/// `Accept: application/vnd.pypi.simple.v1+json`). Drops `files[]`
+/// entries whose `upload-time` is younger than `min_age`, then
+/// prunes the top-level `versions[]` so it only lists versions that
+/// still have at least one file.
+pub fn rewrite_pypi_simple_json(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, PypiRewriteStats) {
+    let mut stats = PypiRewriteStats::default();
+    let mut doc: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("pypi-rewrite(simple-json): pass-through, parse failed: {e}");
+            return (body.to_vec(), stats);
+        }
+    };
+    let Some(obj) = doc.as_object_mut() else {
+        return (body.to_vec(), stats);
+    };
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+
+    if let Some(files) = obj.get_mut("files").and_then(Value::as_array_mut) {
+        let before = files.len();
+        files.retain(|f| {
+            match f
+                .get("upload-time")
+                .and_then(Value::as_str)
+                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+            {
+                Some(t) => (now - t) >= cutoff,
+                None => true, // keep entries with no / unparseable time
+            }
+        });
+        stats.kept = files.len();
+        stats.dropped = before - files.len();
+    }
+
+    // Rebuild surviving version set from remaining filenames so the
+    // top-level `versions` list doesn't advertise versions with zero
+    // files. Filename format per PEP 427 / sdist conventions: first
+    // `-` separated segment that starts with a digit is the version.
+    if stats.dropped > 0 {
+        let surviving: std::collections::HashSet<String> = obj
+            .get("files")
+            .and_then(Value::as_array)
+            .map(|files| {
+                files
+                    .iter()
+                    .filter_map(|f| f.get("filename").and_then(Value::as_str))
+                    .filter_map(extract_version_from_filename)
+                    .collect()
+            })
+            .unwrap_or_default();
+        if let Some(versions) = obj.get_mut("versions").and_then(Value::as_array_mut) {
+            versions.retain(|v| v.as_str().map(|s| surviving.contains(s)).unwrap_or(true));
+        }
+    }
+
+    let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
+    (out, stats)
+}
+
+/// Cheap-and-cheerful "pull the version out of a PyPI filename":
+/// strip the recognised archive extension, split on `-`, return the
+/// first segment starting with a digit. Mirrors the logic already in
+/// [`crate::parser::PypiParser::parse`].
+fn extract_version_from_filename(filename: &str) -> Option<String> {
+    let stem = filename
+        .strip_suffix(".whl")
+        .or_else(|| filename.strip_suffix(".tar.gz"))
+        .or_else(|| filename.strip_suffix(".zip"))
+        .or_else(|| filename.strip_suffix(".egg"))?;
+    let parts: Vec<&str> = stem.split('-').collect();
+    parts
+        .iter()
+        .skip(1)
+        .find(|p| p.starts_with(|c: char| c.is_ascii_digit()))
+        .map(|p| (*p).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn utc(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    fn min_age_hours(h: u64) -> Duration {
+        Duration::from_secs(h * 3600)
+    }
+
+    fn parse(body: &[u8]) -> Value {
+        serde_json::from_slice(body).unwrap()
+    }
+
+    // ---------- JSON API ----------
+
+    fn json_api(releases: &[(&str, &[&str])]) -> String {
+        let mut rels = serde_json::Map::new();
+        for (vers, times) in releases {
+            let files: Vec<Value> = times
+                .iter()
+                .map(|t| {
+                    let mut m = serde_json::Map::new();
+                    m.insert(
+                        "filename".into(),
+                        Value::String(format!("pkg-{vers}.tar.gz")),
+                    );
+                    m.insert("upload_time_iso_8601".into(), Value::String((*t).into()));
+                    Value::Object(m)
+                })
+                .collect();
+            rels.insert((*vers).into(), Value::Array(files));
+        }
+        let mut doc = serde_json::Map::new();
+        doc.insert("info".into(), Value::Object(serde_json::Map::new()));
+        doc.insert("releases".into(), Value::Object(rels));
+        doc.insert("urls".into(), Value::Array(vec![]));
+        serde_json::to_string(&doc).unwrap()
+    }
+
+    #[test]
+    fn json_api_drops_too_young_version_keys() {
+        let now = utc(2025, 1, 10);
+        let body = json_api(&[
+            ("1.0.0", &["2024-12-01T00:00:00Z"]),
+            ("1.1.0", &["2025-01-09T23:00:00Z"]), // too young
+        ]);
+        let (out, stats) = rewrite_pypi_json_api(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        let releases = doc["releases"].as_object().unwrap();
+        assert!(releases.contains_key("1.0.0"));
+        assert!(!releases.contains_key("1.1.0"));
+        assert_eq!(stats.kept, 1);
+        assert_eq!(stats.dropped, 1);
+    }
+
+    #[test]
+    fn json_api_keeps_version_if_any_file_is_old_enough() {
+        // A version with one old file + one young file is judged by
+        // the earliest (= oldest) upload_time. A real PyPI release
+        // uploads all files close together, so this case is rare,
+        // but it's the honest behaviour.
+        let now = utc(2025, 1, 10);
+        let body = json_api(&[("1.0.0", &["2024-06-01T00:00:00Z", "2025-01-09T23:00:00Z"])]);
+        let (out, stats) = rewrite_pypi_json_api(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        assert!(doc["releases"].as_object().unwrap().contains_key("1.0.0"));
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn json_api_prunes_urls_shortcut() {
+        // urls[] lists the latest release's files; if those are young
+        // we strip them so tools that consult urls don't get a young
+        // pin.
+        let now = utc(2025, 1, 10);
+        let body = r#"{
+            "info": {},
+            "releases": {},
+            "urls": [
+                {"upload_time_iso_8601": "2024-01-01T00:00:00Z", "filename": "old.tar.gz"},
+                {"upload_time_iso_8601": "2025-01-09T23:00:00Z", "filename": "new.tar.gz"}
+            ]
+        }"#;
+        let (out, _) = rewrite_pypi_json_api(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        let urls = doc["urls"].as_array().unwrap();
+        assert_eq!(urls.len(), 1);
+        assert_eq!(urls[0]["filename"], "old.tar.gz");
+    }
+
+    #[test]
+    fn json_api_malformed_body_passes_through() {
+        let (out, stats) = rewrite_pypi_json_api(b"not json", min_age_hours(168), utc(2025, 1, 10));
+        assert_eq!(out, b"not json");
+        assert_eq!(stats.dropped, 0);
+    }
+
+    // ---------- Simple JSON ----------
+
+    fn simple_json(files: &[(&str, &str)], versions: &[&str]) -> String {
+        let files_v: Vec<Value> = files
+            .iter()
+            .map(|(filename, t)| {
+                let mut m = serde_json::Map::new();
+                m.insert("filename".into(), Value::String((*filename).into()));
+                m.insert("upload-time".into(), Value::String((*t).into()));
+                Value::Object(m)
+            })
+            .collect();
+        let mut doc = serde_json::Map::new();
+        doc.insert("name".into(), Value::String("pkg".into()));
+        doc.insert("files".into(), Value::Array(files_v));
+        doc.insert(
+            "versions".into(),
+            Value::Array(
+                versions
+                    .iter()
+                    .map(|v| Value::String((*v).into()))
+                    .collect(),
+            ),
+        );
+        serde_json::to_string(&doc).unwrap()
+    }
+
+    #[test]
+    fn simple_json_drops_young_files_and_prunes_versions() {
+        let now = utc(2025, 1, 10);
+        let body = simple_json(
+            &[
+                ("pkg-1.0.0.tar.gz", "2024-06-01T00:00:00Z"),
+                ("pkg-2.0.0.tar.gz", "2025-01-09T00:00:00Z"), // young
+                ("pkg-2.0.0-py3-none-any.whl", "2025-01-09T00:00:01Z"), // young
+            ],
+            &["1.0.0", "2.0.0"],
+        );
+        let (out, stats) = rewrite_pypi_simple_json(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        let files = doc["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0]["filename"], "pkg-1.0.0.tar.gz");
+        let versions: Vec<&str> = doc["versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert_eq!(versions, vec!["1.0.0"]);
+        assert_eq!(stats.dropped, 2);
+        assert_eq!(stats.kept, 1);
+    }
+
+    #[test]
+    fn simple_json_keeps_files_with_no_upload_time() {
+        // Some older index entries have no upload-time. We keep them
+        // — the tarball deny path catches them downstream if needed.
+        let now = utc(2025, 1, 10);
+        let body =
+            r#"{"name":"pkg","files":[{"filename":"pkg-0.0.1.tar.gz"}],"versions":["0.0.1"]}"#;
+        let (out, stats) = rewrite_pypi_simple_json(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        assert_eq!(doc["files"].as_array().unwrap().len(), 1);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn simple_json_malformed_body_passes_through() {
+        let (out, _) = rewrite_pypi_simple_json(
+            b"<!doctype html>\n<body>not json</body>",
+            min_age_hours(168),
+            utc(2025, 1, 10),
+        );
+        assert_eq!(out, b"<!doctype html>\n<body>not json</body>");
+    }
+
+    // ---------- filename → version ----------
+
+    #[test]
+    fn filename_version_extraction_covers_common_shapes() {
+        assert_eq!(
+            extract_version_from_filename("requests-2.32.4.tar.gz").as_deref(),
+            Some("2.32.4")
+        );
+        assert_eq!(
+            extract_version_from_filename("requests-2.32.4-py3-none-any.whl").as_deref(),
+            Some("2.32.4")
+        );
+        assert_eq!(
+            extract_version_from_filename("my-cool-pkg-1.0.0.tar.gz").as_deref(),
+            Some("1.0.0"),
+            "hyphen-separated package name"
+        );
+        assert_eq!(extract_version_from_filename("weird.txt"), None);
+        assert_eq!(extract_version_from_filename(""), None);
+    }
+}


### PR DESCRIPTION
## Summary
Third ecosystem to get pnpm-style auto-fallback (after crates.io in v0.15 and npm in v0.16). Two PyPI endpoints are rewritten:

1. **Warehouse JSON API** (`pypi.org/pypi/<pkg>/json`) — drops version keys from `releases` whose earliest `upload_time_iso_8601` is too young; strips young entries from the `urls` shortcut.
2. **PEP 691 Simple JSON** (`pypi.org/simple/<pkg>/` with `Accept: application/vnd.pypi.simple.v1+json`) — drops too-young `files[]`, rebuilds `versions[]` from surviving filenames.

The legacy HTML Simple index has no upload time in the response and is passed through unchanged. Existing tarball deny on `files.pythonhosted.org` still catches too-young installs there (fail-hard, not silent).

## Live smoke (`requests`, `--min-age 365d`, today=2026-04-20)
| endpoint | direct | via proxy |
|---|---|---|
| JSON API `releases` | 159 | **155** (dropped 2.32.4, 2.32.5, 2.33.0, 2.33.1) |
| JSON API `urls` | 2 | **0** |
| Simple JSON `files` | 236 | **228** |
| Simple JSON `versions` | 156 | **152** |
| HTML Simple | 78914 B | 78914 B (pass-through) |

## Test plan
- [x] `cargo test -p coronarium-proxy` — 65 tests pass (8 new in `rewrite_pypi::tests`, 2 new path matchers + classify cases in `proxy::tests`)
- [x] `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean
- [x] Live smoke above
- [x] Existing `should_intercept` test updated: `pypi.org` now in the intercept list

🤖 Generated with [Claude Code](https://claude.com/claude-code)