### PR TITLE
feat(proxy): typosquat detection (Damerau-Levenshtein OSA)

### DIFF
--- a/crates/coronarium-proxy/src/decision.rs
+++ b/crates/coronarium-proxy/src/decision.rs
@@ -41,6 +41,30 @@ pub struct Decider<O: AgeOracle + ?Sized> {
     /// `--min-age`. Errors during lookup are logged and treated
     /// as "no match" — OSV downtime shouldn't block installs.
     pub known_bad: Option<Box<dyn crate::osv::KnownBadOracle>>,
+    /// Optional typosquat detector. When set, every decide() call
+    /// runs the package name through the detector; matches trigger
+    /// `log::warn!` (in `Warn` mode) or a hard deny (`Block` mode).
+    pub typosquat: Option<TyposquatHook>,
+}
+
+/// How to react to a typosquat hit. Separate from the detector
+/// itself so we can hold one `Detector` and vary policy per
+/// `Decider` (useful in tests and in the future for per-ecosystem
+/// overrides).
+#[derive(Debug, Clone, Copy)]
+pub struct TyposquatHook {
+    pub detector: crate::typosquat::Detector,
+    pub mode: TyposquatMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TyposquatMode {
+    /// Log a warning with the suggested legitimate name; let the
+    /// request proceed to the age check.
+    Warn,
+    /// Return `Deny` immediately with a message naming the
+    /// suggested legitimate package.
+    Block,
 }
 
 impl<O: AgeOracle + ?Sized> Decider<O> {
@@ -51,7 +75,37 @@ impl<O: AgeOracle + ?Sized> Decider<O> {
         version: &str,
         now: DateTime<Utc>,
     ) -> Decision {
-        // Known-malicious check first — hard-deny regardless of age.
+        // Typosquat check — cheapest to run first (pure in-memory
+        // edit-distance), and if we're in Block mode we skip every
+        // downstream network lookup.
+        if let Some(hook) = &self.typosquat
+            && let Some(m) = hook.detector.suggest(eco, name)
+        {
+            match hook.mode {
+                TyposquatMode::Warn => {
+                    log::warn!(
+                        "typosquat: {}/{name} looks like a typo of {} (edit-distance {}). \
+                         Allowing — pass --typosquat block to deny.",
+                        eco.label(),
+                        m.suggested,
+                        m.distance,
+                    );
+                }
+                TyposquatMode::Block => {
+                    return Decision::Deny {
+                        reason: format!(
+                            "coronarium: {}/{name} looks like a typosquat of {}@({} edit(s) away). \
+                             Did you mean `{}`?",
+                            eco.label(),
+                            m.suggested,
+                            m.distance,
+                            m.suggested,
+                        ),
+                    };
+                }
+            }
+        }
+        // Known-malicious check — hard-deny regardless of age.
         if let Some(kb) = &self.known_bad {
             match kb.lookup(eco, name, version) {
                 Ok(Some(ids)) if !ids.is_empty() => {
@@ -202,6 +256,7 @@ mod tests {
             min_age: Duration::from_secs(min_age_hours * 3600),
             fail_on_missing,
             known_bad: None,
+            typosquat: None,
         }
     }
 

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rewrite;
 pub mod rewrite_npm;
 pub mod rewrite_nuget;
 pub mod rewrite_pypi;
+pub mod typosquat;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
 pub use parser::{

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -50,6 +50,10 @@ pub struct ProxyConfig {
     /// Override URL for `osv_mirror`. Defaults to
     /// [`crate::osv_mirror::DEFAULT_MIRROR_URL`].
     pub osv_mirror_url: Option<String>,
+    /// Typosquat detection mode: `None` disables, `Some(Warn)` logs
+    /// close-match warnings, `Some(Block)` hard-denies typosquat
+    /// candidates.
+    pub typosquat: Option<crate::decision::TyposquatMode>,
     pub ca_files: CaFiles,
     pub user_agent: String,
     /// Override to inject a fake oracle in tests.
@@ -66,6 +70,7 @@ impl ProxyConfig {
             osv: false,
             osv_mirror: false,
             osv_mirror_url: None,
+            typosquat: None,
             ca_files: CaFiles::at_default_location()?,
             user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
             oracle: None,
@@ -130,11 +135,19 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
             }))
         }
     };
+    let typosquat = cfg.typosquat.map(|mode| {
+        log::info!("typosquat detection: {:?}", mode);
+        crate::decision::TyposquatHook {
+            detector: crate::typosquat::Detector::new(),
+            mode,
+        }
+    });
     let decider = Arc::new(Decider {
         oracle,
         min_age: cfg.min_age,
         fail_on_missing: cfg.fail_on_missing,
         known_bad,
+        typosquat,
     });
 
     let handler = CoronariumHandler {

--- a/crates/coronarium-proxy/src/rewrite.rs
+++ b/crates/coronarium-proxy/src/rewrite.rs
@@ -232,6 +232,7 @@ mod tests {
             min_age: Duration::from_secs(min_age_hours * 3600),
             fail_on_missing: false,
             known_bad: None,
+            typosquat: None,
         }
     }
 
@@ -361,6 +362,7 @@ mod tests {
             min_age: Duration::from_secs(168 * 3600),
             fail_on_missing: false,
             known_bad: None,
+            typosquat: None,
         };
 
         let body = concat!(
@@ -396,6 +398,7 @@ mod tests {
             min_age: Duration::from_secs(168 * 3600),
             fail_on_missing: false,
             known_bad: None,
+            typosquat: None,
         };
 
         let body = concat!(
@@ -425,6 +428,7 @@ mod tests {
             min_age: Duration::from_secs(168 * 3600),
             fail_on_missing: false,
             known_bad: None,
+            typosquat: None,
         };
 
         let body = r#"{"name":"a","vers":"1.0.0","pubtime":"not-a-date"}

--- a/crates/coronarium-proxy/src/typosquat.rs
+++ b/crates/coronarium-proxy/src/typosquat.rs
@@ -1,0 +1,758 @@
+//! Detect likely typosquats — packages whose names are suspiciously
+//! close to widely-installed legitimate ones (`colurs` vs `colors`,
+//! `reqeusts` vs `requests`, `webpack-loader-x` vs `webpack-loader`).
+//!
+//! The actual mechanics: a small hard-coded list of "top" packages
+//! per ecosystem + Levenshtein edit distance. When an incoming
+//! package name is 1–2 edits away from a top name *but not an exact
+//! match*, we flag it.
+//!
+//! Why a hard-coded list?
+//!
+//! - It's small: 4 × ~100 names = ~400 entries, well under 10 kB of
+//!   embedded data. Rebuilding weekly from download rankings is a
+//!   roadmap item, but the actually-typosquatted names (lodash,
+//!   requests, tokio, Newtonsoft.Json, …) don't churn week-to-week.
+//! - It's offline. No runtime fetch, no DNS, no bulk download.
+//! - It's auditable in a PR — bumps to the list are reviewed like
+//!   any other code change.
+//!
+//! Policy:
+//!
+//! - Distance = 0 ⇒ exact match ⇒ legitimate top package ⇒ allow.
+//! - Distance in 1..=threshold ⇒ suspicious typosquat ⇒ return the
+//!   candidate to the caller, who decides to warn, deny, or ignore.
+//! - Distance > threshold ⇒ no signal.
+//!
+//! The default threshold (1) catches typical single-character
+//! typosquats without flooding the user on commonly-prefixed
+//! packages (`@types/*` on npm would otherwise collide with every
+//! other `@types/…` name). Callers can raise it if they want more
+//! aggressive detection.
+
+use coronarium_core::deps::Ecosystem;
+
+/// Max edit distance, inclusive, to call something a typosquat. A
+/// value of 0 disables detection (nothing can be 0-close without
+/// being identical). We use 1 by default — anything further tends
+/// to produce false positives on genuinely distinct packages.
+pub const DEFAULT_THRESHOLD: usize = 1;
+
+/// One match. `suggested` is the legitimate top-N name that the
+/// input is uncomfortably close to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Match {
+    pub input: String,
+    pub suggested: &'static str,
+    pub distance: usize,
+}
+
+/// Detector wrapping the per-ecosystem top-N lists. Lifetimes are
+/// `'static` because the lists live in the binary.
+#[derive(Debug, Clone, Copy)]
+pub struct Detector {
+    pub threshold: usize,
+}
+
+impl Detector {
+    pub fn new() -> Self {
+        Self {
+            threshold: DEFAULT_THRESHOLD,
+        }
+    }
+
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self { threshold }
+    }
+
+    /// Check `name` against the top-N list for `eco`. Returns the
+    /// closest legitimate name if it's within the detector's
+    /// threshold *and* not the same string (an exact match means
+    /// the input IS the top package, which is fine).
+    pub fn suggest(&self, eco: Ecosystem, name: &str) -> Option<Match> {
+        if self.threshold == 0 || name.is_empty() {
+            return None;
+        }
+        let list = top_list_for(eco);
+        // Fast exact-match exit: if the input is itself a top name,
+        // return None immediately. Avoids the full distance loop for
+        // the common case.
+        if list.iter().any(|top| top.eq_ignore_ascii_case(name)) {
+            return None;
+        }
+        let lc_name = name.to_ascii_lowercase();
+        // Scan for the closest top name. Early-exit as soon as we
+        // find a distance-1 hit — for typosquat purposes, any
+        // 1-close top name is a strong enough signal.
+        let mut best: Option<(&'static str, usize)> = None;
+        for top in list {
+            let lc_top = top.to_ascii_lowercase();
+            // Cheap pre-filter: if the lengths differ by more than
+            // the threshold, no way the distance is within it.
+            if lc_name.len().abs_diff(lc_top.len()) > self.threshold {
+                continue;
+            }
+            let d = edit_distance_bounded(&lc_name, &lc_top, self.threshold);
+            match (d, best) {
+                (Some(0), _) => return None, // exact (case-insensitive)
+                (Some(d), None) => best = Some((top, d)),
+                (Some(d), Some((_, bd))) if d < bd => best = Some((top, d)),
+                _ => {}
+            }
+        }
+        best.map(|(suggested, distance)| Match {
+            input: name.to_string(),
+            suggested,
+            distance,
+        })
+    }
+}
+
+impl Default for Detector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Bounded Damerau-Levenshtein (OSA variant) edit distance.
+/// Returns `None` if the distance exceeds `max`; `Some(d)` otherwise.
+///
+/// We use the OSA (Optimal String Alignment) variant of
+/// Damerau-Levenshtein rather than plain Levenshtein because the
+/// most common class of typosquat — *transposed adjacent letters*
+/// like `raect`/`react`, `pytohn`/`python`, `ngninx`/`nginx` — is
+/// 1 edit under OSA but 2 edits under plain Levenshtein. Raising
+/// plain Levenshtein's threshold to catch those then brings in a
+/// flood of false positives (any two-letter-different packages).
+///
+/// "OSA" means: each substring can be edited at most once. True
+/// Damerau-Levenshtein allows unlimited transpositions of
+/// arbitrary substrings which is slower and rarely-useful here.
+/// The output agrees with Damerau-Levenshtein on all 1-edit
+/// typosquats, which is what we care about.
+///
+/// Implementation: three-row DP (prev-prev, prev, curr), O(min(m,n))
+/// memory, early-exit when the row minimum exceeds `max`.
+pub fn edit_distance_bounded(a: &str, b: &str, max: usize) -> Option<usize> {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let m = a.len();
+    let n = b.len();
+    // Symmetry: keep `b` as the longer string.
+    if m > n {
+        return edit_distance_bounded(
+            std::str::from_utf8(b).unwrap_or(""),
+            std::str::from_utf8(a).unwrap_or(""),
+            max,
+        );
+    }
+    if n - m > max {
+        return None;
+    }
+
+    // Three rolling rows: `pp` = d[j-2], `p` = d[j-1], `c` = d[j].
+    let mut pp: Vec<usize> = vec![0; m + 1];
+    let mut p: Vec<usize> = (0..=m).collect();
+    let mut c: Vec<usize> = vec![0; m + 1];
+
+    for j in 1..=n {
+        c[0] = j;
+        let mut row_min = c[0];
+        for i in 1..=m {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            let mut v = (p[i] + 1) // deletion
+                .min(c[i - 1] + 1) // insertion
+                .min(p[i - 1] + cost); // substitution
+            // Transposition: if a[i-1]a[i-2] = b[j-2]b[j-1] (i.e.
+            // a swap of adjacent chars would align them), we can
+            // take d[i-2][j-2] + 1.
+            if i >= 2 && j >= 2 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                v = v.min(pp[i - 2] + 1);
+            }
+            c[i] = v;
+            if c[i] < row_min {
+                row_min = c[i];
+            }
+        }
+        if row_min > max {
+            return None;
+        }
+        // Rotate: pp ← p, p ← c, c (new scratch) ← pp
+        std::mem::swap(&mut pp, &mut p);
+        std::mem::swap(&mut p, &mut c);
+    }
+    // After the final rotation, `p` holds the last completed row.
+    let d = p[m];
+    (d <= max).then_some(d)
+}
+
+fn top_list_for(eco: Ecosystem) -> &'static [&'static str] {
+    match eco {
+        Ecosystem::Crates => CRATES_TOP,
+        Ecosystem::Npm => NPM_TOP,
+        Ecosystem::Pypi => PYPI_TOP,
+        Ecosystem::Nuget => NUGET_TOP,
+    }
+}
+
+// --- hard-coded top lists ---------------------------------------
+//
+// Derived from recent download rankings (npm Registry stats, PyPI
+// downloads via BigQuery, crates.io `?sort=downloads`, NuGet stats).
+// Names are case-preserved as the registry lists them; the matcher
+// does case-insensitive comparison.
+//
+// These are deliberately small (~100 per ecosystem). The goal isn't
+// coverage — it's to catch typosquats of the *commonly-targeted*
+// big packages. Adding a niche library here gains nothing; a
+// typosquat of it is unlikely. The roadmap includes an automated
+// weekly rebuild from live ranking data; this MVP uses frozen
+// lists so the first release doesn't depend on a separate cron.
+
+/// Top ~100 npm package names.
+pub const NPM_TOP: &[&str] = &[
+    "react",
+    "lodash",
+    "axios",
+    "express",
+    "chalk",
+    "debug",
+    "tslib",
+    "vue",
+    "next",
+    "webpack",
+    "babel-core",
+    "babel-runtime",
+    "typescript",
+    "eslint",
+    "prettier",
+    "mocha",
+    "jest",
+    "chai",
+    "underscore",
+    "moment",
+    "request",
+    "bluebird",
+    "commander",
+    "yargs",
+    "fs-extra",
+    "minimist",
+    "glob",
+    "rimraf",
+    "semver",
+    "rxjs",
+    "tsconfig-paths",
+    "uuid",
+    "dotenv",
+    "ws",
+    "ms",
+    "cheerio",
+    "body-parser",
+    "cors",
+    "passport",
+    "mongoose",
+    "redis",
+    "ioredis",
+    "sequelize",
+    "knex",
+    "pg",
+    "mysql",
+    "mysql2",
+    "sqlite3",
+    "socket.io",
+    "socket.io-client",
+    "form-data",
+    "node-fetch",
+    "cross-env",
+    "cross-spawn",
+    "concurrently",
+    "nodemon",
+    "ts-node",
+    "react-dom",
+    "react-router",
+    "react-router-dom",
+    "redux",
+    "react-redux",
+    "@reduxjs/toolkit",
+    "styled-components",
+    "tailwindcss",
+    "postcss",
+    "autoprefixer",
+    "vite",
+    "rollup",
+    "esbuild",
+    "parcel",
+    "gulp",
+    "grunt",
+    "handlebars",
+    "ejs",
+    "pug",
+    "sass",
+    "less",
+    "node-sass",
+    "jquery",
+    "bootstrap",
+    "three",
+    "d3",
+    "chart.js",
+    "leaflet",
+    "yarn",
+    "pnpm",
+    "npm",
+    "colors",
+    "ansi-styles",
+    "supports-color",
+    "color",
+    "kleur",
+    "picocolors",
+    "inquirer",
+    "ora",
+    "chalk-template",
+    "got",
+    "ky",
+    "superagent",
+    "undici",
+    "graphql",
+    "apollo-client",
+    "@apollo/client",
+    "prisma",
+    "@prisma/client",
+];
+
+/// Top ~100 crates.io crate names.
+pub const CRATES_TOP: &[&str] = &[
+    "serde",
+    "serde_json",
+    "tokio",
+    "anyhow",
+    "thiserror",
+    "clap",
+    "reqwest",
+    "regex",
+    "log",
+    "env_logger",
+    "tracing",
+    "tracing-subscriber",
+    "futures",
+    "futures-util",
+    "async-trait",
+    "rand",
+    "chrono",
+    "time",
+    "uuid",
+    "url",
+    "bytes",
+    "once_cell",
+    "lazy_static",
+    "itertools",
+    "rayon",
+    "parking_lot",
+    "crossbeam",
+    "crossbeam-channel",
+    "dashmap",
+    "hashbrown",
+    "indexmap",
+    "smallvec",
+    "num",
+    "num-traits",
+    "num-bigint",
+    "hex",
+    "base64",
+    "sha2",
+    "md5",
+    "blake3",
+    "ring",
+    "rustls",
+    "openssl",
+    "native-tls",
+    "hyper",
+    "tower",
+    "tower-http",
+    "axum",
+    "actix-web",
+    "warp",
+    "rocket",
+    "diesel",
+    "sqlx",
+    "redis",
+    "mongodb",
+    "bson",
+    "yaml",
+    "serde_yaml",
+    "toml",
+    "ron",
+    "postcard",
+    "bincode",
+    "rmp",
+    "rmp-serde",
+    "flate2",
+    "tar",
+    "zip",
+    "walkdir",
+    "ignore",
+    "notify",
+    "fs-err",
+    "dirs",
+    "directories",
+    "which",
+    "tempfile",
+    "proptest",
+    "criterion",
+    "mockall",
+    "pretty_assertions",
+    "insta",
+    "assert_cmd",
+    "predicates",
+    "strum",
+    "strum_macros",
+    "derive_more",
+    "paste",
+    "pin-project",
+    "pin-project-lite",
+    "async-std",
+    "smol",
+    "tokio-util",
+    "tokio-stream",
+    "async-channel",
+    "flume",
+    "color-eyre",
+    "eyre",
+    "miette",
+    "nom",
+    "combine",
+    "winnow",
+];
+
+/// Top ~100 PyPI package names.
+pub const PYPI_TOP: &[&str] = &[
+    "requests",
+    "urllib3",
+    "numpy",
+    "pandas",
+    "flask",
+    "django",
+    "fastapi",
+    "uvicorn",
+    "gunicorn",
+    "werkzeug",
+    "jinja2",
+    "sqlalchemy",
+    "pydantic",
+    "pydantic-core",
+    "typing-extensions",
+    "click",
+    "rich",
+    "tqdm",
+    "pytest",
+    "pytest-cov",
+    "coverage",
+    "black",
+    "flake8",
+    "isort",
+    "mypy",
+    "ruff",
+    "pylint",
+    "pillow",
+    "matplotlib",
+    "seaborn",
+    "plotly",
+    "bokeh",
+    "scipy",
+    "scikit-learn",
+    "tensorflow",
+    "torch",
+    "keras",
+    "transformers",
+    "huggingface-hub",
+    "datasets",
+    "tokenizers",
+    "openai",
+    "anthropic",
+    "langchain",
+    "langchain-core",
+    "boto3",
+    "botocore",
+    "s3transfer",
+    "pyyaml",
+    "toml",
+    "tomli",
+    "tomli_w",
+    "python-dotenv",
+    "pytz",
+    "python-dateutil",
+    "six",
+    "setuptools",
+    "wheel",
+    "pip",
+    "virtualenv",
+    "poetry",
+    "pipenv",
+    "hatchling",
+    "build",
+    "twine",
+    "keyring",
+    "cryptography",
+    "bcrypt",
+    "passlib",
+    "pyjwt",
+    "oauthlib",
+    "requests-oauthlib",
+    "google-auth",
+    "google-auth-oauthlib",
+    "protobuf",
+    "grpcio",
+    "grpcio-tools",
+    "celery",
+    "redis",
+    "kombu",
+    "billiard",
+    "amqp",
+    "vine",
+    "marshmallow",
+    "attrs",
+    "cattrs",
+    "structlog",
+    "loguru",
+    "colorlog",
+    "httpx",
+    "aiohttp",
+    "asyncio",
+    "trio",
+    "anyio",
+    "websockets",
+    "aioredis",
+    "asyncpg",
+    "psycopg2",
+    "psycopg2-binary",
+    "mysqlclient",
+    "pymysql",
+    "sqlite3-binary",
+    "alembic",
+];
+
+/// Top ~100 NuGet package names. NuGet names are case-sensitive in
+/// listing but case-insensitive in lookup — we keep the canonical
+/// casing here.
+pub const NUGET_TOP: &[&str] = &[
+    "Newtonsoft.Json",
+    "Microsoft.Extensions.Logging",
+    "Microsoft.Extensions.Logging.Abstractions",
+    "Microsoft.Extensions.DependencyInjection",
+    "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "Microsoft.Extensions.Configuration",
+    "Microsoft.Extensions.Configuration.Abstractions",
+    "Microsoft.Extensions.Configuration.Binder",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables",
+    "Microsoft.Extensions.Configuration.FileExtensions",
+    "Microsoft.Extensions.Configuration.Json",
+    "Microsoft.Extensions.Options",
+    "Microsoft.Extensions.Primitives",
+    "Microsoft.Extensions.Hosting",
+    "Microsoft.Extensions.Http",
+    "Microsoft.AspNetCore.App",
+    "Microsoft.NETCore.App",
+    "System.Text.Json",
+    "System.Text.Encodings.Web",
+    "System.Memory",
+    "System.Threading.Tasks.Extensions",
+    "System.Buffers",
+    "System.Runtime.CompilerServices.Unsafe",
+    "System.Net.Http.Json",
+    "System.IdentityModel.Tokens.Jwt",
+    "Microsoft.IdentityModel.Tokens",
+    "Microsoft.IdentityModel.Logging",
+    "Microsoft.Bcl.AsyncInterfaces",
+    "Serilog",
+    "Serilog.AspNetCore",
+    "Serilog.Sinks.Console",
+    "Serilog.Sinks.File",
+    "Serilog.Formatting.Compact",
+    "Serilog.Settings.Configuration",
+    "NLog",
+    "NLog.Web.AspNetCore",
+    "log4net",
+    "AutoMapper",
+    "AutoMapper.Extensions.Microsoft.DependencyInjection",
+    "FluentValidation",
+    "FluentValidation.AspNetCore",
+    "FluentValidation.DependencyInjectionExtensions",
+    "Polly",
+    "Polly.Extensions.Http",
+    "Moq",
+    "Moq.AutoMock",
+    "xunit",
+    "xunit.runner.visualstudio",
+    "xunit.analyzers",
+    "NUnit",
+    "NUnit3TestAdapter",
+    "MSTest.TestAdapter",
+    "MSTest.TestFramework",
+    "Microsoft.NET.Test.Sdk",
+    "FluentAssertions",
+    "Shouldly",
+    "coverlet.collector",
+    "coverlet.msbuild",
+    "EntityFramework",
+    "Microsoft.EntityFrameworkCore",
+    "Microsoft.EntityFrameworkCore.Design",
+    "Microsoft.EntityFrameworkCore.SqlServer",
+    "Microsoft.EntityFrameworkCore.InMemory",
+    "Microsoft.EntityFrameworkCore.Sqlite",
+    "Microsoft.EntityFrameworkCore.Tools",
+    "Dapper",
+    "RestSharp",
+    "Refit",
+    "MediatR",
+    "MediatR.Extensions.Microsoft.DependencyInjection",
+    "MassTransit",
+    "RabbitMQ.Client",
+    "StackExchange.Redis",
+    "Azure.Storage.Blobs",
+    "Azure.Identity",
+    "Azure.Core",
+    "AWSSDK.S3",
+    "AWSSDK.Core",
+    "Swashbuckle.AspNetCore",
+    "Swashbuckle.AspNetCore.Swagger",
+    "Swashbuckle.AspNetCore.SwaggerGen",
+    "Swashbuckle.AspNetCore.SwaggerUI",
+    "Hangfire",
+    "Hangfire.AspNetCore",
+    "Hangfire.SqlServer",
+    "Quartz",
+    "Quartz.Extensions.Hosting",
+    "CsvHelper",
+    "BenchmarkDotNet",
+    "CommandLineParser",
+    "Microsoft.AspNetCore.Authentication.JwtBearer",
+    "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
+    "Microsoft.AspNetCore.Mvc.Versioning",
+    "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+    "Npgsql",
+    "Npgsql.EntityFrameworkCore.PostgreSQL",
+    "MongoDB.Driver",
+    "MongoDB.Bson",
+    "Google.Protobuf",
+    "Grpc.Net.Client",
+    "Grpc.AspNetCore",
+    "Grpc.Tools",
+    "System.CommandLine",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match_returns_none() {
+        let d = Detector::new();
+        // Installing `react` itself is legitimate.
+        assert!(d.suggest(Ecosystem::Npm, "react").is_none());
+        // Case-insensitive on npm / crates / nuget.
+        assert!(d.suggest(Ecosystem::Npm, "REACT").is_none());
+        assert!(d.suggest(Ecosystem::Nuget, "newtonsoft.json").is_none());
+    }
+
+    #[test]
+    fn common_typosquats_are_flagged() {
+        let d = Detector::new();
+        let cases = [
+            (Ecosystem::Npm, "raect", "react"),
+            (Ecosystem::Npm, "lodas", "lodash"),
+            (Ecosystem::Pypi, "reqeusts", "requests"),
+            (Ecosystem::Pypi, "numpya", "numpy"),
+            (Ecosystem::Crates, "serde_jsn", "serde_json"),
+            (Ecosystem::Crates, "tokyo", "tokio"),
+        ];
+        for (eco, input, expected) in cases {
+            let m = d
+                .suggest(eco, input)
+                .unwrap_or_else(|| panic!("{input} should have been flagged near {expected}"));
+            assert_eq!(
+                m.suggested, expected,
+                "typo {input:?}: expected suggestion {expected:?}, got {:?}",
+                m.suggested
+            );
+            assert!(m.distance <= d.threshold);
+        }
+    }
+
+    #[test]
+    fn distance_beyond_threshold_is_ignored() {
+        // "asdf" is far from anything in the lists — should not
+        // trigger a suggestion at threshold=1.
+        let d = Detector::with_threshold(1);
+        assert!(d.suggest(Ecosystem::Npm, "asdf").is_none());
+        assert!(d.suggest(Ecosystem::Npm, "my-private-pkg").is_none());
+    }
+
+    #[test]
+    fn threshold_zero_disables() {
+        // threshold=0 effectively disables detection — the only
+        // name within 0 is the exact match itself, which the early
+        // exit already rejects.
+        let d = Detector::with_threshold(0);
+        assert!(d.suggest(Ecosystem::Npm, "raect").is_none());
+        assert!(d.suggest(Ecosystem::Npm, "anything").is_none());
+    }
+
+    #[test]
+    fn empty_name_returns_none() {
+        let d = Detector::new();
+        assert!(d.suggest(Ecosystem::Npm, "").is_none());
+    }
+
+    #[test]
+    fn higher_threshold_catches_more_but_with_false_positives_risk() {
+        // At threshold=2, common substring-edit typosquats start
+        // triggering. We don't ship this as default precisely because
+        // the false-positive rate on short names goes up.
+        let d = Detector::with_threshold(2);
+        // Two edits away from "react".
+        assert!(d.suggest(Ecosystem::Npm, "ryect").is_some());
+    }
+
+    #[test]
+    fn osa_distance_edge_cases() {
+        // Identical.
+        assert_eq!(edit_distance_bounded("react", "react", 1), Some(0));
+        // Adjacent transposition counts as 1 under OSA (vs 2 under
+        // pure Levenshtein). This is load-bearing for typosquat UX.
+        assert_eq!(edit_distance_bounded("raect", "react", 1), Some(1));
+        assert_eq!(edit_distance_bounded("pytohn", "python", 1), Some(1));
+        // "raet" → "react" needs insert + transpose = 2 edits.
+        assert_eq!(edit_distance_bounded("raet", "react", 1), None);
+        assert_eq!(edit_distance_bounded("raet", "react", 2), Some(2));
+        // Length difference already exceeds bound → bail early.
+        assert_eq!(edit_distance_bounded("", "react", 1), None);
+        assert_eq!(edit_distance_bounded("", "", 0), Some(0));
+        // Single substitution.
+        assert_eq!(edit_distance_bounded("colors", "colars", 1), Some(1));
+    }
+
+    #[test]
+    fn osa_symmetric() {
+        // distance(a, b) == distance(b, a)
+        assert_eq!(
+            edit_distance_bounded("foo", "barbaz", 10),
+            edit_distance_bounded("barbaz", "foo", 10)
+        );
+    }
+
+    #[test]
+    fn lists_are_nonempty_per_ecosystem() {
+        // Sanity: no ecosystem should ship with an empty top list;
+        // would silently disable typosquat detection there.
+        assert!(!NPM_TOP.is_empty());
+        assert!(!CRATES_TOP.is_empty());
+        assert!(!PYPI_TOP.is_empty());
+        assert!(!NUGET_TOP.is_empty());
+        // Also: no duplicates within a list.
+        for list in [NPM_TOP, CRATES_TOP, PYPI_TOP, NUGET_TOP] {
+            let mut seen = std::collections::HashSet::new();
+            for n in list {
+                assert!(seen.insert(n.to_ascii_lowercase()), "dup: {n}");
+            }
+        }
+    }
+}

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -125,6 +125,21 @@ pub struct InstallGateInstallArgs {
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum TyposquatMode {
+    Warn,
+    Block,
+}
+
+impl From<TyposquatMode> for coronarium_proxy::decision::TyposquatMode {
+    fn from(m: TyposquatMode) -> Self {
+        match m {
+            TyposquatMode::Warn => Self::Warn,
+            TyposquatMode::Block => Self::Block,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
 #[allow(clippy::enum_variant_names)]
 pub enum InstallGateShell {
     Bash,
@@ -251,6 +266,12 @@ pub struct ProxyStartArgs {
     /// Only meaningful with `--osv-mirror`.
     #[arg(long)]
     pub osv_mirror_url: Option<String>,
+    /// Typosquat detection: compare incoming package names against
+    /// a small top-N list per ecosystem (lodash, requests, tokio,
+    /// Newtonsoft.Json, …). `warn` logs a warning and lets the
+    /// install proceed; `block` hard-denies. Off by default.
+    #[arg(long, value_enum)]
+    pub typosquat: Option<TyposquatMode>,
     /// Override the CA/config directory. Defaults to
     /// `$XDG_CONFIG_HOME/coronarium` (or `~/.config/coronarium`).
     #[arg(long)]
@@ -478,6 +499,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 osv: args.osv,
                 osv_mirror: args.osv_mirror,
                 osv_mirror_url: args.osv_mirror_url,
+                typosquat: args.typosquat.map(Into::into),
                 ca_files,
                 user_agent: format!("coronarium-proxy/{}", env!("CARGO_PKG_VERSION")),
                 oracle: None,


### PR DESCRIPTION
Detects package names suspiciously close to widely-installed legitimate ones: \`raect\` / \`react\`, \`reqeusts\` / \`requests\`, \`tokyo\` / \`tokio\`, \`colurs\` / \`colors\`. Catches the first-line "grab a popular name minus a letter" attack before OSV / age filters can see anything.

\`\`\`bash
# Warn mode (default UX — doesn't break builds)
coronarium proxy start --min-age 7d --typosquat warn
# → logs: "typosquat: npm/raect looks like a typo of react (edit-distance 1)"

# Block mode (strict)
coronarium proxy start --typosquat block
# → client gets 403 with "Did you mean \`react\`?"
\`\`\`

## Why OSA Damerau-Levenshtein, not plain Levenshtein
The most common typosquat class is **transposed adjacent letters** — \`raect\`/\`react\`, \`pytohn\`/\`python\`. That's 2 edits under plain Levenshtein but 1 under OSA Damerau-Levenshtein. Raising plain-L threshold to 2 flood-fills false positives; OSA at threshold=1 is the sweet spot.

## Policy
- distance=0 → exact → allow (the user IS installing the top package)
- 1 ≤ distance ≤ threshold → suspicious → warn-or-block per config
- distance > threshold → no signal

Default threshold = 1 (configurable via \`Detector::with_threshold\`; not CLI-exposed yet to avoid proliferation).

## Top-N list
Hard-coded, ~100 names × 4 ecosystems = ~400 entries, <10 kB of \`const &str\` data. npm / pypi / crates / nuget. MVP uses frozen lists; a weekly cron to rebuild from download rankings is a roadmap item but the top names barely churn week-to-week (lodash, requests, tokio, Newtonsoft.Json — same every year).

## Integration
- Runs first in \`Decider.decide()\` — cheapest check (no network) and Block mode skips all downstream lookups.
- Warn mode logs via \`log::warn!\` and falls through to the rest of the pipeline. The user sees the signal in proxy logs / CI artifact but the install proceeds.

## Test plan
- [x] \`cargo test --workspace\` — 206 tests pass (+9 new, +1 Decider integration covered by existing cases)
- [x] \`cargo clippy --workspace --all-targets -D warnings\` clean, fmt clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)