### PR TITLE
feat: README hero, `coronarium doctor`, GitHub Action + Docker image

### DIFF
--- a/.github/actions/proxy/action.yml
+++ b/.github/actions/proxy/action.yml
@@ -1,0 +1,126 @@
+name: coronarium-proxy
+description: >
+  Route every HTTPS request from subsequent steps through the
+  coronarium proxy, which silently filters too-young versions out of
+  crates.io / npm / pypi / nuget metadata responses. Gives your CI
+  the pnpm-style "minimumReleaseAge" auto-fallback semantics for
+  every ecosystem, not just npm.
+
+inputs:
+  min-age:
+    description: >
+      Minimum package age (same grammar as `coronarium deps check`,
+      e.g. `7d`, `12h`). Versions younger than this are invisible to
+      the resolver.
+    required: false
+    default: "7d"
+  listen:
+    description: Address the proxy listens on.
+    required: false
+    default: "127.0.0.1:8910"
+  fail-on-missing:
+    description: >
+      When `true`, treat unknown publish dates as a deny. Default
+      fails open (allow through) so a flaky registry doesn't brick
+      the build.
+    required: false
+    default: "false"
+  version:
+    description: >
+      coronarium release tag to download. Defaults to the floating
+      `v0` tag, which always tracks the newest `v0.x.y`.
+    required: false
+    default: "v0"
+
+outputs:
+  ca-cert:
+    description: Absolute path to the proxy's root CA PEM (e.g. for
+      CARGO_HTTP_CAINFO, PIP_CERT, NODE_EXTRA_CA_CERTS).
+    value: ${{ steps.start.outputs.ca_cert }}
+
+runs:
+  using: composite
+  steps:
+    - id: start
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS" in
+          Linux)   arch_triple="$(uname -m)-unknown-linux-musl" ;;
+          macOS)   arch_triple="$(uname -m)-apple-darwin" ;;
+          Windows) arch_triple="x86_64-pc-windows-msvc" ;;
+          *) echo "::error::unsupported runner OS: $RUNNER_OS"; exit 1 ;;
+        esac
+        tmp="${RUNNER_TEMP:-/tmp}/coronarium-proxy"
+        mkdir -p "$tmp"
+        url="https://github.com/bokuweb/coronarium/releases/download/${{ inputs.version }}/coronarium-${arch_triple}.tar.gz"
+        echo "Downloading $url"
+        curl -fsSL "$url" | tar -xz -C "$tmp"
+        bin="$tmp/coronarium"
+        [ -x "$bin" ] || { echo "::error::coronarium binary missing after unpack"; ls -la "$tmp"; exit 1; }
+
+        # Generate the CA. First run creates it; subsequent runs on
+        # the same cached workspace would re-use it, which is fine.
+        export XDG_CONFIG_HOME="$tmp/xdg"
+        mkdir -p "$XDG_CONFIG_HOME"
+        # `proxy start` is long-running, but bootstrapping the CA is
+        # a side-effect of start-up; simplest is to start it and then
+        # read the CA from disk.
+        extra_flags=()
+        if [ "${{ inputs.fail-on-missing }}" = "true" ]; then
+          extra_flags+=("--fail-on-missing")
+        fi
+        nohup "$bin" proxy start \
+            --listen "${{ inputs.listen }}" \
+            --min-age "${{ inputs.min-age }}" \
+            "${extra_flags[@]}" \
+            > "$tmp/proxy.log" 2>&1 &
+        echo $! > "$tmp/proxy.pid"
+
+        # Wait for the listener.
+        for i in $(seq 1 50); do
+          if (echo > "/dev/tcp/127.0.0.1/${{ inputs.listen }}") 2>/dev/null; then
+            break
+          fi
+          # /dev/tcp is bash-specific and doesn't parse `host:port`
+          # directly; try a simpler probe for portability.
+          if nc -z 127.0.0.1 "$(echo "${{ inputs.listen }}" | awk -F: '{print $NF}')" 2>/dev/null; then
+            break
+          fi
+          sleep 0.1
+        done
+        # Last-resort probe using coronarium doctor.
+        if ! "$bin" doctor --listen "${{ inputs.listen }}" >/dev/null 2>&1; then
+          echo "::warning::proxy liveness probe didn't confirm TCP port"
+          sed -n '1,60p' "$tmp/proxy.log" || true
+        fi
+
+        ca="$XDG_CONFIG_HOME/coronarium/ca.pem"
+        [ -f "$ca" ] || { echo "::error::CA missing at $ca"; cat "$tmp/proxy.log" || true; exit 1; }
+        echo "ca_cert=$ca" >> "$GITHUB_OUTPUT"
+
+        # Export env for subsequent steps. GitHub Actions discards
+        # env changes between steps unless they're appended to
+        # $GITHUB_ENV.
+        proxy_url="http://${{ inputs.listen }}"
+        {
+          echo "HTTPS_PROXY=$proxy_url"
+          echo "HTTP_PROXY=$proxy_url"
+          echo "https_proxy=$proxy_url"
+          echo "http_proxy=$proxy_url"
+          # CA plumbing for tools that don't use the system trust
+          # store. Same env vars as `install-gate shellenv`.
+          echo "CARGO_HTTP_CAINFO=$ca"
+          echo "PIP_CERT=$ca"
+          echo "NODE_EXTRA_CA_CERTS=$ca"
+          echo "REQUESTS_CA_BUNDLE=$ca"
+          echo "SSL_CERT_FILE=$ca"
+          # Stash for the post-step cleanup.
+          echo "CORONARIUM_PROXY_TMP=$tmp"
+        } >> "$GITHUB_ENV"
+        echo "coronarium-proxy: listening on $proxy_url, CA at $ca"
+
+    # No post-step: composite actions don't support them, and
+    # GitHub's ephemeral runners tear down the VM at end-of-job which
+    # kills the proxy for us. Self-hosted users who need cleanup can
+    # add a final step that `kill $(cat $CORONARIUM_PROXY_TMP/proxy.pid)`.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: docker
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  proxy-image:
+    # Build + push the coronarium-proxy container image to GHCR on
+    # every `v*` tag. Users consume it via:
+    #   docker run --rm -p 8910:8910 ghcr.io/bokuweb/coronarium-proxy:v0
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Derive tags
+        id: tags
+        run: |
+          set -e
+          ref="${GITHUB_REF#refs/tags/}"
+          # e.g. v0.21.0 → we push :v0.21.0, :v0.21, :v0, :latest
+          # Skip the floating :v0 push for prereleases (v0.21.0-rc1 etc.)
+          major=$(echo "$ref" | awk -F. '{print $1}')
+          minor=$(echo "$ref" | awk -F. '{print $1"."$2}')
+          tags="ghcr.io/${GITHUB_REPOSITORY_OWNER}/coronarium-proxy:${ref}"
+          if [[ "$ref" != *-* ]]; then
+            tags="${tags},ghcr.io/${GITHUB_REPOSITORY_OWNER}/coronarium-proxy:${minor}"
+            tags="${tags},ghcr.io/${GITHUB_REPOSITORY_OWNER}/coronarium-proxy:${major}"
+            tags="${tags},ghcr.io/${GITHUB_REPOSITORY_OWNER}/coronarium-proxy:latest"
+          fi
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.description=HTTPS MITM proxy that enforces minimumReleaseAge across crates.io / npm / pypi / nuget
+            org.opencontainers.image.licenses=MIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1.6
+#
+# coronarium-proxy — runnable as a standalone container.
+#
+#   docker run --rm -p 8910:8910 ghcr.io/bokuweb/coronarium-proxy:v0 \
+#       --listen 0.0.0.0:8910 --min-age 7d
+#
+# The image only ships the `coronarium` binary (scratch-ish
+# distroless). The CA bundle is generated on first run inside the
+# mounted config volume — bind-mount `/etc/coronarium` to persist it
+# across container restarts:
+#
+#   docker run --rm -p 8910:8910 -v coronarium-conf:/etc/coronarium \
+#       ghcr.io/bokuweb/coronarium-proxy:v0 \
+#       --listen 0.0.0.0:8910 --min-age 7d
+#
+# For GitHub Actions adoption use `bokuweb/coronarium/proxy@v0` —
+# it's a composite action that downloads the same binary and wires
+# HTTPS_PROXY into $GITHUB_ENV for subsequent steps. The container
+# image is for users who want to run the proxy in their own infra
+# (Kubernetes, docker-compose, bare ECS, …).
+
+# ---------- build stage ----------
+FROM rust:1-bookworm AS build
+
+WORKDIR /src
+COPY . .
+
+# Only build the proxy binary. Workspace excludes coronarium-ebpf from
+# the default members, so this won't try to compile kernel programs.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/src/target \
+    cargo build --release -p coronarium && \
+    cp /src/target/release/coronarium /usr/local/bin/coronarium && \
+    strip /usr/local/bin/coronarium || true
+
+# ---------- runtime stage ----------
+FROM debian:bookworm-slim
+
+# ca-certificates: the proxy fetches publish dates from the real
+# registries via TLS and needs the system root CAs to verify them.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates tini \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /usr/local/bin/coronarium /usr/local/bin/coronarium
+
+# Persist the generated CA + config here. Users should mount a
+# volume so the CA is stable across restarts; without a mount, the
+# CA is regenerated on every run (still works, but client trust
+# would have to be re-installed each time).
+ENV XDG_CONFIG_HOME=/etc/coronarium-xdg
+RUN mkdir -p /etc/coronarium-xdg/coronarium
+
+EXPOSE 8910
+
+# tini so Ctrl-C / SIGTERM from `docker stop` reaches the proxy
+# quickly and children don't zombie.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/coronarium", "proxy", "start"]
+CMD ["--listen", "0.0.0.0:8910", "--min-age", "7d"]

