### PR TITLE
feat(release): Homebrew formula + auto-sync workflow

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -1,0 +1,106 @@
+name: homebrew-formula
+
+# Runs after `release.yml` has published a new GitHub Release. We
+# download each platform's .tar.gz.sha256 sidecar, rewrite the
+# `version`, `url`, and `sha256` lines in
+# `HomebrewFormula/coronarium.rb`, and commit to main.
+#
+# Separated from release.yml so a broken formula update doesn't
+# cancel the binary release itself, and so we can manually
+# re-run it against an already-published tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to sync (defaults to latest release)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+concurrency:
+  group: homebrew-formula
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          # Need enough history to push a fresh commit; shallow is fine.
+          fetch-depth: 1
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          fi
+          if [ -z "$tag" ]; then
+            # workflow_dispatch with no input → latest release
+            tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+          fi
+          # Version without leading 'v' for the Homebrew `version`
+          # field. `brew` normalises both but the convention is bare.
+          ver="${tag#v}"
+          echo "tag=$tag"   >> "$GITHUB_OUTPUT"
+          echo "ver=$ver"   >> "$GITHUB_OUTPUT"
+          echo "Syncing formula to $tag (version $ver)"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Fetch tarball sha256s
+        id: sha
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          for t in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
+            url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/coronarium-${t}.tar.gz.sha256"
+            echo "fetch $url"
+            sha=$(curl -fsSL "$url" | awk '{print $1}')
+            if [ -z "$sha" ]; then
+              echo "::error::empty sha256 for $t @ $tag"
+              exit 1
+            fi
+            # Export as shell var for the rewrite step.
+            key=$(echo "$t" | tr '.-' '__')
+            echo "${key}=${sha}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Rewrite formula
+        run: |
+          set -euo pipefail
+          python3 scripts/update-homebrew-formula.py \
+              --file HomebrewFormula/coronarium.rb \
+              --version '${{ steps.tag.outputs.ver }}' \
+              --tag '${{ steps.tag.outputs.tag }}' \
+              --sha-aarch64-apple-darwin        '${{ steps.sha.outputs.aarch64_apple_darwin }}' \
+              --sha-x86_64-apple-darwin         '${{ steps.sha.outputs.x86_64_apple_darwin }}' \
+              --sha-aarch64-unknown-linux-musl  '${{ steps.sha.outputs.aarch64_unknown_linux_musl }}' \
+              --sha-x86_64-unknown-linux-musl   '${{ steps.sha.outputs.x86_64_unknown_linux_musl }}'
+
+          echo "--- rewritten formula ---"
+          cat HomebrewFormula/coronarium.rb
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          git config user.name 'coronarium-homebrew-bot'
+          git config user.email 'homebrew-bot@users.noreply.github.com'
+          git add HomebrewFormula/coronarium.rb
+          if git diff --cached --quiet; then
+            echo "Formula already at ${{ steps.tag.outputs.tag }}; nothing to commit."
+            exit 0
+          fi
+          git commit -s -m "chore(homebrew): bump formula to ${{ steps.tag.outputs.tag }}"
+          # Push straight to main. The formula is data-only; no CI
+          # impact beyond the fmt/clippy jobs which don't touch it.
+          git push origin HEAD:main

