### PR TITLE
feat(report): add `host` column with PTR-resolved hostname for connect events

### DIFF
--- a/crates/coronarium-core/src/events.rs
+++ b/crates/coronarium-core/src/events.rs
@@ -21,6 +21,12 @@ pub enum Event {
         dport: u16,
         protocol: u16,
         denied: bool,
+        /// Reverse-DNS of `daddr` (PTR record) when known. Populated
+        /// best-effort by the userspace supervisor after all events
+        /// are collected — the kernel decoder doesn't know it.
+        /// `None` means either "lookup not attempted" or "no PTR".
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hostname: Option<String>,
     },
     Open {
         pid: u32,
@@ -73,6 +79,7 @@ mod tests {
             dport: 0,
             protocol: 6,
             denied: false,
+            hostname: None,
         };
         let open = Event::Open {
             pid: 1,

--- a/crates/coronarium-core/src/html.rs
+++ b/crates/coronarium-core/src/html.rs
@@ -96,7 +96,7 @@ pub fn render(policy: &Policy, stats: &Stats, meta: ReportMeta<'_>) -> String {
       <input id="q" type="search" placeholder="filter by path, host, comm…" autocomplete="off">
     </div>
     <table class="events-table">
-      <thead><tr><th>verdict</th><th>kind</th><th>pid</th><th>comm</th><th>detail</th></tr></thead>
+      <thead><tr><th>verdict</th><th>kind</th><th>pid</th><th>comm</th><th>host</th><th>detail</th></tr></thead>
       <tbody>
 "#,
     );
@@ -172,7 +172,9 @@ fn render_event_row(out: &mut String, ev: &Event) {
     } else {
         r#"<span class="chip chip-allow">ALLOW</span>"#
     };
-    let (kind, kind_class, pid, comm, detail) = match ev {
+    // `host` is the resolved hostname for Connect events (PTR lookup
+    // performed by the userspace supervisor) — empty for exec/open.
+    let (kind, kind_class, pid, comm, host, detail) = match ev {
         Event::Exec {
             pid,
             comm,
@@ -184,6 +186,7 @@ fn render_event_row(out: &mut String, ev: &Event) {
             "chip-exec",
             *pid,
             comm.clone(),
+            String::new(),
             format!(
                 r#"<code>{}</code> <span class="muted">({})</span>"#,
                 html_escape(filename),
@@ -201,6 +204,7 @@ fn render_event_row(out: &mut String, ev: &Event) {
             "chip-open",
             *pid,
             comm.clone(),
+            String::new(),
             format!(
                 r#"<code>{}</code> <span class="muted">flags=0x{:x}</span>"#,
                 html_escape(filename),
@@ -212,16 +216,26 @@ fn render_event_row(out: &mut String, ev: &Event) {
             comm,
             daddr,
             dport,
+            hostname,
             ..
-        } => (
-            "connect",
-            "chip-connect",
-            *pid,
-            comm.clone(),
-            format!(r#"<code>{}:{}</code>"#, html_escape(daddr), dport),
-        ),
+        } => {
+            let host_cell = match hostname.as_deref().filter(|s| !s.is_empty()) {
+                Some(h) => format!(r#"<code>{}</code>"#, html_escape(h)),
+                None => r#"<span class="muted">—</span>"#.to_string(),
+            };
+            (
+                "connect",
+                "chip-connect",
+                *pid,
+                comm.clone(),
+                host_cell,
+                format!(r#"<code>{}:{}</code>"#, html_escape(daddr), dport),
+            )
+        }
     };
-    let searchable = format!("{kind} {pid} {comm} {detail}").to_lowercase();
+    // `searchable` now includes host so the filter box matches by
+    // hostname too, not just IP:port.
+    let searchable = format!("{kind} {pid} {comm} {host} {detail}").to_lowercase();
     let _ = write!(
         out,
         r#"        <tr class="{row_class}" data-kind="{kind}" data-denied="{denied}" data-search="{search}">
@@ -229,6 +243,7 @@ fn render_event_row(out: &mut String, ev: &Event) {
           <td><span class="chip {kind_class}">{kind}</span></td>
           <td class="num">{pid}</td>
           <td><code>{comm}</code></td>
+          <td>{host}</td>
           <td>{detail}</td>
         </tr>
 "#,
@@ -240,6 +255,7 @@ fn render_event_row(out: &mut String, ev: &Event) {
         kind_class = kind_class,
         pid = pid,
         comm = html_escape(&comm),
+        host = host,
         detail = detail,
     );
 }
@@ -497,3 +513,87 @@ const JS: &str = r#"
   q.addEventListener('input', apply);
 })();
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{Mode, Policy};
+    use crate::stats::Stats;
+
+    fn stats_with_one_connect(daddr: &str, hostname: Option<&str>) -> Stats {
+        let mut s = Stats::default();
+        s.ingest(Event::Connect {
+            pid: 42,
+            uid: 0,
+            comm: "curl".into(),
+            daddr: daddr.into(),
+            dport: 443,
+            protocol: 6,
+            denied: false,
+            hostname: hostname.map(|s| s.to_string()),
+        });
+        s
+    }
+
+    fn meta<'a>() -> ReportMeta<'a> {
+        ReportMeta {
+            title: "test",
+            mode: Mode::Audit,
+            command: "curl https://example.com",
+        }
+    }
+
+    #[test]
+    fn html_includes_host_column_header() {
+        let p = Policy::permissive_audit();
+        let s = stats_with_one_connect("1.2.3.4", None);
+        let out = render(&p, &s, meta());
+        assert!(out.contains("<th>host</th>"), "host column header missing");
+    }
+
+    #[test]
+    fn connect_row_shows_hostname_when_present() {
+        let p = Policy::permissive_audit();
+        let s = stats_with_one_connect("1.2.3.4", Some("example.com"));
+        let out = render(&p, &s, meta());
+        assert!(out.contains("example.com"), "hostname should render");
+        // The IP still appears in the detail column.
+        assert!(out.contains("1.2.3.4:443"));
+    }
+
+    #[test]
+    fn connect_row_shows_dash_when_hostname_missing() {
+        let p = Policy::permissive_audit();
+        let s = stats_with_one_connect("1.2.3.4", None);
+        let out = render(&p, &s, meta());
+        // Em-dash placeholder in the host cell.
+        assert!(out.contains("—"), "dash placeholder expected when no PTR");
+    }
+
+    #[test]
+    fn exec_and_open_rows_leave_host_empty_placeholder() {
+        let p = Policy::permissive_audit();
+        let mut s = Stats::default();
+        s.ingest(Event::Exec {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: "/bin/sh".into(),
+            argv0: "sh".into(),
+            denied: false,
+        });
+        s.ingest(Event::Open {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: "/etc/passwd".into(),
+            flags: 0,
+            denied: false,
+        });
+        let out = render(&p, &s, meta());
+        // Both rows should render; the host cell is simply empty for
+        // non-connect events.
+        assert!(out.contains("/bin/sh"));
+        assert!(out.contains("/etc/passwd"));
+    }
+}

--- a/crates/coronarium-core/src/stats.rs
+++ b/crates/coronarium-core/src/stats.rs
@@ -109,6 +109,7 @@ mod tests {
                 dport: 80,
                 protocol: 6,
                 denied: false,
+                hostname: None,
             });
         }
         assert_eq!(s.samples.len(), 3 * PER_KIND_CAP);

--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -352,6 +352,7 @@ fn handle_network_event(
         dport,
         protocol: 6,
         denied,
+        hostname: None,
     };
     stats.lock().unwrap().ingest(ev);
 }

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -566,7 +566,13 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
 
     let supervised = loader::Supervisor::start(policy.clone(), mode).await?;
     let exit = supervised.run_child(&args.command).await?;
-    let stats = supervised.shutdown().await?;
+    let mut stats = supervised.shutdown().await?;
+
+    // Best-effort PTR enrichment so the HTML report shows hostnames
+    // next to raw IPs. Failures are silent — the report is still
+    // useful without resolved names, and we don't want to block the
+    // CI step on flaky DNS.
+    crate::resolve_hostnames::resolve(&mut stats).await;
 
     let command_str = args.command.join(" ");
     let report_args = ReportArgs {

--- a/crates/coronarium/src/events.rs
+++ b/crates/coronarium/src/events.rs
@@ -47,6 +47,7 @@ fn decode_connect4(bytes: &[u8]) -> Option<Event> {
         dport: u16::from_be(ev.dport),
         protocol: ev.protocol,
         denied: ev.header.verdict == VERDICT_DENY,
+        hostname: None,
     })
 }
 
@@ -60,6 +61,7 @@ fn decode_connect6(bytes: &[u8]) -> Option<Event> {
         dport: u16::from_be(ev.dport),
         protocol: ev.protocol,
         denied: ev.header.verdict == VERDICT_DENY,
+        hostname: None,
     })
 }
 

--- a/crates/coronarium/src/main.rs
+++ b/crates/coronarium/src/main.rs
@@ -8,6 +8,7 @@ mod install_gate;
 mod loader;
 mod policy;
 mod resolve;
+mod resolve_hostnames;
 
 use anyhow::Result;
 use clap::Parser;

--- a/crates/coronarium/src/resolve_hostnames.rs
+++ b/crates/coronarium/src/resolve_hostnames.rs
@@ -1,0 +1,112 @@
+//! Best-effort PTR lookup for `Event::Connect` samples in the report.
+//!
+//! The kernel/ETW decoders only know the remote IP — they never see
+//! the hostname the client resolved. This module batches a reverse
+//! DNS lookup across every unique IP in `stats.samples` (capped so
+//! we don't hammer the resolver on pathological inputs) and stamps
+//! the result back into each matching `Event::Connect.hostname`.
+//!
+//! Failures are swallowed: no PTR record, private-range IP, or a
+//! timeout leaves `hostname = None` and the HTML report falls back
+//! to the plain IP:port cell. We log at debug level only.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use coronarium_core::events::Event;
+use coronarium_core::stats::Stats;
+use hickory_resolver::TokioAsyncResolver;
+
+/// Hard cap on the number of PTR lookups we issue. Typical runs have
+/// under 50 unique destinations; the cap exists so a pathological
+/// policy with thousands of distinct connects doesn't stall the
+/// report step for minutes.
+const MAX_LOOKUPS: usize = 256;
+
+/// Per-lookup timeout. hickory's default is much longer; PTR on a
+/// public resolver should come back in well under a second, and if
+/// it doesn't we'd rather skip than block the CI step.
+const LOOKUP_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Mutate `stats.samples`, populating `Event::Connect.hostname` for
+/// every connect whose `daddr` parses as an IP and has a PTR record.
+pub async fn resolve(stats: &mut Stats) {
+    // 1. Collect unique IPs to look up.
+    let ips: Vec<IpAddr> = {
+        let mut seen = std::collections::HashSet::new();
+        stats
+            .samples
+            .iter()
+            .filter_map(|ev| match ev {
+                Event::Connect { daddr, .. } => daddr.parse::<IpAddr>().ok(),
+                _ => None,
+            })
+            .filter(|ip| seen.insert(*ip))
+            .take(MAX_LOOKUPS)
+            .collect()
+    };
+    if ips.is_empty() {
+        return;
+    }
+
+    // 2. Build a resolver from the host's /etc/resolv.conf (Linux /
+    //    macOS) or system config (Windows). If construction fails we
+    //    just skip the whole step — the report still renders, just
+    //    without hostnames.
+    let resolver = match TokioAsyncResolver::tokio_from_system_conf() {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("resolve_hostnames: skipping, resolver init failed: {e}");
+            return;
+        }
+    };
+
+    // 3. Issue every PTR lookup in parallel, with a per-call timeout.
+    //    For hundreds of IPs, parallelism drops the total time from
+    //    tens-of-seconds to well under a second.
+    let lookups = ips.into_iter().map(|ip| {
+        let resolver = resolver.clone();
+        async move {
+            let res = tokio::time::timeout(LOOKUP_TIMEOUT, resolver.reverse_lookup(ip)).await;
+            let name = match res {
+                Ok(Ok(rev)) => rev
+                    .iter()
+                    .next()
+                    .map(|n| n.to_string().trim_end_matches('.').to_string()),
+                Ok(Err(e)) => {
+                    log::debug!("PTR for {ip} failed: {e}");
+                    None
+                }
+                Err(_) => {
+                    log::debug!("PTR for {ip} timed out");
+                    None
+                }
+            };
+            (ip, name)
+        }
+    });
+    let results: Vec<(IpAddr, Option<String>)> = futures::future::join_all(lookups)
+        .await
+        .into_iter()
+        .collect();
+
+    // 4. Build the final IP -> hostname map, discarding empty answers.
+    let map: HashMap<IpAddr, String> = results
+        .into_iter()
+        .filter_map(|(ip, n)| n.map(|n| (ip, n)))
+        .collect();
+
+    // 5. Stamp the hostnames back into every matching sample.
+    for ev in stats.samples.iter_mut() {
+        if let Event::Connect {
+            daddr, hostname, ..
+        } = ev
+            && hostname.is_none()
+            && let Ok(ip) = daddr.parse::<IpAddr>()
+            && let Some(name) = map.get(&ip)
+        {
+            *hostname = Some(name.clone());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The HTML report's connect rows previously showed only the raw IP:port pair, so logs like \`2606:4700:10::6814:179a:443\` required eyeball-grepping. This PR resolves the PTR record at report time and surfaces it in a new \`host\` column.

Example before/after on the same run:

| verdict | kind | pid | comm | *host (NEW)* | detail |
|---|---|---|---|---|---|
| ALLOW | connect | 2254 | curl | \`one.one.one.one\` | \`1.1.1.1:443\` |
| ALLOW | connect | 2254 | curl | \`dns.google\` | \`8.8.8.8:443\` |
| ALLOW | connect | 2254 | curl | — | \`127.0.0.53:53\` |

## Implementation
- New \`Event::Connect.hostname: Option<String>\` (serde-skipped when None).
- \`resolve_hostnames\` module in the bin crate: between \`shutdown()\` and \`report::write\`, bulk-parallel PTR lookup via hickory with a 750ms per-call timeout and a 256-IP cap. All errors silent.
- HTML \`render\_event\_row\` gains a column; detail still prints \`IP:port\` verbatim.
- Searchable \`data-search\` attribute includes the host so the filter box matches by domain too.

## Test plan
- [x] \`cargo test --workspace\` — core: 64 → 68 (4 new html tests covering the column header, PTR-present path, dash placeholder, non-connect rows still render)
- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean, \`cargo fmt --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)