--- a/README.md
+++ b/README.md
@@ -1,24 +1,162 @@
 # coronarium
 
-eBPF-based audit & block for CI workloads, written in Rust with [aya].
+**Stop your team from pulling a 2-hour-old crate.** A cross-ecosystem
+supply-chain guard, written in Rust, that gives every package manager
+on your machine pnpm's `minimumReleaseAge` semantics — transparently,
+without any resolver integration.
 
-`coronarium` wraps a build/test command and, via eBPF programs attached to a
-dedicated cgroup v2, observes (and optionally denies) its:
+```bash
+$ coronarium proxy install-ca              # trust the proxy's root CA
+$ coronarium proxy install-daemon          # run the proxy in the background
+$ coronarium install-gate install          # route your shell through it
+
+# Open a new shell. Business as usual.
+$ npm install react
+# → proxy silently drops versions < 7d old, npm picks the newest older version
+# → no error, no broken build, just a measurably safer dependency.
+```
+
+Four ecosystems are covered today, end-to-end:
+
+| ecosystem | silent auto-fallback via proxy | tarball hard-deny |
+|---|---|---|
+| **crates.io** | ✅ sparse-index rewrite | ✅ |
+| **npm** | ✅ packument rewrite (+ `dist-tags.latest` retargeted) | ✅ |
+| **pypi** | ✅ JSON API + PEP 691 Simple JSON | ✅ |
+| **nuget** | ✅ registration-page rewrite | ✅ |
+
+Supply-chain attacks typically live in the 24–72h gap between a
+malicious version being published and the community catching it. If
+your installs only ever see versions older than that window, you dodge
+most of them. [pnpm 10.x ships this](https://pnpm.io/next/settings#minimumreleaseage)
+for npm only — coronarium brings the same thing to every major
+ecosystem, as a single HTTPS proxy the package managers already trust.
+
+## Quick start (desktop — macOS / Linux)
+
+```bash
+# 1. Install (prebuilt binary). Replace $TRIPLE with your platform, e.g.
+#    aarch64-apple-darwin / x86_64-apple-darwin / x86_64-unknown-linux-musl.
+curl -fsSL "https://github.com/bokuweb/coronarium/releases/latest/download/coronarium-$TRIPLE.tar.gz" \
+  | sudo tar -xz -C /usr/local/bin
+
+# 2. Generate the proxy's root CA, install into the system trust store.
+coronarium proxy install-ca
+# (prompts for sudo — we use the OS `security` / `update-ca-certificates`
+#  CLI, auditable and reversible with the same commands.)
+
+# 3. Run the proxy as a background daemon (launchd on macOS, systemd
+#    --user on Linux) so it's always up.
+coronarium proxy install-daemon
+# Follow the printed `launchctl bootstrap …` / `systemctl --user enable --now`
+# line.
+
+# 4. Wire your shell so every new terminal picks up HTTPS_PROXY + the CA.
+coronarium install-gate install
+
+# 5. Open a new shell. Done.
+$ env | grep HTTPS_PROXY
+HTTPS_PROXY=http://127.0.0.1:8910
+```
+
+From here, `npm install` / `pnpm add` / `yarn add` / `cargo add` /
+`cargo build` / `pip install` / `uv add` / `poetry add` / `dotnet add
+package` / `dotnet restore` all go through the proxy and silently get
+the fallback treatment.
+
+## What "silent fallback" actually means
+
+Concretely, for `crates.io` the proxy rewrites the sparse-index
+response to drop JSONL lines whose `pubtime` is younger than
+`--min-age`:
+
+```
+$ curl -s https://index.crates.io/se/rd/serde | wc -l           # direct
+315
+$ coronarium proxy start --min-age 365d &
+$ curl -s -x http://127.0.0.1:8910 https://index.crates.io/se/rd/serde | wc -l
+306     # the 9 most recent versions are now invisible to cargo's resolver
+```
+
+cargo then picks the newest remaining in-range version — **no error**,
+just a slightly older (and harder-to-attack) dependency. Same shape
+for npm's packument (where `dist-tags.latest` is also retargeted to
+the highest remaining semver so bare `npm install <pkg>` doesn't
+resolve to a removed version), PyPI's JSON API + PEP 691 Simple JSON,
+and NuGet's registration pages.
+
+For unhandled paths (direct tarball pinning, etc.) the proxy returns
+`403` with an `x-coronarium-deny` header so the install stops loudly.
+
+## In CI (GitHub Actions)
+
+```yaml
+# .github/workflows/build.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Route every HTTPS request from later steps through the proxy.
+      # Versions published less than 7 days ago are invisible to your
+      # resolver, so `cargo build` / `npm install` / `pip install` /
+      # `dotnet restore` silently pick the newest older version.
+      - uses: bokuweb/coronarium/proxy@v0
+        with:
+          min-age: 7d
+
+      - run: cargo test      # flows through the proxy
+      - run: npm ci          # ditto
+```
+
+Prefer running the proxy yourself (Kubernetes, docker-compose,
+internal infra)? A prebuilt image lives on GHCR:
+
+```bash
+docker run --rm -p 8910:8910 ghcr.io/bokuweb/coronarium-proxy:v0 \
+    --listen 0.0.0.0:8910 --min-age 7d
+# Then point your package managers at http://<host>:8910 as HTTPS_PROXY.
+```
+
+## When to use what
+
+| situation | reach for |
+|---|---|
+| Dev machine, want every `npm install` to auto-fallback | `install-gate` + `proxy install-daemon` (Quick start above) |
+| CI job, want the build to fail loudly on too-young deps | `coronarium deps check` ([CI features](#ci-features)) |
+| CI job, want kernel-level audit of what the build does | `coronarium run` + a policy file ([CI features](#ci-features)) |
+| macOS user who wants background lockfile monitoring | `coronarium deps watch` (see [desktop watch](#desktop-watch-mode-macos)) |
+
+---
+
+## Platforms
+
+- **Linux** — proxy ✅, eBPF supervisor ✅ (network kernel-block,
+  file kernel-kill, exec audit).
+- **macOS** — proxy ✅, `deps check` + `deps watch` (supply-chain
+  guard). The supervised-child runtime is Linux/Windows only; macOS
+  is the developer-desktop home.
+- **Windows** — proxy ✅, ETW supervisor ✅ (ETW audit, kernel network
+  deny via dynamic Defender Firewall rules).
+
+---
+
+## CI features
+
+Everything below predates the proxy and is still fully supported. For
+CI the proxy story is usually overkill; `deps check` as a pre-install
+step + optional `coronarium run` supervisor is a simpler shape.
+
+`coronarium` wraps a build/test command and, via eBPF programs
+attached to a dedicated cgroup v2, observes (and optionally denies) its:
 
 - **Network** — outbound `connect(2)` on IPv4 and IPv6
-- **File** — `openat(2)` (audit; deny is on the roadmap)
+- **File** — `openat(2)` (audit + kernel-kill on deny)
 - **Process** — `execve(2)` (audit; deny is on the roadmap)
 
 It can run locally as a CLI, or be installed into a GitHub Actions workflow
 as a composite action.
-
-> **Platforms:**
-> - **Linux** — eBPF supervisor (network kernel-block, file tripwire, exec audit).
-> - **Windows** — ETW supervisor (ETW audit, kernel network deny via
->   dynamic Defender Firewall rules).
-> - **macOS** — `deps check` + `deps watch` (supply-chain guard). The
->   supervised-child runtime is Linux/Windows only; macOS is the
->   developer-desktop home.
 
 ## Architecture
 

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -82,6 +82,10 @@ pub enum Command {
         #[command(subcommand)]
         cmd: InstallGateCommand,
     },
+    /// One-command diagnostic: checks CA files, proxy liveness,
+    /// $HTTPS_PROXY, rc-file block, and daemon unit. Exits non-zero
+    /// if any critical check fails.
+    Doctor(DoctorArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -154,6 +158,22 @@ pub enum ProxyCommand {
     InstallDaemon(ProxyDaemonArgs),
     /// Remove the daemon unit written by `install-daemon`.
     UninstallDaemon(ProxyDaemonArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct DoctorArgs {
+    /// Proxy listen address to probe. Must match whatever you passed
+    /// to `proxy start` / `install-daemon`.
+    #[arg(long, default_value = "127.0.0.1:8910")]
+    pub listen: std::net::SocketAddr,
+    /// Override the CA/config directory. Defaults to the same logic
+    /// as `proxy start`.
+    #[arg(long)]
+    pub config_dir: Option<PathBuf>,
+    /// Shell rc file to inspect. Defaults to the one `install-gate`
+    /// would target for the detected shell.
+    #[arg(long)]
+    pub rc: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -420,6 +440,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             coronarium_proxy::run(cfg).await?;
             Ok(())
         }
+        Command::Doctor(args) => run_doctor(args),
         Command::Proxy {
             cmd: ProxyCommand::InstallDaemon(args),
         } => run_install_daemon(args),
@@ -657,4 +678,44 @@ fn run_uninstall_daemon(args: ProxyDaemonArgs) -> Result<()> {
         plan.deactivate_command,
     );
     Ok(())
+}
+
+fn run_doctor(args: DoctorArgs) -> Result<()> {
+    let ca_files = ca_files_for(args.config_dir)?;
+    let expected_https_proxy = format!("http://{}", args.listen);
+    let rc_path = args.rc.or_else(|| {
+        let home = std::env::var_os("HOME").map(PathBuf::from)?;
+        let shell = crate::install_gate::detect_shell_from_env();
+        Some(crate::install_gate::default_rc_path(&home, shell))
+    });
+    let daemon_unit_path = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .and_then(|home| {
+            use coronarium_proxy::daemon::{DaemonBackend, DaemonInputs, render};
+            let backend = DaemonBackend::detect()?;
+            let plan = render(
+                backend,
+                &DaemonInputs {
+                    binary_path: PathBuf::from("coronarium"),
+                    listen: args.listen,
+                    min_age: "7d".into(),
+                    home,
+                },
+            );
+            Some(plan.unit_path)
+        });
+    let inputs = crate::doctor::DoctorInputs {
+        ca_cert: ca_files.cert_pem.clone(),
+        ca_key: ca_files.key_pem.clone(),
+        proxy_addr: args.listen,
+        https_proxy_env: std::env::var("HTTPS_PROXY")
+            .ok()
+            .or_else(|| std::env::var("https_proxy").ok()),
+        expected_https_proxy,
+        rc_path,
+        daemon_unit_path,
+    };
+    let results = crate::doctor::run_checks(&inputs);
+    print!("{}", crate::doctor::render_report(&results));
+    std::process::exit(crate::doctor::exit_code(&results));
 }

--- a/crates/coronarium/src/doctor.rs
+++ b/crates/coronarium/src/doctor.rs
@@ -1,0 +1,374 @@
+//! `coronarium doctor` — one-command diagnostic for the install-gate
+//! and proxy setup. When users say "it doesn't work", this is the
+//! first thing they (or we) run.
+//!
+//! The checks below are ordered roughly from "most likely to be the
+//! root cause" to "least likely". Each check is pure-ish (takes its
+//! inputs as references, returns a `Report`) so we can unit-test the
+//! rendering without hitting the real filesystem or network.
+
+use std::net::{SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    /// One-line human-readable explanation.
+    pub detail: String,
+    /// Optional fix hint — an exact command or file the user can
+    /// touch. Shown after a ↳.
+    pub hint: Option<String>,
+}
+
+impl CheckResult {
+    pub fn ok(name: &str, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Ok,
+            detail: detail.into(),
+            hint: None,
+        }
+    }
+    pub fn warn(name: &str, detail: impl Into<String>, hint: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Warn,
+            detail: detail.into(),
+            hint: Some(hint.into()),
+        }
+    }
+    pub fn fail(name: &str, detail: impl Into<String>, hint: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+            hint: Some(hint.into()),
+        }
+    }
+}
+
+/// Plain-text, ANSI-friendly rendering. Safe for unit tests and for
+/// non-TTY stdout (pipes, CI logs). The caller is expected to print.
+pub fn render_report(results: &[CheckResult]) -> String {
+    let mut out = String::new();
+    out.push_str("coronarium doctor\n");
+    out.push_str(&"─".repeat(60));
+    out.push('\n');
+    for r in results {
+        let mark = match r.status {
+            CheckStatus::Ok => "✓",
+            CheckStatus::Warn => "!",
+            CheckStatus::Fail => "✗",
+        };
+        out.push_str(&format!("{mark} {:<28} {}\n", r.name, r.detail));
+        if let Some(h) = &r.hint {
+            out.push_str(&format!("  ↳ {h}\n"));
+        }
+    }
+    out.push_str(&"─".repeat(60));
+    out.push('\n');
+    let fails = results
+        .iter()
+        .filter(|r| r.status == CheckStatus::Fail)
+        .count();
+    let warns = results
+        .iter()
+        .filter(|r| r.status == CheckStatus::Warn)
+        .count();
+    out.push_str(&format!(
+        "{} check(s): {fails} fail, {warns} warn\n",
+        results.len()
+    ));
+    out
+}
+
+/// Overall exit code for the doctor command. Fails are the only
+/// thing we exit non-zero on — warnings are informational.
+pub fn exit_code(results: &[CheckResult]) -> i32 {
+    if results.iter().any(|r| r.status == CheckStatus::Fail) {
+        1
+    } else {
+        0
+    }
+}
+
+// ---------------- individual checks ----------------
+
+pub struct DoctorInputs {
+    pub ca_cert: PathBuf,
+    pub ca_key: PathBuf,
+    /// Expected proxy listen address. `coronarium proxy` default
+    /// is `127.0.0.1:8910`.
+    pub proxy_addr: SocketAddr,
+    /// `$HTTPS_PROXY` as the user's shell sees it right now
+    /// (read from our own process env at invocation time).
+    pub https_proxy_env: Option<String>,
+    /// Expected value for `HTTPS_PROXY` assuming the install-gate
+    /// block is active (derived from `proxy_addr`).
+    pub expected_https_proxy: String,
+    /// Path to the shell rc file (for the marker-presence check).
+    /// `None` means "skip this check" — useful on Windows or when
+    /// `$HOME` is unset.
+    pub rc_path: Option<PathBuf>,
+    /// Path to the daemon unit (launchd plist / systemd unit).
+    /// `None` means "skip this check".
+    pub daemon_unit_path: Option<PathBuf>,
+}
+
+/// Run every check with the given inputs. Pure-ish — does read the
+/// filesystem and attempt a TCP connect, but nothing that mutates.
+pub fn run_checks(inp: &DoctorInputs) -> Vec<CheckResult> {
+    let mut out = Vec::with_capacity(6);
+    out.push(check_ca_file(&inp.ca_cert));
+    out.push(check_ca_key(&inp.ca_key));
+    out.push(check_proxy_listening(inp.proxy_addr));
+    out.push(check_env_https_proxy(
+        inp.https_proxy_env.as_deref(),
+        &inp.expected_https_proxy,
+    ));
+    if let Some(rc) = &inp.rc_path {
+        out.push(check_install_gate_marker(rc));
+    }
+    if let Some(d) = &inp.daemon_unit_path {
+        out.push(check_daemon_unit(d));
+    }
+    out
+}
+
+fn check_ca_file(path: &Path) -> CheckResult {
+    if !path.exists() {
+        return CheckResult::fail(
+            "CA certificate",
+            format!("missing at {}", path.display()),
+            "run `coronarium proxy start` once to generate the CA, then `coronarium proxy install-ca` to trust it",
+        );
+    }
+    match std::fs::metadata(path) {
+        Ok(m) if m.len() > 0 => CheckResult::ok(
+            "CA certificate",
+            format!("{} ({} bytes)", path.display(), m.len()),
+        ),
+        _ => CheckResult::fail(
+            "CA certificate",
+            format!("{} exists but is empty", path.display()),
+            "delete it and re-run `coronarium proxy start`",
+        ),
+    }
+}
+
+fn check_ca_key(path: &Path) -> CheckResult {
+    if !path.exists() {
+        return CheckResult::fail(
+            "CA private key",
+            format!("missing at {}", path.display()),
+            "re-run `coronarium proxy start` to regenerate the keypair",
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(m) = std::fs::metadata(path) {
+            let mode = m.permissions().mode() & 0o777;
+            if mode & 0o077 != 0 {
+                return CheckResult::warn(
+                    "CA private key",
+                    format!(
+                        "{} mode is 0{mode:o} (group/world readable)",
+                        path.display()
+                    ),
+                    format!("chmod 600 {}", path.display()),
+                );
+            }
+        }
+    }
+    CheckResult::ok("CA private key", path.display().to_string())
+}
+
+fn check_proxy_listening(addr: SocketAddr) -> CheckResult {
+    match TcpStream::connect_timeout(&addr, Duration::from_millis(300)) {
+        Ok(_) => CheckResult::ok("Proxy reachable", format!("accepted TCP on {addr}")),
+        Err(e) => CheckResult::fail(
+            "Proxy reachable",
+            format!("no listener on {addr}: {e}"),
+            "start it: `coronarium proxy start` (or, for background: `coronarium proxy install-daemon`)",
+        ),
+    }
+}
+
+fn check_env_https_proxy(actual: Option<&str>, expected: &str) -> CheckResult {
+    match actual {
+        None => CheckResult::warn(
+            "$HTTPS_PROXY",
+            "unset in this shell",
+            "run `coronarium install-gate install` and open a new shell",
+        ),
+        Some(s) if s == expected => CheckResult::ok("$HTTPS_PROXY", s.to_string()),
+        Some(s) => CheckResult::warn(
+            "$HTTPS_PROXY",
+            format!("set to {s:?} (expected {expected:?})"),
+            "double-check `--listen` matches on both proxy + install-gate",
+        ),
+    }
+}
+
+fn check_install_gate_marker(rc: &Path) -> CheckResult {
+    if !rc.exists() {
+        return CheckResult::warn(
+            "install-gate rc",
+            format!("{} does not exist yet", rc.display()),
+            "run `coronarium install-gate install`",
+        );
+    }
+    let Ok(text) = std::fs::read_to_string(rc) else {
+        return CheckResult::warn(
+            "install-gate rc",
+            format!("couldn't read {}", rc.display()),
+            "check permissions",
+        );
+    };
+    if text.contains("# >>> coronarium install-gate >>>") {
+        CheckResult::ok("install-gate rc", rc.display().to_string())
+    } else {
+        CheckResult::warn(
+            "install-gate rc",
+            format!("{} has no coronarium block", rc.display()),
+            "run `coronarium install-gate install`",
+        )
+    }
+}
+
+fn check_daemon_unit(path: &Path) -> CheckResult {
+    if path.exists() {
+        CheckResult::ok("Daemon unit", path.display().to_string())
+    } else {
+        CheckResult::warn(
+            "Daemon unit",
+            format!("{} missing", path.display()),
+            "run `coronarium proxy install-daemon` so the proxy auto-starts",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmpdir() -> PathBuf {
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("coronarium-doctor-{id}"));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn ca_file_missing_is_fail() {
+        let r = check_ca_file(&PathBuf::from("/no/such/thing"));
+        assert_eq!(r.status, CheckStatus::Fail);
+        assert!(r.hint.unwrap().contains("proxy start"));
+    }
+
+    #[test]
+    fn ca_file_present_is_ok() {
+        let d = tmpdir();
+        let p = d.join("ca.pem");
+        fs::write(
+            &p,
+            b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        let r = check_ca_file(&p);
+        assert_eq!(r.status, CheckStatus::Ok);
+        fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn env_https_proxy_matches_is_ok() {
+        let r = check_env_https_proxy(Some("http://127.0.0.1:8910"), "http://127.0.0.1:8910");
+        assert_eq!(r.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn env_https_proxy_unset_is_warn_with_install_gate_hint() {
+        let r = check_env_https_proxy(None, "http://127.0.0.1:8910");
+        assert_eq!(r.status, CheckStatus::Warn);
+        assert!(r.hint.unwrap().contains("install-gate install"));
+    }
+
+    #[test]
+    fn env_https_proxy_mismatch_is_warn() {
+        let r = check_env_https_proxy(Some("http://127.0.0.1:8910"), "http://127.0.0.1:9999");
+        assert_eq!(r.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn install_gate_marker_detected() {
+        let d = tmpdir();
+        let rc = d.join(".zshrc");
+        fs::write(
+            &rc,
+            "# existing\n# >>> coronarium install-gate >>>\neval ...\n# <<< coronarium install-gate <<<\n",
+        )
+        .unwrap();
+        let r = check_install_gate_marker(&rc);
+        assert_eq!(r.status, CheckStatus::Ok);
+        fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn install_gate_marker_absent_is_warn() {
+        let d = tmpdir();
+        let rc = d.join(".zshrc");
+        fs::write(&rc, "alias foo=bar\n").unwrap();
+        let r = check_install_gate_marker(&rc);
+        assert_eq!(r.status, CheckStatus::Warn);
+        fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn rendering_includes_footer_with_counts() {
+        let results = vec![
+            CheckResult::ok("a", "fine"),
+            CheckResult::warn("b", "meh", "try harder"),
+            CheckResult::fail("c", "nope", "do the thing"),
+        ];
+        let s = render_report(&results);
+        assert!(s.contains("✓ a"));
+        assert!(s.contains("! b"));
+        assert!(s.contains("✗ c"));
+        assert!(s.contains("↳ try harder"));
+        assert!(s.contains("↳ do the thing"));
+        assert!(s.contains("3 check(s): 1 fail, 1 warn"));
+    }
+
+    #[test]
+    fn exit_code_is_1_when_any_fails() {
+        assert_eq!(exit_code(&[CheckResult::ok("x", "")]), 0);
+        assert_eq!(
+            exit_code(&[CheckResult::warn("x", "", "y")]),
+            0,
+            "warnings alone don't fail exit"
+        );
+        assert_eq!(exit_code(&[CheckResult::fail("x", "", "y")]), 1);
+    }
+
+    #[test]
+    fn proxy_unreachable_port_is_fail() {
+        // Pick a wildly unlikely port.
+        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let r = check_proxy_listening(addr);
+        assert_eq!(r.status, CheckStatus::Fail);
+    }
+}

--- a/crates/coronarium/src/main.rs
+++ b/crates/coronarium/src/main.rs
@@ -2,6 +2,7 @@
 
 mod cgroup;
 mod cli;
+mod doctor;
 mod enforcer;
 mod events;
 mod install_gate;


### PR DESCRIPTION
## Summary
Three independent usability / adoption items bundled as v0.21:

### 1. README hero rewrite
The README now opens with the proxy + install-gate story (the actual user value as of v0.20) instead of eBPF-for-CI. Four-ecosystem matrix, concrete Quick start, silent-fallback explanation. Original eBPF/ETW/supply-chain-lockfile sections preserved below the fold.

### 2. \`coronarium doctor\`
One-command diagnostic: CA cert/key, proxy TCP liveness, \`\$HTTPS_PROXY\`, shell rc marker, daemon unit. Warnings informational; real failures exit 1. Pure \`run_checks\` + 10 tests.

Live-verified:
\`\`\`
$ coronarium doctor               # no proxy running
✓ CA certificate  ...
✗ Proxy reachable no listener on 127.0.0.1:8910
  ↳ start it: \`coronarium proxy start\`
…
exit=1

$ coronarium proxy start &
$ HTTPS_PROXY=http://127.0.0.1:8910 coronarium doctor
✓ Proxy reachable accepted TCP on 127.0.0.1:8910
✓ \$HTTPS_PROXY   http://127.0.0.1:8910
…
exit=0
\`\`\`

### 3. GitHub Action (composite) + Docker image
- \`uses: bokuweb/coronarium/proxy@v0\` downloads the release binary, starts the proxy in the background, appends HTTPS_PROXY + all CA env vars to \`\$GITHUB_ENV\` for subsequent steps.
- Multi-stage \`Dockerfile\` for users running their own infra; pushed to \`ghcr.io/bokuweb/coronarium-proxy\` on every \`v*\` tag (v0/v0.N/v0.N.M/latest, prereleases skip floating tags).
- Action tested locally for the env-setting shape; full e2e needs this PR's v0 to exist — will self-test on the next release tag.

## Test plan
- [x] \`cargo test --workspace\` — all green (64 core + 76 proxy + 20 coronarium/install_gate/doctor)
- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Live smoke: \`coronarium doctor\` before + after \`proxy start\`
- [ ] CI green across all existing jobs
- [ ] docker workflow tests on v0.21.0 tag (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)