### PR TITLE
feat(proxy): npm `--require-provenance` strict mode

### DIFF
--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -22,7 +22,7 @@ use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
 use crate::rewrite::rewrite_crates_index_jsonl;
-use crate::rewrite_npm::rewrite_npm_packument;
+use crate::rewrite_npm::{NpmRewriteOptions, rewrite_npm_packument_with};
 use crate::rewrite_nuget::rewrite_nuget_registration;
 use crate::rewrite_pypi::{rewrite_pypi_json_api, rewrite_pypi_simple_json};
 
@@ -30,6 +30,12 @@ pub struct ProxyConfig {
     pub listen: SocketAddr,
     pub min_age: Duration,
     pub fail_on_missing: bool,
+    /// Strict mode: when `true`, npm packument rewriting drops every
+    /// version without a Sigstore provenance claim (see
+    /// [`crate::rewrite_npm::NpmRewriteOptions`]). This is the
+    /// strongest single knob against "stolen publish token" attacks
+    /// that `minimumReleaseAge` alone can't catch.
+    pub require_provenance: bool,
     pub ca_files: CaFiles,
     pub user_agent: String,
     /// Override to inject a fake oracle in tests.
@@ -42,6 +48,7 @@ impl ProxyConfig {
             listen: "127.0.0.1:0".parse().unwrap(),
             min_age: Duration::from_secs(7 * 24 * 3600),
             fail_on_missing: false,
+            require_provenance: false,
             ca_files: CaFiles::at_default_location()?,
             user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
             oracle: None,
@@ -83,6 +90,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         decider,
         last_host: None,
         last_path: None,
+        require_provenance: cfg.require_provenance,
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -124,6 +132,9 @@ struct CoronariumHandler {
     /// `registry.npmjs.org` response is a packument (bare `/<pkg>`) —
     /// per-version endpoints and tarballs must be left untouched.
     last_path: Option<String>,
+    /// Forwarded from [`ProxyConfig::require_provenance`]. Consulted
+    /// by the npm rewrite path.
+    require_provenance: bool,
 }
 
 impl HttpHandler for CoronariumHandler {
@@ -231,11 +242,19 @@ impl HttpHandler for CoronariumHandler {
                 out
             }
             RewriteTarget::NpmPackument => {
-                let (out, stats) = rewrite_npm_packument(&collected, self.decider.min_age, now);
+                let (out, stats) = rewrite_npm_packument_with(
+                    &collected,
+                    self.decider.min_age,
+                    now,
+                    NpmRewriteOptions {
+                        require_provenance: self.require_provenance,
+                    },
+                );
                 if stats.dropped > 0 {
                     log::info!(
-                        "npm-rewrite: dropped {} version(s), kept {}, retargeted {} tag(s)",
+                        "npm-rewrite: dropped {} version(s) ({} for missing provenance), kept {}, retargeted {} tag(s)",
                         stats.dropped,
+                        stats.dropped_no_provenance,
                         stats.kept,
                         stats.retargeted_tags
                     );

--- a/crates/coronarium-proxy/src/rewrite_npm.rs
+++ b/crates/coronarium-proxy/src/rewrite_npm.rs
@@ -46,24 +46,54 @@ pub struct NpmRewriteStats {
     pub kept: usize,
     pub dropped: usize,
     pub retargeted_tags: usize,
+    /// How many versions were dropped *specifically* because they
+    /// lacked Sigstore provenance (i.e. would have otherwise been
+    /// kept by the age filter). 0 when `require_provenance` is off.
+    pub dropped_no_provenance: usize,
+}
+
+/// Strict-mode knob that lives on the rewriter's side of the call
+/// graph. When `require_provenance = true`, any version whose
+/// `dist.attestations.provenance` is missing is dropped in addition
+/// to the age-based filter — so the resolver sees only OIDC-signed
+/// versions, neutralising the "steal-token-and-publish-fresh"
+/// attack that `minimumReleaseAge` alone can't stop.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NpmRewriteOptions {
+    pub require_provenance: bool,
+}
+
+/// Legacy entry point: equivalent to calling
+/// [`rewrite_npm_packument_with`] with default options. Kept so
+/// existing call-sites (and the v0.22 tests below) compile
+/// unchanged.
+pub fn rewrite_npm_packument(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, NpmRewriteStats) {
+    rewrite_npm_packument_with(body, min_age, now, NpmRewriteOptions::default())
 }
 
 /// Rewrite an npm packument body, dropping too-young versions and
+/// (optionally) versions without Sigstore provenance, then
 /// re-pointing dist-tags at the newest remaining version.
 ///
 /// On parse failure returns the body unchanged with zero stats — a
 /// malformed packument we don't understand is safer to forward than to
 /// silently break. Callers should pass only 2xx bodies (the proxy
 /// already gates on that).
-pub fn rewrite_npm_packument(
+pub fn rewrite_npm_packument_with(
     body: &[u8],
     min_age: Duration,
     now: DateTime<Utc>,
+    opts: NpmRewriteOptions,
 ) -> (Vec<u8>, NpmRewriteStats) {
     let mut stats = NpmRewriteStats {
         kept: 0,
         dropped: 0,
         retargeted_tags: 0,
+        dropped_no_provenance: 0,
     };
 
     let mut doc: Value = match serde_json::from_slice(body) {
@@ -80,10 +110,8 @@ pub fn rewrite_npm_packument(
 
     let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
 
-    // Collect publish dates from `time`. npm reserves "created" and
-    // "modified" for metadata; every other key is expected to be a
-    // version string.
-    let too_young: Vec<String> = obj
+    // Age filter — collect too-young version keys from `time`.
+    let age_drop: Vec<String> = obj
         .get("time")
         .and_then(Value::as_object)
         .map(|time| {
@@ -102,6 +130,49 @@ pub fn rewrite_npm_packument(
         })
         .unwrap_or_default();
 
+    // Provenance filter — find versions whose `dist.attestations.provenance`
+    // is absent. Only applied when `require_provenance` is on.
+    //
+    // A version is considered to have provenance iff
+    //   versions.<v>.dist.attestations.provenance.predicateType
+    // is a non-empty string. npm's own schema puts the SLSA
+    // predicateType here; a missing or empty value means no bundle
+    // was published. We deliberately do NOT download and verify the
+    // bundle here — that's a bigger feature; filtering on the claim
+    // alone is already enough to force "publisher opted into
+    // provenance" for every surviving version.
+    let provenance_drop: Vec<String> = if opts.require_provenance {
+        obj.get("versions")
+            .and_then(Value::as_object)
+            .map(|versions| {
+                versions
+                    .iter()
+                    .filter(|(_, meta)| !has_provenance(meta))
+                    .map(|(v, _)| v.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // Union: a version dropped by age, provenance, or both is
+    // ultimately dropped once. We only count it in
+    // `dropped_no_provenance` if provenance was the *only* reason
+    // it got removed (otherwise the number would double-count on
+    // too-young-and-no-provenance versions).
+    let age_set: std::collections::HashSet<String> = age_drop.iter().cloned().collect();
+    for v in &provenance_drop {
+        if !age_set.contains(v) {
+            stats.dropped_no_provenance += 1;
+        }
+    }
+    let mut too_young: Vec<String> = age_drop;
+    for v in provenance_drop {
+        if !age_set.contains(&v) {
+            too_young.push(v);
+        }
+    }
     stats.dropped = too_young.len();
 
     if !too_young.is_empty() {
@@ -164,6 +235,26 @@ pub fn rewrite_npm_packument(
 
     let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
     (out, stats)
+}
+
+/// Does this per-version metadata carry a Sigstore provenance
+/// claim? npm stores it at `dist.attestations.provenance` —
+/// specifically `.predicateType`, which for an npm-published
+/// provenance is always `"https://slsa.dev/provenance/v1"` (for
+/// SLSA v1). We only check for *presence* of a non-empty
+/// predicateType; downloading and cryptographically verifying the
+/// attached Sigstore bundle is a separate roadmap item, but a
+/// claim of "I have provenance" is itself a meaningful signal
+/// (npm refuses to attach this field unless the publish pipeline
+/// was an OIDC-authenticated GitHub Actions / GitLab CI run).
+fn has_provenance(meta: &Value) -> bool {
+    meta.get("dist")
+        .and_then(|d| d.get("attestations"))
+        .and_then(|a| a.get("provenance"))
+        .and_then(|p| p.get("predicateType"))
+        .and_then(Value::as_str)
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
 }
 
 /// Highest remaining version by semver. Falls back to lexical
@@ -380,6 +471,149 @@ mod tests {
         assert_eq!(before, after);
         assert_eq!(stats.dropped, 0);
         assert_eq!(stats.kept, 2);
+    }
+
+    /// Build a packument where each version optionally carries a
+    /// Sigstore provenance claim. `has_prov[i]` toggles for the
+    /// matching `versions[i]` entry.
+    fn packument_with_provenance(
+        versions: &[(&str, &str)],
+        latest: &str,
+        has_prov: &[bool],
+    ) -> String {
+        assert_eq!(versions.len(), has_prov.len());
+        let mut time = serde_json::Map::new();
+        time.insert(
+            "created".into(),
+            Value::String("2024-01-01T00:00:00Z".into()),
+        );
+        time.insert(
+            "modified".into(),
+            Value::String("2025-01-01T00:00:00Z".into()),
+        );
+        let mut vs = serde_json::Map::new();
+        for ((v, t), prov) in versions.iter().zip(has_prov) {
+            time.insert((*v).into(), Value::String((*t).into()));
+            let mut man = serde_json::Map::new();
+            man.insert("name".into(), Value::String("pkg".into()));
+            man.insert("version".into(), Value::String((*v).into()));
+            let mut dist = serde_json::Map::new();
+            if *prov {
+                dist.insert(
+                    "attestations".into(),
+                    serde_json::json!({
+                        "url": format!("https://registry.npmjs.org/-/npm/v1/attestations/pkg@{v}"),
+                        "provenance": {
+                            "predicateType": "https://slsa.dev/provenance/v1"
+                        }
+                    }),
+                );
+            }
+            man.insert("dist".into(), Value::Object(dist));
+            vs.insert((*v).into(), Value::Object(man));
+        }
+        let mut doc = serde_json::Map::new();
+        doc.insert("name".into(), Value::String("pkg".into()));
+        doc.insert("dist-tags".into(), serde_json::json!({"latest": latest}));
+        doc.insert("versions".into(), Value::Object(vs));
+        doc.insert("time".into(), Value::Object(time));
+        serde_json::to_string(&doc).unwrap()
+    }
+
+    #[test]
+    fn require_provenance_drops_versions_without_attestations() {
+        // All three versions are old enough; only two have provenance.
+        let now = utc(2025, 1, 10);
+        let body = packument_with_provenance(
+            &[
+                ("1.0.0", "2024-01-01T00:00:00Z"),
+                ("1.1.0", "2024-06-01T00:00:00Z"),
+                ("2.0.0", "2024-09-01T00:00:00Z"),
+            ],
+            "2.0.0",
+            &[true, false, true], // 1.1.0 missing provenance
+        );
+        let (out, stats) = rewrite_npm_packument_with(
+            body.as_bytes(),
+            min_age_hours(168),
+            now,
+            NpmRewriteOptions {
+                require_provenance: true,
+            },
+        );
+        let doc = parse(&out);
+        let vs = doc["versions"].as_object().unwrap();
+        assert!(vs.contains_key("1.0.0"));
+        assert!(!vs.contains_key("1.1.0"));
+        assert!(vs.contains_key("2.0.0"));
+        assert_eq!(stats.dropped_no_provenance, 1);
+        assert_eq!(stats.dropped, 1);
+    }
+
+    #[test]
+    fn provenance_off_is_a_no_op_for_missing_attestations() {
+        let now = utc(2025, 1, 10);
+        let body = packument_with_provenance(
+            &[("1.0.0", "2024-01-01T00:00:00Z")],
+            "1.0.0",
+            &[false], // no provenance
+        );
+        let (_out, stats) = rewrite_npm_packument_with(
+            body.as_bytes(),
+            min_age_hours(168),
+            now,
+            NpmRewriteOptions {
+                require_provenance: false, // OFF
+            },
+        );
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.dropped_no_provenance, 0);
+    }
+
+    #[test]
+    fn provenance_and_age_dedup_does_not_double_count() {
+        // One version is both too-young AND missing provenance.
+        // It should be dropped exactly once, and NOT counted in
+        // `dropped_no_provenance` (age was enough reason already).
+        let now = utc(2025, 1, 10);
+        let body = packument_with_provenance(
+            &[
+                ("1.0.0", "2024-01-01T00:00:00Z"), // old + signed
+                ("2.0.0", "2025-01-09T23:00:00Z"), // too young + unsigned
+            ],
+            "2.0.0",
+            &[true, false],
+        );
+        let (_out, stats) = rewrite_npm_packument_with(
+            body.as_bytes(),
+            min_age_hours(168),
+            now,
+            NpmRewriteOptions {
+                require_provenance: true,
+            },
+        );
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.dropped_no_provenance, 0);
+    }
+
+    #[test]
+    fn has_provenance_rejects_empty_or_missing_predicate_type() {
+        let with_prov = serde_json::json!({
+            "dist": {
+                "attestations": {
+                    "provenance": { "predicateType": "https://slsa.dev/provenance/v1" }
+                }
+            }
+        });
+        let empty_pt = serde_json::json!({
+            "dist": { "attestations": { "provenance": { "predicateType": "" } } }
+        });
+        let no_attestations = serde_json::json!({ "dist": {} });
+        let no_dist = serde_json::json!({});
+        assert!(has_provenance(&with_prov));
+        assert!(!has_provenance(&empty_pt));
+        assert!(!has_provenance(&no_attestations));
+        assert!(!has_provenance(&no_dist));
     }
 
     #[test]

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -214,6 +214,17 @@ pub struct ProxyStartArgs {
     /// allow through).
     #[arg(long)]
     pub fail_on_missing: bool,
+    /// **Strict mode.** Drop every npm package version that doesn't
+    /// carry a Sigstore provenance claim (`dist.attestations.provenance`).
+    /// Closes the "stolen publish token" hole that `--min-age`
+    /// alone can't cover: a token thief can publish immediately,
+    /// but without an OIDC-authenticated CI run they can't attach a
+    /// valid provenance attestation.
+    ///
+    /// Only affects the npm packument path. pypi / nuget / crates
+    /// equivalents (PEP 740, cargo attestation) are roadmap items.
+    #[arg(long)]
+    pub require_provenance: bool,
     /// Override the CA/config directory. Defaults to
     /// `$XDG_CONFIG_HOME/coronarium` (or `~/.config/coronarium`).
     #[arg(long)]
@@ -437,6 +448,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 listen: args.listen,
                 min_age,
                 fail_on_missing: args.fail_on_missing,
+                require_provenance: args.require_provenance,
                 ca_files,
                 user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
                 oracle: None,


### PR DESCRIPTION
## #2 of 3 (Windows parity → **provenance** → OSV)

Closes the "stolen publish token" hole that \`minimumReleaseAge\` alone can't cover: a thief with a valid \`_authToken\` can publish immediately, and age-filter won't save you. But they can't attach a valid Sigstore provenance bundle without an OIDC-authenticated CI pipeline run — so requiring provenance forces publishers to go through a tamper-evident path.

### MVP scope (this PR)
- Filter on **claim presence** (\`dist.attestations.provenance.predicateType\` non-empty) — npm refuses to attach this field unless the publish was OIDC-authenticated GitHub Actions / GitLab CI. Full Sigstore bundle download + crypto verification is a follow-up.
- npm only for now; PEP 740 (pypi), NuGet package signing, crates attestation are roadmap items.
- Opt-in via \`coronarium proxy start --require-provenance\` — default OFF so v0.23 users with legitimate unsigned deps aren't broken.

### Behaviour example
\`\`\`
$ coronarium proxy start --min-age 7d --require-provenance
# npm resolver now sees only:
#   - versions ≥ 7 days old AND
#   - versions with a Sigstore provenance claim
# All other versions become invisible (silent fallback).
\`\`\`

### Test plan
- [x] \`cargo test --workspace\` — 172 tests pass (+4 new in \`rewrite_npm::tests\`)
- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean, fmt clean
- [ ] CI green
- [ ] Confirmed log output shape: \`npm-rewrite: dropped N version(s) (M for missing provenance), kept K, retargeted T tag(s)\`

### Stats shape
- \`dropped_no_provenance\` counts versions removed *solely* for missing provenance (dedupes the too-young-AND-unsigned case, so totals aren't inflated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)