### PR TITLE
feat(proxy): NuGet registration-page rewrite (pnpm-style auto-fallback)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,23 @@ older deps.
   the response; it passes through unchanged. pip fall-back to
   tarball-level `files.pythonhosted.org` deny still catches those
   installs fail-hard.
-- **nuget** — still fail-hard. NuGet uses versioned flat-container
-  URLs (`api.nuget.org/v3-flatcontainer/<id>/index.json`); same
-  pattern as the others, just one more ecosystem to wire.
+- **nuget** — ✅ implemented for the **registration** endpoints
+  (`api.nuget.org/v3/registration<X>*/<id>/index.json` and the
+  paged `.../page/<lower>/<upper>.json`). Leaves whose
+  `catalogEntry.published` is too young are dropped from every
+  page's `items[]`; `count` fields are rewritten so they stay
+  consistent. Pages that reference a separate URL instead of
+  carrying inline items are left alone — the re-fetch is a new
+  request and goes through the same rewriter.
+
+  The **flat-container index** (`/v3-flatcontainer/<id>/index.json`
+  — a plain `{"versions":[...]}` with no dates) is **not** yet
+  silently filtered; we'd need an out-of-band lookup to the
+  registration endpoint to get dates. Until we do, dotnet restore
+  paths through flat-container still hit the existing nupkg
+  download deny at `api.nuget.org/v3-flatcontainer/<id>/<version>/…`
+  — fail-hard, not silent. This is the last remaining roadmap
+  item for the four-ecosystem sweep.
 
 For ecosystems without rewriting, `deps check` (CI) or the proxy's
 hard-deny (desktop) is still the defense — just not silent.
@@ -127,9 +141,12 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 2. **HTTPS registry proxy** — same idea but transparent: set
    `HTTPS_PROXY` system-wide, filter fetch traffic. No shell
    aliasing required, but MITM cert management is a UX chore.
-3. **pnpm-style auto-fallback for nuget** — crates.io (v0.15),
-   npm (v0.16) and pypi (v0.17) already work. NuGet's
-   flat-container index is the last of the four to wire.
+3. **NuGet flat-container auto-fallback** — NuGet registration
+   pages are rewritten as of v0.18. The last silent-fallback gap
+   is the flat-container `/v3-flatcontainer/<id>/index.json`
+   endpoint, which carries no publish dates inline. Fix needs
+   an out-of-band lookup to the registration endpoint (cached)
+   to learn dates, then filter the version list.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -8,6 +8,7 @@ pub mod parser;
 pub mod proxy;
 pub mod rewrite;
 pub mod rewrite_npm;
+pub mod rewrite_nuget;
 pub mod rewrite_pypi;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
@@ -18,4 +19,5 @@ pub use parser::{
 pub use proxy::{ProxyConfig, run};
 pub use rewrite::{RewriteStats, rewrite_crates_index_jsonl};
 pub use rewrite_npm::{NpmRewriteStats, rewrite_npm_packument};
+pub use rewrite_nuget::{NugetRewriteStats, rewrite_nuget_registration};
 pub use rewrite_pypi::{PypiRewriteStats, rewrite_pypi_json_api, rewrite_pypi_simple_json};

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -23,6 +23,7 @@ use crate::decision::{AgeOracle, Decider, Decision};
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
 use crate::rewrite::rewrite_crates_index_jsonl;
 use crate::rewrite_npm::rewrite_npm_packument;
+use crate::rewrite_nuget::rewrite_nuget_registration;
 use crate::rewrite_pypi::{rewrite_pypi_json_api, rewrite_pypi_simple_json};
 
 pub struct ProxyConfig {
@@ -273,6 +274,18 @@ impl HttpHandler for CoronariumHandler {
                 }
                 out
             }
+            RewriteTarget::NugetRegistration => {
+                let (out, stats) =
+                    rewrite_nuget_registration(&collected, self.decider.min_age, now);
+                if stats.dropped > 0 {
+                    log::info!(
+                        "nuget-rewrite: dropped {} version(s), kept {}",
+                        stats.dropped,
+                        stats.kept
+                    );
+                }
+                out
+            }
         };
 
         // Strip Content-Length so hyper recomputes it from the new body.
@@ -290,6 +303,7 @@ enum RewriteTarget {
     NpmPackument,
     PypiJsonApi,
     PypiSimpleJson,
+    NugetRegistration,
 }
 
 /// Match the in-flight `(host, path)` to a rewriter. Returning `None`
@@ -320,7 +334,34 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
             return Some(RewriteTarget::PypiSimpleJson);
         }
     }