--- a/HomebrewFormula/coronarium.rb
+++ b/HomebrewFormula/coronarium.rb
@@ -1,0 +1,81 @@
+class Coronarium < Formula
+  desc "Cross-platform supply-chain guard for every package manager"
+  homepage "https://github.com/bokuweb/coronarium"
+  license "MIT"
+  version "0.26.0"
+
+  # This formula is a per-release binary installer — we consume the
+  # prebuilt tarballs that `.github/workflows/release.yml` publishes
+  # to the GitHub Release. Keeps the formula tiny (no cargo build,
+  # no nightly toolchain for the eBPF object) and lets users on
+  # macOS benefit immediately.
+  #
+  # The `.github/workflows/homebrew-formula.yml` workflow rewrites
+  # the URLs + sha256s on every `v*` tag push, so the only manual
+  # step is the initial tap setup.
+
+  on_macos do
+    on_arm do
+      url "https://github.com/bokuweb/coronarium/releases/download/v0.26.0/coronarium-aarch64-apple-darwin.tar.gz"
+      sha256 "80907949dc623686245be77c5833fba3d41a3b8d66406d2ea4c10fa0f1793251"
+    end
+    on_intel do
+      url "https://github.com/bokuweb/coronarium/releases/download/v0.26.0/coronarium-x86_64-apple-darwin.tar.gz"
+      sha256 "f6d2c6e8770eb70a7b2173aa10043f28215e9a655db5fc0a80c9aef00fdf17c8"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/bokuweb/coronarium/releases/download/v0.26.0/coronarium-aarch64-unknown-linux-musl.tar.gz"
+      sha256 "7ae6f9a1e7f9ad369b80571eebb00ca64692598d0bc1c1df11d84ad07c828b57"
+    end
+    on_intel do
+      url "https://github.com/bokuweb/coronarium/releases/download/v0.26.0/coronarium-x86_64-unknown-linux-musl.tar.gz"
+      sha256 "ba9bf9f8a7dbe8b21daf3e0ce72c29873dc56ea4eac6716f3a92ce19c234986e"
+    end
+  end
+
+  def install
+    bin.install "coronarium"
+    # Linux tarball also ships the eBPF object — only useful for
+    # `coronarium run` supervised mode. Install it next to the binary
+    # so the default `CORONARIUM_BPF_OBJ` search path finds it.
+    if OS.linux?
+      (libexec/"bpf").install "coronarium.bpf.o" if File.exist?("coronarium.bpf.o")
+    end
+  end
+
+  def caveats
+    <<~EOS
+      coronarium is installed. Desktop quick start (three commands):
+
+        coronarium proxy install-ca        # trust the proxy's root CA
+        coronarium proxy install-daemon    # run the proxy in the background
+        coronarium install-gate install    # route your shell through it
+
+      Open a new shell, then `npm install` / `cargo add` / `pip install` will
+      silently fall back to versions older than --min-age (default 7d).
+
+      Verify the install:
+
+        coronarium doctor
+
+      #{OS.linux? ? "eBPF supervised-run mode (`coronarium run`) needs the bpf object at:\n  #{libexec}/bpf/coronarium.bpf.o\nExport CORONARIUM_BPF_OBJ=$(brew --prefix)/opt/coronarium/libexec/bpf/coronarium.bpf.o\nbefore running `coronarium run`." : ""}
+    EOS
+  end
+
+  test do
+    # Smoke the binary starts and reports its version.
+    assert_match version.to_s, shell_output("#{bin}/coronarium --version")
+    # Policy parser exits cleanly on a minimal document.
+    (testpath/"policy.yml").write <<~YAML
+      mode: audit
+      network:
+        default: allow
+      file:
+        default: allow
+    YAML
+    system "#{bin}/coronarium", "check-policy", "-p", testpath/"policy.yml"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ pinned fetches downstream fail hard at the tarball layer.
 
 Pick whichever fits your setup.
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install bokuweb/coronarium/coronarium
+# ↑ the repo-is-its-own-tap convention; no separate `brew tap` needed.
+```
+
+Auto-updated on every release via the `homebrew-formula.yml`
+workflow — the formula lives at
+[`HomebrewFormula/coronarium.rb`](HomebrewFormula/coronarium.rb)
+in this repo.
+
 ### Pre-built binary (macOS / Linux / Windows)
 
 ```bash

