### PR TITLE
ci(consumer-smoke): richer audit policy + PTR-friendly IPs

### DIFF
--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -27,24 +27,65 @@ jobs:
 
       - name: Run supervised command
         run: |
+          # Policy is intentionally rich (one deny per kind) so the
+          # uploaded report + PR comment artifact show the realistic
+          # ALLOW+DENY mix users will see in block mode. Audit mode
+          # means nothing is actually blocked.
+          #
+          # Targets are picked to look good in the `host` column:
+          # 1.1.1.1 and 8.8.8.8 have PTR records (`one.one.one.one`
+          # and `dns.google`), whereas CDN anycast IPs like
+          # 104.20.x.x / 172.66.x.x don't publish PTR at all — so
+          # using example.com (which currently resolves to Cloudflare)
+          # would just produce a sea of "—" in the host column.
           cat > /tmp/policy.yml <<'EOF'
           mode: audit
           network:
             default: allow
+            deny:
+              - target: 1.1.1.1
+                ports: [443]
+              - target: 8.8.8.8
+                ports: [443]
           file:
             default: allow
             deny:
               - /etc/shadow
+          process:
+            deny_exec:
+              - /usr/bin/whoami
           EOF
           sudo -E "$CORONARIUM_BIN" run \
             --policy /tmp/policy.yml \
             --log coronarium.log.json \
             --html coronarium-report.html \
             --summary "$GITHUB_STEP_SUMMARY" \
-            -- /bin/sh -c 'cat /etc/shadow >/dev/null 2>&1 || true; cat /etc/hostname >/dev/null; curl -s -o /dev/null https://example.com || true'
+            -- /bin/sh -c '
+              echo hello from coronarium;
+              /usr/bin/whoami >/dev/null 2>&1 || true;
+              cat /etc/shadow >/dev/null 2>&1 || true;
+              cat /etc/hostname >/dev/null;
+              curl -s -o /dev/null -m 5 https://1.1.1.1 || true;
+              curl -s -o /dev/null -m 5 https://8.8.8.8 || true;
+            '
           cat coronarium.log.json | head -60
-          observed=$(python3 -c 'import json;print(json.load(open("coronarium.log.json"))["observed"])')
-          test "$observed" -gt 0
+          # Assert each kind has at least one DENY-tagged sample so
+          # the PR comment/artifact genuinely demonstrates the full
+          # verdict range — regressions here would quietly produce a
+          # boring all-ALLOW report for consumers looking at the comment.
+          python3 - <<'PY'
+          import json, sys
+          d = json.load(open("coronarium.log.json"))
+          denied = {}
+          for s in d.get("samples", []):
+              if s.get("denied"):
+                  denied[s["kind"]] = denied.get(s["kind"], 0) + 1
+          print(f"observed={d['observed']} denied={d['denied']} denied-by-kind={denied}")
+          assert d["observed"] > 0
+          for k in ("exec", "open", "connect"):
+              if denied.get(k, 0) == 0:
+                  print(f"::warning::no denied {k} samples — report artifact will be weaker")
+          PY
           test -f coronarium-report.html
 
       # Upload both so the comment's one-liner can pull the HTML.


### PR DESCRIPTION
## 原因
見てもらっているレポートは \`ci.yml\` の audit-mode e2e artifact ではなく、**\`consumer-smoke.yml\`** が PR コメントに貼る方でした。こちらは policy がまだ \`file.deny: [/etc/shadow]\` のみ + \`curl https://example.com\` だったので:

- DENY が 1件 (/etc/shadow) のみ
- host 列がほぼ全部 "—"

## 2 つの原因 → 2 つの修正

### 1. DENY が 1 件しかない
policy が file だけ → exec/connect deny ゼロ。\`ci.yml\` PR #21 で入れた方と同じ形の policy に合わせる:
- \`process.deny_exec: /usr/bin/whoami\`
- \`file.deny: /etc/shadow\`
- \`network.deny: [1.1.1.1:443, 8.8.8.8:443]\`

子コマンドも全部 trigger するように。

### 2. host 列が "—" ばかり
ターゲットが \`example.com\` → Cloudflare anycast (104.20.x.x / 172.66.x.x / 2606:4700::) に解決される → **CDN anycast IPs は PTR 未公開** (実測):

\`\`\`
$ dig -x 104.20.23.154 +short   → (no PTR)
$ dig -x 1.1.1.1 +short          → one.one.one.one.
$ dig -x 8.8.8.8 +short          → dns.google.
\`\`\`

→ \`1.1.1.1\` / \`8.8.8.8\` 直 URL に変更。IP リテラルなので:
- DNS detour なしで確実に deny map に hit (ラウンドロビンで別IPに行く心配ゼロ)
- PTR が確実に出て、host 列が見栄え良くなる

## 期待される次の artifact
| verdict | kind | comm | host | detail |
|---|---|---|---|---|
| DENY | exec | sh | | /usr/bin/whoami |
| DENY | open | cat | | /etc/shadow |
| DENY | connect | curl | \`one.one.one.one\` | 1.1.1.1:443 |
| DENY | connect | curl | \`dns.google\` | 8.8.8.8:443 |
| ALLOW | connect | curl | \`localhost\` | 127.0.0.53:53 |
| ALLOW | open | cat | | /etc/hostname |

## Test plan
- [x] policy parses via \`check-policy\`
- [ ] CI green (consumer-smoke.yml \`use-as-action\` step runs against this PR)
- [ ] Verify merged PR comment shows 3+ denies and real hostnames for 1.1.1.1 / 8.8.8.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)