+    if host.eq_ignore_ascii_case("api.nuget.org") && is_nuget_registration_path(path) {
+        return Some(RewriteTarget::NugetRegistration);
+    }
     None
+}
+
+/// NuGet registration endpoints:
+/// - `/v3/registration<X>*/<id>/index.json` (top-level index)
+/// - `/v3/registration<X>*/<id>/page/<lower>/<upper>.json` (paged)
+///
+/// `<X>*` is one of the many versioned URL bases NuGet publishes
+/// (`registration5-semver1`, `registration5-gz-semver2`, …). We match
+/// any prefix starting with `registration` so new endpoints added by
+/// NuGet don't require a code change.
+fn is_nuget_registration_path(path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    let rest = match path.strip_prefix("/v3/") {
+        Some(r) => r,
+        None => return false,
+    };
+    let mut parts = rest.splitn(2, '/');
+    let base = parts.next().unwrap_or("");
+    let tail = parts.next().unwrap_or("");
+    if !base.starts_with("registration") {
+        return false;
+    }
+    // index.json or page/<lower>/<upper>.json anywhere in the tail.
+    tail.ends_with("/index.json") || (tail.contains("/page/") && tail.ends_with(".json"))
 }
 
 /// `GET /pypi/<pkg>/json` — the Warehouse legacy JSON API.
@@ -441,6 +482,25 @@ mod tests {
     }
 
     #[test]