--- a/scripts/update-homebrew-formula.py
+++ b/scripts/update-homebrew-formula.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Rewrite `HomebrewFormula/coronarium.rb` to point at a new release
+tag. Called from `.github/workflows/homebrew-formula.yml` after a
+`v*` release is published; the workflow computes the sha256 of
+each platform's tarball and passes them in via flags.
+
+Pure-Python, no external deps — runs on any stock GH runner.
+
+Why not just `sed`? The formula uses `on_arm` / `on_intel` blocks,
+so we need *positional* substitution (the N-th `sha256 "..."` line
+maps to a specific target triple). A structured rewrite is less
+fragile than positional sed regex.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Order matches the formula file top-to-bottom: each tuple is
+# (target-triple, argparse-attr). Keep in sync with the formula
+# AND the workflow step that fetches these.
+TARGETS = [
+    ("aarch64-apple-darwin", "sha_aarch64_apple_darwin"),
+    ("x86_64-apple-darwin", "sha_x86_64_apple_darwin"),
+    ("aarch64-unknown-linux-musl", "sha_aarch64_unknown_linux_musl"),
+    ("x86_64-unknown-linux-musl", "sha_x86_64_unknown_linux_musl"),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--file", required=True, type=pathlib.Path)
+    p.add_argument("--version", required=True, help='e.g. "0.27.0"')
+    p.add_argument("--tag", required=True, help='e.g. "v0.27.0"')
+    for t, attr in TARGETS:
+        p.add_argument(f"--sha-{t}", dest=attr, required=True)
+    return p.parse_args()
+
+
+def rewrite(text: str, args: argparse.Namespace) -> str:
+    # 1. `version "..."` — single line, anywhere in the file.
+    text = re.sub(
+        r'(^\s*version\s+)"[^"]+"',
+        lambda m: f'{m.group(1)}"{args.version}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    # 2. URLs — one per target triple, in the order declared in
+    #    TARGETS. We replace ALL url lines in place, matched
+    #    positionally, so the `on_arm` / `on_intel` blocks each
+    #    get their correct tarball.
+    urls_iter = iter(
+        f'url "https://github.com/bokuweb/coronarium/releases/download/{args.tag}/coronarium-{t}.tar.gz"'
+        for t, _ in TARGETS
+    )
+
+    def url_sub(_match: re.Match) -> str:
+        return next(urls_iter)
+
+    text, url_count = re.subn(
+        r'url\s+"[^"]+"',
+        url_sub,
+        text,
+    )
+    if url_count != len(TARGETS):
+        raise SystemExit(f"expected {len(TARGETS)} url lines, rewrote {url_count}")
+
+    # 3. sha256 — same positional story.
+    shas_iter = iter(
+        f'sha256 "{getattr(args, attr)}"' for _, attr in TARGETS
+    )
+
+    def sha_sub(_match: re.Match) -> str:
+        return next(shas_iter)
+
+    text, sha_count = re.subn(
+        r'sha256\s+"[^"]+"',
+        sha_sub,
+        text,
+    )
+    if sha_count != len(TARGETS):
+        raise SystemExit(f"expected {len(TARGETS)} sha256 lines, rewrote {sha_count}")
+
+    return text
+
+
+def main() -> int:
+    args = parse_args()
+    text = args.file.read_text(encoding="utf-8")
+    out = rewrite(text, args)
+    args.file.write_text(out, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Single-command install for macOS / Linux users:

\`\`\`
brew install bokuweb/coronarium/coronarium
\`\`\`

Uses the **repo-is-its-own-tap** convention: the formula lives at \`HomebrewFormula/coronarium.rb\` in this repo, so no separate \`bokuweb/homebrew-tap\` repository is required.

## What's in this PR

1. **\`HomebrewFormula/coronarium.rb\`** — per-platform binary installer with \`on_macos\` / \`on_linux\` × \`on_arm\` / \`on_intel\` blocks. Linux install also stashes \`coronarium.bpf.o\` under \`libexec/bpf/\` with caveats pointing at the right \`CORONARIUM_BPF_OBJ\` value. Seeded with real v0.26.0 sha256s.
2. **\`.github/workflows/homebrew-formula.yml\`** — fires on every GitHub Release: downloads each \`.tar.gz.sha256\` sidecar, rewrites the formula, force-commits to main. Also available as \`workflow_dispatch\` for manual re-runs.
3. **\`scripts/update-homebrew-formula.py\`** — positional rewrite (one substitution per \`on_*\` block). Safer than sed across the nested blocks. Smoke-tested locally with a synthetic v0.99.0 tag — all 4 URLs + 4 sha256s swap cleanly, nothing else moves.
4. README gains a Homebrew install block above the curl-tarball section.

## Test plan
- [x] \`python3 scripts/update-homebrew-formula.py\` smoke-tested with a fake v0.99.0 tag, diff confirmed correct
- [ ] CI green
- [ ] Post-merge: trigger \`homebrew-formula.yml\` manually against v0.26.0 to verify end-to-end
- [ ] On macOS: \`brew install bokuweb/coronarium/coronarium && brew test coronarium\`

Windows users still get curl / PowerShell install; a Scoop bucket is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)