### PR TITLE
ci(report): audit-mode artifact shows DENY rows across all 3 kinds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,25 +301,51 @@ jobs:
       - name: policy dry-run
         run: |
           ./bin/coronarium check-policy -p examples/coronarium.yml
-      - name: audit-mode e2e (captures exec/open/connect)
+      - name: audit-mode e2e (captures exec/open/connect with mixed ALLOW+DENY)
         env:
           CORONARIUM_BPF_OBJ: ${{ github.workspace }}/bpf/coronarium
           RUST_LOG: info
         run: |
+          # Policy is *audit* mode (nothing is actually blocked) but
+          # includes explicit deny entries for each event class so the
+          # uploaded HTML artifact shows the realistic "ALLOW + DENY"
+          # mix a user would see in block mode. This gives reviewers
+          # something useful to look at in the PR report artifact
+          # instead of the previous all-ALLOW noise.
           cat > /tmp/audit.yml <<'EOF'
           mode: audit
           network:
             default: allow
+            deny:
+              - target: example.com      # resolved to 1+ IPs at startup
+                ports: [443]
+              - target: 1.1.1.1
+                ports: [443]
           file:
             default: allow
+            deny:
+              - /etc/os-release          # the child below reads this
+          process:
+            deny_exec:
+              - /usr/bin/whoami          # the child below runs this
           EOF
-          # Run with stderr captured so we can assert the BPF programs
-          # actually loaded (no passthrough fallback).
+          # The child exercises every deny path so the report has
+          # DENY-annotated exec, open, and connect rows:
+          #   - whoami        → exec deny
+          #   - cat os-release→ open deny
+          #   - curl example  → connect deny
+          #   - plain echo    → plain ALLOW exec, for contrast
           sudo -E ./bin/coronarium run \
             --policy /tmp/audit.yml \
             --log /tmp/coronarium.log.json \
             --html /tmp/coronarium-report.html \
-            -- /bin/sh -c 'echo hello from coronarium; curl -s -o /dev/null -m 5 https://example.com || true' \
+            -- /bin/sh -c '
+              echo hello from coronarium;
+              /usr/bin/whoami >/dev/null 2>&1 || true;
+              cat /etc/os-release >/dev/null 2>&1 || true;
+              curl -s -o /dev/null -m 5 https://example.com || true;
+              curl -s -o /dev/null -m 5 https://1.1.1.1 || true;
+            ' \
             2> /tmp/coronarium.stderr
           echo "--- stderr ---"
           cat /tmp/coronarium.stderr
@@ -333,18 +359,27 @@ jobs:
           import json, sys
           log = json.load(open("/tmp/coronarium.log.json"))
           kinds = {}
+          denied_kinds = {}
           for s in log.get("samples", []):
               kinds[s["kind"]] = kinds.get(s["kind"], 0) + 1
+              if s.get("denied"):
+                  denied_kinds[s["kind"]] = denied_kinds.get(s["kind"], 0) + 1
           print(f"observed={log['observed']} denied={log['denied']} lost={log['lost']}")
           print(f"sample kinds: {kinds}")
-          missing = []
-          for k in ("exec", "open", "connect"):
-              if kinds.get(k, 0) == 0:
-                  missing.append(k)
+          print(f"denied-sample kinds: {denied_kinds}")
+          # Every kind must be represented in the samples.
+          missing = [k for k in ("exec", "open", "connect") if kinds.get(k, 0) == 0]
+          if "exec" in missing:
+              print(f"::error::no exec samples captured")
+              sys.exit(1)
           if missing:
               print(f"::warning::no samples for: {missing}")
-              if "exec" in missing:
-                  sys.exit(1)
+          # Report-artifact requirement: at least one DENY in each
+          # of exec/open/connect so the uploaded HTML visibly shows
+          # the mixed-verdict table.
+          for kind in ("exec", "open", "connect"):
+              if denied_kinds.get(kind, 0) == 0:
+                  print(f"::warning::no DENY-tagged {kind} samples — report will look plain")
           PY
       - name: block-mode e2e (kernel actually denies egress)
         env:


### PR DESCRIPTION
## Q: ドメインは allow-list で connect 時点で弾けるんだっけ？
A: Yes. 仕組みは2層:

1. **起動時 (userspace)** — hickory-resolver で \`target: example.com\` を A+AAAA 両方引いて、得られた全IPをカーネル側 BPF HashMap (\`NET4\`/\`NET6\`) に書き込む。
2. **カーネル時 (eBPF)** — cgroup/connect4 のプログラムが syscall 発火前に HashMap を lookup、\`POLICY_DENY\` なら戻り値 0 を返す → カーネルが \`connect(2)\` を EPERM で reject。ユーザー空間は「socket すら作られていない、SYN 1発も飛んでない」状態で失敗する。

## このPRの内容
CI artifact として upload される HTML レポートが "ALLOW ばかりで見栄えしない" 問題を解消。audit-mode の policy に各イベント種類の deny 例を1つずつ入れて、artifact を開いた時に ALLOW+DENY 混在の現実的な絵を見せる:

| kind | deny example | child が hit する方法 |
|---|---|---|
| connect | \`example.com:443\`, \`1.1.1.1:443\` | \`curl https://example.com\` + \`curl https://1.1.1.1\` |
| open | \`/etc/os-release\` | \`cat /etc/os-release\` |
| exec | \`/usr/bin/whoami\` | \`/usr/bin/whoami\` |

audit mode のままなので実際の挙動は変わらず (コマンドは全部成功する)、ログ上の \`denied: true\` タグだけが付く。Python のアサートも「各 kind に DENY サンプルあるか」を追加チェック (警告のみ — 将来 DNS ラウンドロビンで example.com のIPが変わっても CI は落とさない)。

## Test plan
- [x] ローカルで \`coronarium check-policy\` に通して新 policy が正しくパースできることを確認
- [ ] CI で audit-mode e2e が green で通る
- [ ] upload された \`coronarium-report-*.html\` を DL、DENY 行が exec/open/connect それぞれに出ていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)