+    fn nuget_registration_path_matches_index_and_page_shapes() {
+        assert!(is_nuget_registration_path(
+            "/v3/registration5-semver1/newtonsoft.json/index.json"
+        ));
+        assert!(is_nuget_registration_path(
+            "/v3/registration5-gz-semver2/serilog/index.json"
+        ));
+        assert!(is_nuget_registration_path(
+            "/v3/registration5-semver1/pkg/page/1.0.0/9.9.9.json"
+        ));
+        // Not registration.
+        assert!(!is_nuget_registration_path(
+            "/v3-flatcontainer/pkg/index.json"
+        ));
+        assert!(!is_nuget_registration_path("/v3/search-query"));
+        assert!(!is_nuget_registration_path("/"));
+    }
+
+    #[test]
     fn classify_response_routes_to_correct_rewriter() {
         assert_eq!(
             classify_response(Some("index.crates.io"), Some("/anything")),
@@ -468,6 +528,22 @@ mod tests {
             Some(RewriteTarget::PypiSimpleJson)
         );
         assert_eq!(classify_response(Some("pypi.org"), Some("/")), None);
+        // NuGet registration.
+        assert_eq!(
+            classify_response(
+                Some("api.nuget.org"),
+                Some("/v3/registration5-semver1/newtonsoft.json/index.json")
+            ),
+            Some(RewriteTarget::NugetRegistration)
+        );
+        // NuGet flat-container is NOT rewritten yet.
+        assert_eq!(
+            classify_response(
+                Some("api.nuget.org"),
+                Some("/v3-flatcontainer/newtonsoft.json/index.json")
+            ),
+            None
+        );
         // unrecognised host
         assert_eq!(
             classify_response(Some("evil.example.com"), Some("/foo")),

--- a/crates/coronarium-proxy/src/rewrite_nuget.rs
+++ b/crates/coronarium-proxy/src/rewrite_nuget.rs
@@ -1,0 +1,270 @@
+//! NuGet registration-index rewriter.
+//!
+//! NuGet's "registration" endpoints are the per-package metadata
+//! documents that list every published version plus its
+//! `catalogEntry.published` timestamp. There are two shapes we
+//! handle with the same rewriter:
+//!
+//! 1. `https://api.nuget.org/v3/registration<X>/<id>/index.json`
+//!    — the top-level index. Contains an outer `items[]` where each
+//!    element is a *page*. A page either carries its versions
+//!    inline (`items` nested inside) or points at a separate
+//!    page URL.
+//!
+//! 2. `https://api.nuget.org/v3/registration<X>/<id>/page/<lower>/<upper>.json`
+//!    — a paged file. Same shape as an inline page: `items[]` of
+//!    `{ catalogEntry: { version, published, … }, … }`.
+//!
+//! In both cases we walk `items[]` recursively, drop entries whose
+//! `catalogEntry.published` is younger than `min_age`, and fix up
+//! the `count` field so it stays consistent.
+//!
+//! Flat-container (`/v3-flatcontainer/<id>/index.json`) has no dates
+//! inline, so it's NOT rewritten here. dotnet restore paths through
+//! flat-container for nupkg download still hit the existing
+//! tarball-level deny — fail-hard, not silent. Silent fallback for
+//! flat-container is a roadmap item.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NugetRewriteStats {
+    pub kept: usize,
+    pub dropped: usize,
+}
+
+/// Rewrite a NuGet registration document (index.json or a paged
+/// *.json file). Drops `items[]` entries recursively whose
+/// `catalogEntry.published` is younger than `min_age`.
+///
+/// Pass-through on parse failure; the rewriter is best-effort and
+/// preserves the body byte-for-byte when we don't understand it.
+pub fn rewrite_nuget_registration(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, NugetRewriteStats) {
+    let mut stats = NugetRewriteStats::default();
+    let mut doc: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("nuget-rewrite: pass-through, parse failed: {e}");
+            return (body.to_vec(), stats);
+        }
+    };
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+    filter_items_recursively(&mut doc, cutoff, now, &mut stats);
+    let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
+    (out, stats)
+}
+
+fn filter_items_recursively(
+    v: &mut Value,
+    cutoff: chrono::Duration,
+    now: DateTime<Utc>,
+    stats: &mut NugetRewriteStats,
+) {
+    let Some(obj) = v.as_object_mut() else {
+        return;
+    };
+    if let Some(items) = obj.get_mut("items").and_then(Value::as_array_mut) {
+        // Two possibilities per item:
+        // (a) leaf: { catalogEntry: { published: … } }
+        // (b) page: { items: […] } — recurse.
+        let before = items.len();
+        items.retain_mut(|it| {
+            if let Some(entry) = it.get("catalogEntry") {
+                // Leaf — drop if too young.
+                let keep = entry
+                    .get("published")
+                    .and_then(Value::as_str)
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| (now - dt.with_timezone(&Utc)) >= cutoff)
+                    .unwrap_or(true); // unknown → keep
+                if keep {
+                    stats.kept += 1;
+                } else {
+                    stats.dropped += 1;
+                }
+                keep
+            } else if it.get("items").is_some() {
+                // Page with inline nested items — recurse; keep the
+                // page even if it ends up empty, because it still
+                // carries valid lower/upper bounds and a re-fetch URL.
+                filter_items_recursively(it, cutoff, now, stats);
+                if let Some(nested) = it.get("items").and_then(Value::as_array) {
+                    let count = nested.len();
+                    if let Some(obj) = it.as_object_mut() {
+                        obj.insert(
+                            "count".into(),
+                            Value::Number(serde_json::Number::from(count)),
+                        );
+                    }
+                }
+                true
+            } else {
+                // Page reference without inline items — leave alone;
+                // the separate fetch for that page will be rewritten
+                // when the client follows the link.
+                true
+            }
+        });
+        let new_count = items.len();
+        let _ = before;
+        // Preserve the count field on the outer document / page so
+        // downstream consumers don't see a stale length.
+        if let Some(count) = obj.get_mut("count") {
+            *count = Value::Number(serde_json::Number::from(new_count));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn utc(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    fn min_age_hours(h: u64) -> Duration {
+        Duration::from_secs(h * 3600)
+    }
+
+    fn parse(body: &[u8]) -> Value {
+        serde_json::from_slice(body).unwrap()
+    }
+
+    fn leaf(version: &str, published: &str) -> Value {
+        serde_json::json!({
+            "@id": format!("https://api.nuget.org/v3/registration5-semver1/pkg/{version}.json"),
+            "catalogEntry": {
+                "id": "Pkg",
+                "version": version,
+                "published": published
+            }
+        })
+    }
+
+    fn paged_index(leaves: &[(&str, &str)]) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "@id": "https://api.nuget.org/v3/registration5-semver1/pkg/index.json",
+            "count": 1,
+            "items": [{
+                "@id": "page",
+                "lower": leaves.first().map(|(v,_)| v).unwrap_or(&"0.0.0"),
+                "upper": leaves.last().map(|(v,_)| v).unwrap_or(&"0.0.0"),
+                "count": leaves.len(),
+                "items": leaves.iter().map(|(v,t)| leaf(v,t)).collect::<Vec<_>>()
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn drops_young_leaf_entries_and_fixes_counts() {
+        let now = utc(2025, 1, 10);
+        let body = paged_index(&[
+            ("1.0.0", "2024-01-01T00:00:00Z"),
+            ("1.1.0", "2024-06-01T00:00:00Z"),
+            ("2.0.0", "2025-01-09T23:00:00Z"), // too young
+        ]);
+        let (out, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+
+        let pages = doc["items"].as_array().unwrap();
+        assert_eq!(pages.len(), 1);
+        let page = &pages[0];
+        let leaves = page["items"].as_array().unwrap();
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(page["count"], 2);
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 2);
+    }
+
+    #[test]
+    fn keeps_entries_with_missing_or_unparseable_published() {
+        let now = utc(2025, 1, 10);
+        let body = serde_json::to_string(&serde_json::json!({
+            "count": 1,
+            "items": [{
+                "count": 2,
+                "items": [
+                    { "catalogEntry": { "version": "1.0.0" /* no published */ } },
+                    { "catalogEntry": { "version": "1.1.0", "published": "not-a-date" } }
+                ]
+            }]
+        }))
+        .unwrap();
+        let (out, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
+        let doc = parse(&out);
+        assert_eq!(
+            doc["items"][0]["items"].as_array().unwrap().len(),
+            2,
+            "unknown dates should be kept (fail-open)"
+        );
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn leaves_page_references_without_inline_items_alone() {
+        // Some index.json pages reference a separate /page/<lower>/<upper>.json URL.
+        let now = utc(2025, 1, 10);
+        let body = serde_json::to_string(&serde_json::json!({
+            "count": 1,
+            "items": [{
+                "@id": "https://api.nuget.org/v3/registration5-semver1/pkg/page/1.0.0/9.9.9.json",
+                "lower": "1.0.0",
+                "upper": "9.9.9"
+                /* no "items" — client must fetch the page URL */
+            }]
+        }))
+        .unwrap();
+        let before: Value = serde_json::from_slice(body.as_bytes()).unwrap();
+        let (out, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
+        let after: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(before, after);
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 0);
+    }
+
+    #[test]
+    fn malformed_body_passes_through() {
+        let (out, stats) =
+            rewrite_nuget_registration(b"not json", min_age_hours(168), utc(2025, 1, 10));
+        assert_eq!(out, b"not json");
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn rfc3339_with_offset_works() {
+        // NuGet commonly emits `+00:00` instead of `Z`.
+        let now = utc(2025, 1, 10);
+        let body = paged_index(&[
+            ("1.0.0", "2024-01-01T00:00:00.000+00:00"),
+            ("2.0.0", "2025-01-09T23:00:00.000+00:00"), // too young
+        ]);
+        let (_, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 1);
+    }
+
+    #[test]
+    fn nothing_young_means_body_semantics_preserved() {
+        let now = utc(2025, 1, 10);
+        let body = paged_index(&[
+            ("1.0.0", "2024-01-01T00:00:00Z"),
+            ("1.1.0", "2024-06-01T00:00:00Z"),
+        ]);
+        let (out, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
+        let before: Value = serde_json::from_slice(body.as_bytes()).unwrap();
+        let after: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(before, after);
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 2);
+    }
+}


### PR DESCRIPTION
## Summary
Fourth and (nearly) final ecosystem to get pnpm-style auto-fallback — after crates.io v0.15, npm v0.16, pypi v0.17. The proxy rewrites NuGet registration endpoints (`api.nuget.org/v3/registration<X>*/<id>/index.json` and the paged `.../page/<lower>/<upper>.json`), walking `items[]` recursively and dropping leaves whose `catalogEntry.published` is too young. `count` fields are kept consistent.

Pages that don't carry inline items (i.e. they reference a separate URL) are left alone — the re-fetch is a new request that goes through the same rewriter.

The **flat-container index** (`/v3-flatcontainer/<id>/index.json` — plain `{"versions":[...]}` with no dates) is **not** yet silently filtered. dotnet restore going through flat-container for nupkg download still hits the existing tarball-level deny — fail-hard, not silent. Called out in CLAUDE.md as the last remaining roadmap gap.

## Live smoke (`Newtonsoft.Json`, `--min-age 365d`, today=2026-04-20)
| | leaves | too-young (>2025-04-20) |
|---|---|---|
| direct | 84 | 2 (`13.0.4`, `13.0.5-beta1`) |
| via proxy | **82** | **0** |

## Test plan
- [x] `cargo test -p coronarium-proxy` — 72 tests pass (6 new in `rewrite_nuget::tests`, 2 new path matchers + classify cases)
- [x] `cargo clippy --all-targets -D warnings` clean, `cargo fmt --check` clean
- [x] Live smoke above
- [x] Correctness: `count` fields stay consistent, entries with missing/malformed `published` are kept (fail-open), RFC3339 offsets are accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)