### PR TITLE
feat(proxy): Sigstore semantic verification (P0-1a) + NuGet flat-container fallback (P1-3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,13 +96,15 @@ older deps.
   request and goes through the same rewriter.
 
   The **flat-container index** (`/v3-flatcontainer/<id>/index.json`
-  — a plain `{"versions":[...]}` with no dates) is **not** yet
-  silently filtered; we'd need an out-of-band lookup to the
-  registration endpoint to get dates. Until we do, dotnet restore
-  paths through flat-container still hit the existing nupkg
-  download deny at `api.nuget.org/v3-flatcontainer/<id>/<version>/…`
-  — fail-hard, not silent. This is the last remaining roadmap
-  item for the four-ecosystem sweep.
+  — a plain `{"versions":[...]}` with no dates) is silently filtered
+  via an out-of-band lookup to the registration endpoint. The
+  `NugetFlatContainerClient` fetches
+  `/v3/registration5-semver1/<id>/index.json`, extracts version→
+  publish-time pairs (walking page references up to a bounded
+  depth), caches the map per-package for 10 minutes, and feeds the
+  rewriter's oracle. Failed lookups yield an empty map → fail-open,
+  but pinned `.nupkg` fetches still hard-deny at the tarball layer
+  so stale cache can't silently admit young versions.
 
 For ecosystems without rewriting, `deps check` (CI) or the proxy's
 hard-deny (desktop) is still the defense — just not silent.
@@ -159,12 +161,11 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 2. **HTTPS registry proxy** — same idea but transparent: set
    `HTTPS_PROXY` system-wide, filter fetch traffic. No shell
    aliasing required, but MITM cert management is a UX chore.
-3. **NuGet flat-container auto-fallback** — NuGet registration
-   pages are rewritten as of v0.18. The last silent-fallback gap
-   is the flat-container `/v3-flatcontainer/<id>/index.json`
-   endpoint, which carries no publish dates inline. Fix needs
-   an out-of-band lookup to the registration endpoint (cached)
-   to learn dates, then filter the version list.
+3. ~~**NuGet flat-container auto-fallback**~~ — done.
+   `NugetFlatContainerClient` fetches the registration endpoint
+   out-of-band, caches the version→publish-time map per package,
+   and feeds the flat-container rewriter. All four ecosystems
+   now have silent fallback.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ name = "coronarium-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "chrono",
  "coronarium-core",
@@ -498,6 +499,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "time",
  "tokio",
  "ureq",
@@ -2072,6 +2074,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ from then on, every HTTPS request your package managers make through
 | **crates.io** | ✅ sparse-index JSONL rewrite (drops too-young lines from `/<prefix>/<name>`) | ✅ `403` on `.crate` download to a denied version |
 | **npm** | ✅ packument rewrite (drops versions + retargets `dist-tags.latest`) | ✅ `403` on `.tgz` download |
 | **pypi** | ✅ Warehouse JSON API (`/pypi/<pkg>/json`) + PEP 691 Simple JSON | ✅ `403` on `files.pythonhosted.org` tarball download |
-| **nuget** | ✅ registration-page rewrite (`/v3/registration*/...`) | ✅ `403` on `.nupkg` download |
+| **nuget** | ✅ registration-page rewrite (`/v3/registration*/...`) + flat-container index via registration lookup | ✅ `403` on `.nupkg` download |
 
-The legacy HTML Simple index (pypi) and flat-container index (nuget)
-carry no publish time inline, so they still pass through unchanged;
-pinned fetches downstream fail hard at the tarball layer.
+The legacy HTML Simple index (pypi) still passes through unchanged
+(no inline publish time); pinned fetches downstream fail hard at the
+tarball layer.
 
 ---
 
@@ -771,9 +771,9 @@ Honest assessment. Full details in [CLAUDE.md](CLAUDE.md).
   require a separate JSON lookup. Pinned fetches downstream on
   `files.pythonhosted.org` still hard-deny. Modern pip/uv prefer
   the JSON endpoints anyway.
-- **nuget flat-container index** (`/v3-flatcontainer/<id>/index.json`)
-  is also passed through — same reason, dates live in the
-  registration endpoint. Pinned `.nupkg` fetches still hard-deny.
+<!-- nuget flat-container is now silently filtered via an out-of-band
+     registration-endpoint lookup (cached in-proxy for 10 min). No
+     limitation to document here anymore. -->
 - **Sigstore bundle verification** (not just claim presence) is a
   roadmap item. `--require-provenance` currently checks that the
   `dist.attestations.provenance.predicateType` field is non-empty,

--- a/crates/coronarium-proxy/Cargo.toml
+++ b/crates/coronarium-proxy/Cargo.toml
@@ -32,3 +32,10 @@ http = "1"
 http-body-util = "0.1"
 bytes = "1"
 semver = "1"
+
+# Sigstore bundle parsing + semantic verification (P0-1 stage 1).
+# Crypto verification (DSSE signature, Fulcio cert chain, Rekor SET)
+# is the next stage and will introduce p256 / x509-parser / ed25519
+# deps. We keep this list intentionally small for now.
+base64 = "0.22"
+sha2 = "0.10"

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rewrite;
 pub mod rewrite_npm;
 pub mod rewrite_nuget;
 pub mod rewrite_pypi;
+pub mod sigstore_verify;
 pub mod typosquat;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ca;
 pub mod daemon;
 pub mod decision;
 pub mod install;
+pub mod nuget_flatcontainer_client;
 pub mod osv;
 pub mod osv_mirror;
 pub mod parser;
@@ -24,5 +25,8 @@ pub use parser::{
 pub use proxy::{ProxyConfig, run};
 pub use rewrite::{RewriteStats, rewrite_crates_index_jsonl};
 pub use rewrite_npm::{NpmRewriteStats, rewrite_npm_packument};
-pub use rewrite_nuget::{NugetRewriteStats, rewrite_nuget_registration};
+pub use rewrite_nuget::{
+    NugetRewriteStats, extract_publish_times_from_registration, rewrite_nuget_flatcontainer,
+    rewrite_nuget_registration,
+};
 pub use rewrite_pypi::{PypiRewriteStats, rewrite_pypi_json_api, rewrite_pypi_simple_json};

--- a/crates/coronarium-proxy/src/nuget_flatcontainer_client.rs
+++ b/crates/coronarium-proxy/src/nuget_flatcontainer_client.rs
@@ -1,0 +1,364 @@
+//! Out-of-band lookup that gives the flat-container rewriter the
+//! publish times it needs.
+//!
+//! The flat-container endpoint (`/v3-flatcontainer/<id>/index.json`)
+//! is a plain `{"versions":[…]}` with no dates. The registration
+//! endpoint (`/v3/registration5-semver1/<id>/index.json`) has the
+//! dates. This module fetches the latter, walks the index (following
+//! separate-URL page references when necessary), and hands back a
+//! `version → published` map.
+//!
+//! Cache policy: per-package-id, populated lazily, kept in-memory
+//! for the lifetime of the proxy. NuGet's registration data only
+//! gains new versions over time, so a stale cache entry can cause
+//! us to miss *new* young versions (false-negative — we'd let
+//! through a too-young version we should have filtered). To bound
+//! that window we expire cache entries after `CACHE_TTL`. Pinned
+//! `.nupkg` fetches still hard-deny at the tarball layer when our
+//! cache is stale, so the worst case is "user sees a too-young
+//! version in the index but install still fails when cargo/dotnet
+//! tries to fetch the nupkg".
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use crate::rewrite_nuget::extract_publish_times_from_registration;
+
+/// Max lifetime of a cached registration lookup. 10 minutes is long
+/// enough that a typical CI run doesn't re-fetch for every package
+/// but short enough that newly-published versions become visible in
+/// the silent-fallback filter within the same day.
+const CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+
+/// Bound the number of page-reference fetches we'll chase per lookup.
+/// Real packages have 1–3 pages; a pathological registry document
+/// pointing at thousands of pages should not stall the proxy.
+const MAX_PAGES_PER_LOOKUP: usize = 16;
+
+/// One URL base per registration family. We only need semver1
+/// (non-gz) for MVP — nuget serves the same data across families and
+/// dotnet / nuget.exe pull from this base by default.
+const REGISTRATION_BASE: &str = "https://api.nuget.org/v3/registration5-semver1";
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    data: Arc<HashMap<String, DateTime<Utc>>>,
+    fetched: Instant,
+}
+
+/// Thread-safe lookup client. Clone-cheap: internally Arc-wrapped.
+#[derive(Clone)]
+pub struct NugetFlatContainerClient {
+    inner: Arc<Inner>,
+}
+
+type FetchFn = dyn Fn(&str) -> Result<Vec<u8>, String> + Send + Sync;
+
+struct Inner {
+    cache: Mutex<HashMap<String, CacheEntry>>,
+    user_agent: String,
+    /// Fetch hook — `None` means real network (ureq). Injected in tests
+    /// so we can stub responses without mocking the HTTP stack.
+    fetcher: Box<FetchFn>,
+}
+
+impl NugetFlatContainerClient {
+    /// Real-network constructor. Uses `ureq` on a `spawn_blocking`
+    /// worker when called from async context (see [`Self::lookup`]).
+    pub fn new(user_agent: impl Into<String>) -> Self {
+        let ua = user_agent.into();
+        let ua_for_fetch = ua.clone();
+        Self {
+            inner: Arc::new(Inner {
+                cache: Mutex::new(HashMap::new()),
+                user_agent: ua,
+                fetcher: Box::new(move |url| fetch_blocking(url, &ua_for_fetch)),
+            }),
+        }
+    }
+
+    /// Test constructor — pass any closure that maps URL → response
+    /// body bytes (or error message). Bypasses the network entirely.
+    #[cfg(test)]
+    pub fn with_fetcher<F>(fetcher: F) -> Self
+    where
+        F: Fn(&str) -> Result<Vec<u8>, String> + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(Inner {
+                cache: Mutex::new(HashMap::new()),
+                user_agent: "test".into(),
+                fetcher: Box::new(fetcher),
+            }),
+        }
+    }
+
+    /// Return the cached publish-times map for `package_id`, fetching
+    /// from the registration endpoint when the cache is empty or
+    /// stale. On network failure returns an empty map (callers treat
+    /// it as "no data → fail-open" inside the flat-container filter).
+    pub async fn lookup(&self, package_id: &str) -> Arc<HashMap<String, DateTime<Utc>>> {
+        if let Some(cached) = self.get_fresh(package_id) {
+            return cached;
+        }
+
+        // Refresh. Done on a blocking pool because the underlying
+        // fetch is sync (ureq). For the test fetcher this is still
+        // correct — spawn_blocking runs the closure on a worker.
+        let client = self.clone();
+        let id = package_id.to_ascii_lowercase();
+        let map = tokio::task::spawn_blocking(move || client.refresh_now(&id))
+            .await
+            .unwrap_or_default();
+        let arc = Arc::new(map);
+        self.put(package_id, Arc::clone(&arc));
+        arc
+    }
+
+    /// Blocking sibling of [`Self::lookup`]. Tests call this directly.
+    pub fn lookup_blocking(&self, package_id: &str) -> Arc<HashMap<String, DateTime<Utc>>> {
+        if let Some(cached) = self.get_fresh(package_id) {
+            return cached;
+        }
+        let id = package_id.to_ascii_lowercase();
+        let arc = Arc::new(self.refresh_now(&id));
+        self.put(package_id, Arc::clone(&arc));
+        arc
+    }
+
+    fn get_fresh(&self, id: &str) -> Option<Arc<HashMap<String, DateTime<Utc>>>> {
+        let key = id.to_ascii_lowercase();
+        let cache = self.inner.cache.lock().ok()?;
+        let entry = cache.get(&key)?;
+        if entry.fetched.elapsed() < CACHE_TTL {
+            Some(Arc::clone(&entry.data))
+        } else {
+            None
+        }
+    }
+
+    fn put(&self, id: &str, data: Arc<HashMap<String, DateTime<Utc>>>) {
+        let key = id.to_ascii_lowercase();
+        if let Ok(mut cache) = self.inner.cache.lock() {
+            cache.insert(
+                key,
+                CacheEntry {
+                    data,
+                    fetched: Instant::now(),
+                },
+            );
+        }
+    }
+
+    fn refresh_now(&self, package_id_lower: &str) -> HashMap<String, DateTime<Utc>> {
+        let index_url = format!("{REGISTRATION_BASE}/{package_id_lower}/index.json");
+        let body = match (self.inner.fetcher)(&index_url) {
+            Ok(b) => b,
+            Err(e) => {
+                log::debug!("nuget-flat: registration fetch failed for {package_id_lower}: {e}");
+                return HashMap::new();
+            }
+        };
+        let mut map = extract_publish_times_from_registration(&body);
+
+        // Follow page references that didn't carry inline items. Bounded.
+        let pages = collect_page_urls(&body);
+        for url in pages.into_iter().take(MAX_PAGES_PER_LOOKUP) {
+            match (self.inner.fetcher)(&url) {
+                Ok(page_body) => {
+                    for (k, v) in extract_publish_times_from_registration(&page_body) {
+                        map.entry(k).or_insert(v);
+                    }
+                }
+                Err(e) => {
+                    log::debug!("nuget-flat: page fetch failed for {url}: {e}");
+                }
+            }
+        }
+        map
+    }
+
+    /// Exposed for logs / tests.
+    pub fn user_agent(&self) -> &str {
+        &self.inner.user_agent
+    }
+}
+
+fn collect_page_urls(body: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    let Ok(doc): Result<Value, _> = serde_json::from_slice(body) else {
+        return out;
+    };
+    let Some(items) = doc.get("items").and_then(Value::as_array) else {
+        return out;
+    };
+    for it in items {
+        // A page-reference-only entry has `@id` but no inline `items`.
+        let has_inline_items = it.get("items").is_some();
+        if has_inline_items {
+            continue;
+        }
+        if let Some(url) = it.get("@id").and_then(Value::as_str) {
+            out.push(url.to_string());
+        }
+    }
+    out
+}
+
+fn fetch_blocking(url: &str, ua: &str) -> Result<Vec<u8>, String> {
+    let resp = ureq::get(url)
+        .set("user-agent", ua)
+        .set("accept", "application/json")
+        .timeout(Duration::from_millis(3000))
+        .call()
+        .map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
+    Ok(buf)
+}
+
+use std::io::Read as _;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn leaf(version: &str, published: &str) -> Value {
+        json!({
+            "@id": format!("https://api.nuget.org/v3/registration5-semver1/pkg/{version}.json"),
+            "catalogEntry": {
+                "id": "Pkg",
+                "version": version,
+                "published": published
+            }
+        })
+    }
+
+    fn paged_index(leaves: &[(&str, &str)]) -> Vec<u8> {
+        serde_json::to_vec(&json!({
+            "count": 1,
+            "items": [{
+                "count": leaves.len(),
+                "items": leaves.iter().map(|(v,t)| leaf(v,t)).collect::<Vec<_>>()
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn lookup_hits_registration_endpoint_and_returns_publish_times() {
+        let client = NugetFlatContainerClient::with_fetcher(|url| {
+            assert!(url.contains("/registration5-semver1/newtonsoft.json/index.json"));
+            Ok(paged_index(&[
+                ("1.0.0", "2024-01-01T00:00:00Z"),
+                ("1.1.0", "2024-06-01T00:00:00Z"),
+            ]))
+        });
+        let map = client.lookup_blocking("Newtonsoft.Json");
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("1.0.0"));
+        assert!(map.contains_key("1.1.0"));
+    }
+
+    #[test]
+    fn lookup_caches_subsequent_calls() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        let client = NugetFlatContainerClient::with_fetcher(move |_url| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            Ok(paged_index(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+        });
+        let _ = client.lookup_blocking("pkg");
+        let _ = client.lookup_blocking("pkg");
+        let _ = client.lookup_blocking("PKG"); // case-insensitive hit
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn lookup_network_failure_returns_empty_map_and_caches_it() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        let client = NugetFlatContainerClient::with_fetcher(move |_url| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            Err("connection refused".into())
+        });
+        let map = client.lookup_blocking("pkg");
+        assert!(map.is_empty());
+        // Still cached so we don't hammer a dead registry.
+        let _ = client.lookup_blocking("pkg");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn lookup_follows_page_references_and_merges() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        let client = NugetFlatContainerClient::with_fetcher(move |url| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            if url.ends_with("/index.json") {
+                // Index references two pages without inline items.
+                Ok(serde_json::to_vec(&json!({
+                    "items": [
+                        { "@id": "https://api.nuget.org/page1.json", "lower": "1.0.0", "upper": "1.9.9" },
+                        { "@id": "https://api.nuget.org/page2.json", "lower": "2.0.0", "upper": "2.9.9" }
+                    ]
+                }))
+                .unwrap())
+            } else if url.contains("page1") {
+                Ok(paged_index(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+            } else if url.contains("page2") {
+                Ok(paged_index(&[("2.0.0", "2024-06-01T00:00:00Z")]))
+            } else {
+                Err(format!("unexpected url {url}"))
+            }
+        });
+        let map = client.lookup_blocking("pkg");
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("1.0.0"));
+        assert!(map.contains_key("2.0.0"));
+        assert_eq!(hits.load(Ordering::SeqCst), 3); // index + 2 pages
+    }
+
+    #[test]
+    fn lookup_bounds_page_fetches() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        // Build an index claiming 1000 separate pages; we should only
+        // fetch MAX_PAGES_PER_LOOKUP of them.
+        let client = NugetFlatContainerClient::with_fetcher(move |url| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            if url.ends_with("/index.json") {
+                let items: Vec<Value> = (0..1000)
+                    .map(|i| json!({ "@id": format!("https://api.nuget.org/p{i}.json") }))
+                    .collect();
+                Ok(serde_json::to_vec(&json!({ "items": items })).unwrap())
+            } else {
+                Ok(paged_index(&[]))
+            }
+        });
+        let _ = client.lookup_blocking("pkg");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1 + MAX_PAGES_PER_LOOKUP,
+            "should stop at MAX_PAGES_PER_LOOKUP"
+        );
+    }
+
+    #[tokio::test]
+    async fn async_lookup_uses_blocking_executor() {
+        let client = NugetFlatContainerClient::with_fetcher(|_| {
+            Ok(paged_index(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+        });
+        let map = client.lookup("pkg").await;
+        assert_eq!(map.len(), 1);
+    }
+}

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -20,10 +20,11 @@ use hudsucker::{
 
 use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
+use crate::nuget_flatcontainer_client::NugetFlatContainerClient;
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
 use crate::rewrite::rewrite_crates_index_jsonl;
 use crate::rewrite_npm::{NpmRewriteOptions, rewrite_npm_packument_with};
-use crate::rewrite_nuget::rewrite_nuget_registration;
+use crate::rewrite_nuget::{rewrite_nuget_flatcontainer, rewrite_nuget_registration};
 use crate::rewrite_pypi::{rewrite_pypi_json_api, rewrite_pypi_simple_json};
 
 pub struct ProxyConfig {
@@ -180,6 +181,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         last_host: None,
         last_path: None,
         require_provenance: cfg.require_provenance,
+        nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -224,6 +226,10 @@ struct CoronariumHandler {
     /// Forwarded from [`ProxyConfig::require_provenance`]. Consulted
     /// by the npm rewrite path.
     require_provenance: bool,
+    /// Looks up per-package publish times from the registration
+    /// endpoint so we can silently filter the flat-container index
+    /// (which has no dates inline).
+    nuget_flat: NugetFlatContainerClient,
 }
 
 impl HttpHandler for CoronariumHandler {
@@ -405,6 +411,27 @@ impl HttpHandler for CoronariumHandler {
                 }
                 out
             }
+            RewriteTarget::NugetFlatContainerIndex(id) => {
+                // Look up publish times from the registration endpoint.
+                // Cached per package; a failed lookup yields an empty
+                // map which makes the filter fail-open (pinned `.nupkg`
+                // fetches still hard-deny at the tarball layer, so
+                // fail-open doesn't silently admit young versions into
+                // a build).
+                let oracle = self.nuget_flat.lookup(&id).await;
+                let (out, stats) =
+                    rewrite_nuget_flatcontainer(&collected, self.decider.min_age, now, |v| {
+                        oracle.get(v).copied()
+                    });
+                if stats.dropped > 0 {
+                    log::info!(
+                        "nuget-flat: dropped {} version(s), kept {} for {id}",
+                        stats.dropped,
+                        stats.kept
+                    );
+                }
+                out
+            }
         };
 
         // Strip Content-Length so hyper recomputes it from the new body.
@@ -416,13 +443,18 @@ impl HttpHandler for CoronariumHandler {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum RewriteTarget {
     CratesSparse,
     NpmPackument,
     PypiJsonApi,
     PypiSimpleJson,
     NugetRegistration,
+    /// Flat-container index (`/v3-flatcontainer/<id>/index.json`).
+    /// The String is the lower-cased package id, captured here so the
+    /// handler can feed it to the out-of-band registration fetcher
+    /// without re-parsing the path.
+    NugetFlatContainerIndex(String),
 }
 
 /// Match the in-flight `(host, path)` to a rewriter. Returning `None`
@@ -453,10 +485,30 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
             return Some(RewriteTarget::PypiSimpleJson);
         }
     }
-    if host.eq_ignore_ascii_case("api.nuget.org") && is_nuget_registration_path(path) {
-        return Some(RewriteTarget::NugetRegistration);
+    if host.eq_ignore_ascii_case("api.nuget.org") {
+        if is_nuget_registration_path(path) {
+            return Some(RewriteTarget::NugetRegistration);
+        }
+        if let Some(id) = parse_nuget_flatcontainer_index_path(path) {
+            return Some(RewriteTarget::NugetFlatContainerIndex(id));
+        }
     }
     None
+}
+
+/// NuGet flat-container index: `/v3-flatcontainer/<id>/index.json`.
+/// The body is a `{"versions":[…]}` with no timestamps; we look them
+/// up out-of-band from the registration endpoint. Returns the lower-
+/// cased package id on match, `None` otherwise.
+fn parse_nuget_flatcontainer_index_path(path: &str) -> Option<String> {
+    let path = path.split('?').next().unwrap_or(path);
+    let rest = path.strip_prefix("/v3-flatcontainer/")?;
+    // Expect exactly `<id>/index.json`.
+    let (id, tail) = rest.split_once('/')?;
+    if id.is_empty() || tail != "index.json" {
+        return None;
+    }
+    Some(id.to_ascii_lowercase())
 }
 
 /// NuGet registration endpoints:
@@ -620,6 +672,40 @@ mod tests {
     }
 
     #[test]
+    fn parse_nuget_flatcontainer_index_path_is_lenient_on_casing() {
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path("/v3-flatcontainer/Newtonsoft.Json/index.json"),
+            Some("newtonsoft.json".into())
+        );
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path("/v3-flatcontainer/serilog/index.json"),
+            Some("serilog".into())
+        );
+        // Not an index.json — `.nupkg` or a version directory.
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path(
+                "/v3-flatcontainer/serilog/3.0.0/serilog.3.0.0.nupkg"
+            ),
+            None
+        );
+        // Registration endpoint — different path family.
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path("/v3/registration5-semver1/serilog/index.json"),
+            None
+        );
+        // Empty id.
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path("/v3-flatcontainer//index.json"),
+            None
+        );
+        // Query string tolerated.
+        assert_eq!(
+            parse_nuget_flatcontainer_index_path("/v3-flatcontainer/pkg/index.json?ts=1"),
+            Some("pkg".into())
+        );
+    }
+
+    #[test]
     fn classify_response_routes_to_correct_rewriter() {
         assert_eq!(
             classify_response(Some("index.crates.io"), Some("/anything")),
@@ -655,11 +741,22 @@ mod tests {
             ),
             Some(RewriteTarget::NugetRegistration)
         );
-        // NuGet flat-container is NOT rewritten yet.
+        // NuGet flat-container index: handled via registration lookup.
         assert_eq!(
             classify_response(
                 Some("api.nuget.org"),
                 Some("/v3-flatcontainer/newtonsoft.json/index.json")
+            ),
+            Some(RewriteTarget::NugetFlatContainerIndex(
+                "newtonsoft.json".into()
+            ))
+        );
+        // Pinned `.nupkg` fetches under flat-container still fall
+        // through to the pin decider — not rewritten here.
+        assert_eq!(
+            classify_response(
+                Some("api.nuget.org"),
+                Some("/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg")
             ),
             None
         );

--- a/crates/coronarium-proxy/src/rewrite_nuget.rs
+++ b/crates/coronarium-proxy/src/rewrite_nuget.rs
@@ -19,12 +19,21 @@
 //! `catalogEntry.published` is younger than `min_age`, and fix up
 //! the `count` field so it stays consistent.
 //!
-//! Flat-container (`/v3-flatcontainer/<id>/index.json`) has no dates
-//! inline, so it's NOT rewritten here. dotnet restore paths through
-//! flat-container for nupkg download still hit the existing
-//! tarball-level deny — fail-hard, not silent. Silent fallback for
-//! flat-container is a roadmap item.
+//! Flat-container (`/v3-flatcontainer/<id>/index.json`) carries **no
+//! dates inline** (`{"versions":[...]}`), so filtering it silently
+//! requires borrowing publish times from the registration endpoint
+//! out-of-band. This module exposes:
+//!
+//! - [`rewrite_nuget_flatcontainer`] — pure filter that takes a
+//!   version→published oracle (tests pass a HashMap, production
+//!   wires a cached registration-index fetcher).
+//! - [`extract_publish_times_from_registration`] — parses a fetched
+//!   registration index into the HashMap that oracle expects.
+//!
+//! Proxy-level wiring (which actually issues the registration
+//! request + caches it per package) lives in `proxy.rs`.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -118,6 +127,120 @@ fn filter_items_recursively(
         // downstream consumers don't see a stale length.
         if let Some(count) = obj.get_mut("count") {
             *count = Value::Number(serde_json::Number::from(new_count));
+        }
+    }
+}
+
+/// Rewrite a NuGet flat-container `/v3-flatcontainer/<id>/index.json`
+/// body. The document is a plain `{"versions": ["1.0.0", …]}` with no
+/// timestamps, so the caller supplies a `publish_time` oracle (usually
+/// built by parsing the package's registration index, see
+/// [`extract_publish_times_from_registration`]).
+///
+/// Semantics match the other rewriters:
+///
+/// - Versions whose oracle-returned publish time is younger than
+///   `min_age` are dropped.
+/// - Versions the oracle doesn't know about are **kept** (fail-open).
+///   The registration index is authoritative; a missing entry usually
+///   means the registration lookup was flaky, and we'd rather not
+///   brick installs over a transient registry hiccup. Pinned `.nupkg`
+///   fetches to denied versions are still hard-denied at the tarball
+///   layer, so an attacker can't game this to get a too-young version
+///   through.
+/// - Parse failure / non-matching shape → pass-through unchanged.
+pub fn rewrite_nuget_flatcontainer<F>(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+    publish_time: F,
+) -> (Vec<u8>, NugetRewriteStats)
+where
+    F: Fn(&str) -> Option<DateTime<Utc>>,
+{
+    let mut stats = NugetRewriteStats::default();
+    let mut doc: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("nuget-flatcontainer: pass-through, parse failed: {e}");
+            return (body.to_vec(), stats);
+        }
+    };
+
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+
+    let Some(versions) = doc.get_mut("versions").and_then(Value::as_array_mut) else {
+        return (body.to_vec(), stats);
+    };
+
+    versions.retain(|v| {
+        let Some(ver) = v.as_str() else {
+            // unparseable entry — keep, don't stamp stats
+            return true;
+        };
+        match publish_time(ver) {
+            Some(published) => {
+                let keep = (now - published) >= cutoff;
+                if keep {
+                    stats.kept += 1;
+                } else {
+                    stats.dropped += 1;
+                }
+                keep
+            }
+            None => {
+                // Unknown — fail-open. Still counts as kept for logging.
+                stats.kept += 1;
+                true
+            }
+        }
+    });
+
+    let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
+    (out, stats)
+}
+
+/// Walk a NuGet registration-index JSON body and extract a map
+/// `version → publish time`. Only inline leaves are read — pages that
+/// carry only a separate-URL reference (no inline `items`) are
+/// skipped; the caller should fetch those pages and call this helper
+/// again, merging the results.
+///
+/// Tolerant to unexpected shapes: anything that doesn't match leaves
+/// the map unchanged for that entry.
+pub fn extract_publish_times_from_registration(body: &[u8]) -> HashMap<String, DateTime<Utc>> {
+    let mut out = HashMap::new();
+    let Ok(doc): Result<Value, _> = serde_json::from_slice(body) else {
+        return out;
+    };
+    collect_publish_times(&doc, &mut out);
+    out
+}
+
+fn collect_publish_times(v: &Value, out: &mut HashMap<String, DateTime<Utc>>) {
+    let Some(items) = v.get("items").and_then(Value::as_array) else {
+        return;
+    };
+    for it in items {
+        if let Some(entry) = it.get("catalogEntry") {
+            let Some(version) = entry.get("version").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(published) = entry.get("published").and_then(Value::as_str) else {
+                continue;
+            };
+            let Ok(dt) = DateTime::parse_from_rfc3339(published) else {
+                continue;
+            };
+            // NuGet uses `0001-01-01T00:00:00Z` as a sentinel for
+            // "unlisted" — those we treat as unknown (skip).
+            let dt_utc = dt.with_timezone(&Utc);
+            if dt_utc.timestamp() <= 0 {
+                continue;
+            }
+            out.insert(version.to_string(), dt_utc);
+        } else if it.get("items").is_some() {
+            collect_publish_times(it, out);
         }
     }
 }
@@ -251,6 +374,176 @@ mod tests {
         let (_, stats) = rewrite_nuget_registration(body.as_bytes(), min_age_hours(168), now);
         assert_eq!(stats.dropped, 1);
         assert_eq!(stats.kept, 1);
+    }
+
+    // ---------- flat-container tests ----------
+
+    fn flatcontainer(versions: &[&str]) -> String {
+        serde_json::to_string(&serde_json::json!({ "versions": versions })).unwrap()
+    }
+
+    fn oracle_from(pairs: &[(&str, &str)]) -> HashMap<String, DateTime<Utc>> {
+        pairs
+            .iter()
+            .map(|(v, t)| {
+                let dt = DateTime::parse_from_rfc3339(t).unwrap().with_timezone(&Utc);
+                ((*v).to_string(), dt)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn flatcontainer_drops_versions_whose_oracle_says_too_young() {
+        let now = utc(2025, 1, 10);
+        let body = flatcontainer(&["1.0.0", "1.1.0", "2.0.0"]);
+        let oracle = oracle_from(&[
+            ("1.0.0", "2024-01-01T00:00:00Z"),
+            ("1.1.0", "2024-06-01T00:00:00Z"),
+            ("2.0.0", "2025-01-09T23:00:00Z"), // too young
+        ]);
+        let (out, stats) =
+            rewrite_nuget_flatcontainer(body.as_bytes(), min_age_hours(168), now, |v| {
+                oracle.get(v).copied()
+            });
+        let doc = parse(&out);
+        let vs: Vec<&str> = doc["versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(vs, vec!["1.0.0", "1.1.0"]);
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 2);
+    }
+
+    #[test]
+    fn flatcontainer_unknown_versions_are_kept_fail_open() {
+        let now = utc(2025, 1, 10);
+        let body = flatcontainer(&["1.0.0", "2.0.0"]);
+        // oracle has nothing — treat everything as unknown.
+        let (out, stats) =
+            rewrite_nuget_flatcontainer(body.as_bytes(), min_age_hours(168), now, |_| None);
+        let doc = parse(&out);
+        assert_eq!(doc["versions"].as_array().unwrap().len(), 2);
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 2);
+    }
+
+    #[test]
+    fn flatcontainer_malformed_body_passes_through() {
+        let now = utc(2025, 1, 10);
+        let (out, stats) =
+            rewrite_nuget_flatcontainer(b"not json", min_age_hours(168), now, |_| None);
+        assert_eq!(out, b"not json");
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn flatcontainer_missing_versions_key_is_pass_through() {
+        // Some edge / error responses omit the `versions` array. We
+        // should not mangle those.
+        let now = utc(2025, 1, 10);
+        let body = br#"{"other": []}"#;
+        let (out, stats) = rewrite_nuget_flatcontainer(body, min_age_hours(168), now, |_| None);
+        let before: Value = serde_json::from_slice(body).unwrap();
+        let after: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(before, after);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn flatcontainer_empty_versions_list_is_passthrough() {
+        let now = utc(2025, 1, 10);
+        let body = flatcontainer(&[]);
+        let (out, stats) =
+            rewrite_nuget_flatcontainer(body.as_bytes(), min_age_hours(168), now, |_| None);
+        let doc = parse(&out);
+        assert_eq!(doc["versions"].as_array().unwrap().len(), 0);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn extract_publish_times_walks_inline_leaves() {
+        let body = paged_index(&[
+            ("1.0.0", "2024-01-01T00:00:00Z"),
+            ("1.1.0", "2024-06-01T00:00:00Z"),
+            ("2.0.0", "2025-01-09T23:00:00Z"),
+        ]);
+        let map = extract_publish_times_from_registration(body.as_bytes());
+        assert_eq!(map.len(), 3);
+        assert!(map.contains_key("1.0.0"));
+        assert!(map.contains_key("2.0.0"));
+    }
+
+    #[test]
+    fn extract_publish_times_skips_page_references() {
+        // Page with no inline items — our helper skips it; caller must
+        // fetch the separate page URL and merge.
+        let body = serde_json::to_string(&serde_json::json!({
+            "items": [{
+                "@id": "https://api.nuget.org/v3/registration5-semver1/pkg/page/1.0.0/9.9.9.json",
+                "lower": "1.0.0",
+                "upper": "9.9.9"
+            }]
+        }))
+        .unwrap();
+        let map = extract_publish_times_from_registration(body.as_bytes());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn extract_publish_times_ignores_unlisted_sentinel() {
+        // NuGet marks unlisted packages with the epoch-zero date
+        // `0001-01-01T00:00:00+00:00`. We treat those as unknown so
+        // the fail-open branch kicks in.
+        let body = serde_json::to_string(&serde_json::json!({
+            "items": [{
+                "items": [{
+                    "catalogEntry": {
+                        "version": "1.0.0-unlisted",
+                        "published": "0001-01-01T00:00:00+00:00"
+                    }
+                }]
+            }]
+        }))
+        .unwrap();
+        let map = extract_publish_times_from_registration(body.as_bytes());
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn extract_publish_times_tolerates_garbage() {
+        let map = extract_publish_times_from_registration(b"not json");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn flatcontainer_end_to_end_with_extracted_oracle() {
+        // Simulate the real proxy path: fetch registration body,
+        // extract times, filter flat-container with it.
+        let now = utc(2025, 1, 10);
+        let registration = paged_index(&[
+            ("1.0.0", "2024-01-01T00:00:00Z"),
+            ("1.1.0", "2024-06-01T00:00:00Z"),
+            ("2.0.0", "2025-01-09T23:00:00Z"), // too young
+        ]);
+        let oracle = extract_publish_times_from_registration(registration.as_bytes());
+
+        let flat = flatcontainer(&["1.0.0", "1.1.0", "2.0.0"]);
+        let (out, stats) =
+            rewrite_nuget_flatcontainer(flat.as_bytes(), min_age_hours(168), now, |v| {
+                oracle.get(v).copied()
+            });
+        let doc = parse(&out);
+        let vs: Vec<&str> = doc["versions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert_eq!(vs, vec!["1.0.0", "1.1.0"]);
+        assert_eq!(stats.dropped, 1);
     }
 
     #[test]

--- a/crates/coronarium-proxy/src/sigstore_verify.rs
+++ b/crates/coronarium-proxy/src/sigstore_verify.rs
@@ -1,0 +1,533 @@
+//! Sigstore bundle verification — stage 1 of 2.
+//!
+//! # What this module does today (semantic layer)
+//!
+//! npm attestations API returns a Sigstore bundle per published
+//! version. The bundle wraps a DSSE envelope whose payload is an
+//! in-toto v1 statement. This module:
+//!
+//! 1. Parses the bundle JSON (both the `v0.2` and `v0.3` media types).
+//! 2. Base64-decodes the DSSE payload into an in-toto statement.
+//! 3. Asserts `subject[0].digest.sha512` matches the npm-reported
+//!    `dist.integrity` (SHA-512 of the tarball).
+//! 4. Asserts `predicateType == https://slsa.dev/provenance/v1`.
+//! 5. Applies a small built-in policy on `predicate.buildDefinition`
+//!    (builder id must be a recognised OIDC-backed CI).
+//!
+//! Catching a subject-digest mismatch alone closes a real gap: the
+//! "attacker steals a publish token, publishes a malicious tarball,
+//! and attaches an attestation from an unrelated build" attack. npm
+//! enforces digest matching at publish time, so any mismatch we see
+//! means the bundle was re-used from a different artifact.
+//!
+//! # What this module does NOT do yet (crypto layer — stage 2)
+//!
+//! - DSSE signature verification with the Fulcio-issued ephemeral key.
+//! - Fulcio certificate chain validation against the Sigstore trust
+//!   root.
+//! - Rekor SET (Signed Entry Timestamp) / inclusion-proof verification.
+//!
+//! Those require embedding the Sigstore public-good trust root and
+//! pulling in ECDSA + X.509 crates. Tracked as P0-1b.
+//!
+//! Everything here is pure (no IO) and synchronous — the proxy's
+//! rewrite path calls it with an already-fetched bundle body.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha512};
+
+/// Every failure reason the verifier can produce. Structured so the
+/// proxy can bucket stats cleanly and the user sees *why* a given
+/// version was dropped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyError {
+    /// Bundle JSON didn't parse at all, or the expected fields were
+    /// missing. Forwarded as "cannot trust".
+    Malformed(String),
+    /// DSSE payload base64 decode failed.
+    PayloadDecode(String),
+    /// DSSE payload wasn't a JSON in-toto statement.
+    PayloadShape(String),
+    /// `subject[0].digest.sha512` didn't match the tarball integrity
+    /// the npm packument advertised. Strong evidence of a stolen
+    /// token + reused attestation.
+    SubjectDigestMismatch {
+        expected_sha512_hex: String,
+        actual_sha512_hex: String,
+    },
+    /// `predicateType` wasn't an accepted SLSA provenance URI.
+    UnexpectedPredicateType(String),
+    /// The builder identity doesn't match any allowlisted OIDC
+    /// issuer. Configurable in a later revision; hardcoded for now.
+    DisallowedBuilder(String),
+}
+
+impl std::fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(m) => write!(f, "malformed bundle: {m}"),
+            Self::PayloadDecode(m) => write!(f, "DSSE payload base64 decode failed: {m}"),
+            Self::PayloadShape(m) => write!(f, "DSSE payload shape error: {m}"),
+            Self::SubjectDigestMismatch {
+                expected_sha512_hex,
+                actual_sha512_hex,
+            } => write!(
+                f,
+                "subject digest mismatch: expected sha512={expected_sha512_hex}, attestation sha512={actual_sha512_hex}"
+            ),
+            Self::UnexpectedPredicateType(t) => write!(f, "unexpected predicateType {t}"),
+            Self::DisallowedBuilder(b) => write!(f, "builder {b} not in allowlist"),
+        }
+    }
+}
+
+impl std::error::Error for VerifyError {}
+
+/// Parsed, semantically-validated provenance statement. The crypto
+/// layer (P0-1b) will add a `verified_by: CertIdentity` field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedProvenance {
+    pub predicate_type: String,
+    pub subject_name: String,
+    pub subject_sha512_hex: String,
+    pub builder_id: String,
+    /// The raw in-toto statement JSON, kept so callers can surface
+    /// fields without re-parsing.
+    pub statement: Value,
+}
+
+/// Accepted SLSA provenance predicate types. v1 is what npm /
+/// GitHub publish; v0.2 still shows up in older bundles.
+const ACCEPTED_PREDICATE_TYPES: &[&str] = &[
+    "https://slsa.dev/provenance/v1",
+    "https://slsa.dev/provenance/v0.2",
+];
+
+/// Allowlisted `builder.id` prefixes. An attacker who manages to get
+/// *some* Sigstore bundle attached to a stolen-token publish will
+/// trip this unless they also control one of these CI surfaces and
+/// can pass the subject-digest check — which is a much larger
+/// attack than "stole an npm token".
+const ALLOWED_BUILDER_PREFIXES: &[&str] = &[
+    "https://github.com/actions/runner/",
+    "https://github.com/slsa-framework/",
+    "https://gitlab.com/",
+];
+
+/// npm attestations API returns a JSON document of this shape:
+///
+/// ```json
+/// {
+///   "attestations": [
+///     { "predicateType": "...", "bundle": { …sigstore bundle… } }
+///   ]
+/// }
+/// ```
+///
+/// Pick the first attestation whose `predicateType` is SLSA
+/// provenance and hand back its `bundle`.
+pub fn pick_slsa_bundle(attestations_body: &[u8]) -> Result<Value, VerifyError> {
+    let doc: Value = serde_json::from_slice(attestations_body)
+        .map_err(|e| VerifyError::Malformed(format!("attestations JSON: {e}")))?;
+    let list = doc
+        .get("attestations")
+        .and_then(Value::as_array)
+        .ok_or_else(|| VerifyError::Malformed("no `attestations` array".into()))?;
+    for att in list {
+        let pt = att
+            .get("predicateType")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if ACCEPTED_PREDICATE_TYPES.contains(&pt)
+            && let Some(bundle) = att.get("bundle")
+        {
+            return Ok(bundle.clone());
+        }
+    }
+    Err(VerifyError::Malformed(
+        "no SLSA-provenance attestation in list".into(),
+    ))
+}
+
+/// Convert an npm `dist.integrity` string (`sha512-<base64>`) into the
+/// hex-encoded digest. Returns None for anything we don't recognise
+/// (e.g. a weaker `sha1-` prefix, which npm still emits for very old
+/// packages — callers should refuse to verify those and drop them).
+pub fn integrity_to_sha512_hex(integrity: &str) -> Option<String> {
+    let rest = integrity.strip_prefix("sha512-")?;
+    let raw = BASE64.decode(rest.as_bytes()).ok()?;
+    if raw.len() != 64 {
+        return None;
+    }
+    Some(hex_encode(&raw))
+}
+
+/// Verify a Sigstore bundle (already JSON-parsed) against the
+/// expected tarball integrity claim. Returns a
+/// [`VerifiedProvenance`] on success or a [`VerifyError`] variant
+/// explaining what failed.
+///
+/// `expected_integrity` is npm's `dist.integrity` string
+/// (`sha512-<base64>`); if it is missing or uses a non-sha512
+/// algorithm, the caller should drop the version before reaching
+/// us (we require sha512 for digest matching).
+pub fn verify_bundle_semantics(
+    bundle: &Value,
+    expected_integrity: &str,
+) -> Result<VerifiedProvenance, VerifyError> {
+    let expected_hex = integrity_to_sha512_hex(expected_integrity).ok_or_else(|| {
+        VerifyError::Malformed(format!(
+            "unsupported or malformed dist.integrity: {expected_integrity}"
+        ))
+    })?;
+
+    // Both bundle v0.2 and v0.3 place the DSSE envelope at the same
+    // JSON path; only the outer `mediaType` differs.
+    let dsse = bundle
+        .get("dsseEnvelope")
+        .ok_or_else(|| VerifyError::Malformed("bundle missing dsseEnvelope".into()))?;
+
+    let payload_b64 = dsse
+        .get("payload")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VerifyError::Malformed("dsseEnvelope.payload missing".into()))?;
+    let payload = BASE64
+        .decode(payload_b64.as_bytes())
+        .map_err(|e| VerifyError::PayloadDecode(e.to_string()))?;
+
+    // payloadType must be in-toto. DSSE allows other types in theory;
+    // for npm we expect exactly this.
+    let payload_type = dsse
+        .get("payloadType")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if payload_type != "application/vnd.in-toto+json" {
+        return Err(VerifyError::PayloadShape(format!(
+            "payloadType={payload_type}, expected application/vnd.in-toto+json"
+        )));
+    }
+
+    let statement: Value = serde_json::from_slice(&payload)
+        .map_err(|e| VerifyError::PayloadShape(format!("in-toto JSON: {e}")))?;
+
+    let predicate_type = statement
+        .get("predicateType")
+        .and_then(Value::as_str)
+        .ok_or_else(|| VerifyError::PayloadShape("no predicateType".into()))?
+        .to_string();
+    if !ACCEPTED_PREDICATE_TYPES.contains(&predicate_type.as_str()) {
+        return Err(VerifyError::UnexpectedPredicateType(predicate_type));
+    }
+
+    let subjects = statement
+        .get("subject")
+        .and_then(Value::as_array)
+        .ok_or_else(|| VerifyError::PayloadShape("no subject[]".into()))?;
+    let subject = subjects
+        .first()
+        .ok_or_else(|| VerifyError::PayloadShape("empty subject[]".into()))?;
+    let subject_name = subject
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let subject_sha512 = subject
+        .get("digest")
+        .and_then(|d| d.get("sha512"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| VerifyError::PayloadShape("no subject[0].digest.sha512".into()))?
+        .to_lowercase();
+
+    if subject_sha512 != expected_hex {
+        return Err(VerifyError::SubjectDigestMismatch {
+            expected_sha512_hex: expected_hex,
+            actual_sha512_hex: subject_sha512,
+        });
+    }
+
+    // Builder id. SLSA v1 path: predicate.runDetails.builder.id
+    // SLSA v0.2 path: predicate.builder.id. Try both.
+    let builder_id = statement
+        .pointer("/predicate/runDetails/builder/id")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            statement
+                .pointer("/predicate/builder/id")
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("")
+        .to_string();
+    if !ALLOWED_BUILDER_PREFIXES
+        .iter()
+        .any(|p| builder_id.starts_with(p))
+    {
+        return Err(VerifyError::DisallowedBuilder(builder_id));
+    }
+
+    Ok(VerifiedProvenance {
+        predicate_type,
+        subject_name,
+        subject_sha512_hex: subject_sha512,
+        builder_id,
+        statement,
+    })
+}
+
+/// Compute SHA-512 of a tarball byte slice and return the hex digest,
+/// for when the caller has the actual tarball in hand (e.g. proxy
+/// sees the `.tgz` response). Used by a future phase where we also
+/// catch divergence between the attestation and the bytes actually
+/// being served.
+pub fn sha512_hex(bytes: &[u8]) -> String {
+    hex_encode(&Sha512::digest(bytes))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Minimal typed view over the subset of the bundle we care about —
+/// useful for deserialise-and-dispatch callers. Kept `pub` so the
+/// crypto-layer (P0-1b) module can reuse it.
+#[derive(Debug, Deserialize)]
+pub struct BundleShape {
+    #[serde(rename = "mediaType")]
+    pub media_type: Option<String>,
+    #[serde(rename = "dsseEnvelope")]
+    pub dsse_envelope: Option<DsseEnvelope>,
+    #[serde(rename = "verificationMaterial")]
+    pub verification_material: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DsseEnvelope {
+    pub payload: String,
+    #[serde(rename = "payloadType")]
+    pub payload_type: String,
+    pub signatures: Vec<DsseSignature>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DsseSignature {
+    pub sig: String,
+    #[serde(default)]
+    pub keyid: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Build a synthetic Sigstore bundle whose DSSE payload is a
+    /// minimal in-toto v1 statement with the given subject digest
+    /// and builder id. Crypto fields are stubbed — the semantic
+    /// layer doesn't read them.
+    fn bundle_with(
+        subject_name: &str,
+        subject_sha512_hex: &str,
+        predicate_type: &str,
+        builder_id: &str,
+    ) -> Value {
+        let statement = json!({
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{
+                "name": subject_name,
+                "digest": { "sha512": subject_sha512_hex }
+            }],
+            "predicateType": predicate_type,
+            "predicate": {
+                "buildDefinition": {
+                    "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+                },
+                "runDetails": {
+                    "builder": { "id": builder_id }
+                }
+            }
+        });
+        let payload_b64 = BASE64.encode(serde_json::to_vec(&statement).unwrap());
+        json!({
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": { "certificate": { "rawBytes": "stub" } },
+            "dsseEnvelope": {
+                "payload": payload_b64,
+                "payloadType": "application/vnd.in-toto+json",
+                "signatures": [{"sig": "stub"}]
+            }
+        })
+    }
+
+    /// Byte string whose sha512 we can compute once and reuse below.
+    fn known_tarball() -> &'static [u8] {
+        b"coronarium-test-tarball-fixture-please-do-not-depend-on-me"
+    }
+
+    fn known_integrity() -> String {
+        let hex = sha512_hex(known_tarball());
+        // reverse-engineer the npm `sha512-<base64>` form.
+        let raw: Vec<u8> = (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect();
+        format!("sha512-{}", BASE64.encode(raw))
+    }
+
+    #[test]
+    fn integrity_round_trip() {
+        let integ = known_integrity();
+        let hex = integrity_to_sha512_hex(&integ).unwrap();
+        assert_eq!(hex, sha512_hex(known_tarball()));
+    }
+
+    #[test]
+    fn integrity_rejects_sha1() {
+        assert!(integrity_to_sha512_hex("sha1-abcdef").is_none());
+    }
+
+    #[test]
+    fn integrity_rejects_wrong_length() {
+        // sha512 base64 of 63 bytes — shorter than 64.
+        let short = BASE64.encode([0u8; 63]);
+        assert!(integrity_to_sha512_hex(&format!("sha512-{short}")).is_none());
+    }
+
+    #[test]
+    fn verifies_happy_path() {
+        let hex = sha512_hex(known_tarball());
+        let bundle = bundle_with(
+            "pkg:npm/foo@1.0.0",
+            &hex,
+            "https://slsa.dev/provenance/v1",
+            "https://github.com/actions/runner/github-hosted",
+        );
+        let v = verify_bundle_semantics(&bundle, &known_integrity()).unwrap();
+        assert_eq!(v.predicate_type, "https://slsa.dev/provenance/v1");
+        assert_eq!(v.subject_sha512_hex, hex);
+        assert!(v.builder_id.starts_with("https://github.com/actions/runner/"));
+    }
+
+    #[test]
+    fn rejects_digest_mismatch() {
+        let bundle = bundle_with(
+            "pkg:npm/foo@1.0.0",
+            &"aa".repeat(64), // wrong digest
+            "https://slsa.dev/provenance/v1",
+            "https://github.com/actions/runner/github-hosted",
+        );
+        let err = verify_bundle_semantics(&bundle, &known_integrity()).unwrap_err();
+        match err {
+            VerifyError::SubjectDigestMismatch { .. } => (),
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_predicate_type() {
+        let hex = sha512_hex(known_tarball());
+        let bundle = bundle_with(
+            "pkg:npm/foo@1.0.0",
+            &hex,
+            "https://example.com/made-up/v1",
+            "https://github.com/actions/runner/github-hosted",
+        );
+        let err = verify_bundle_semantics(&bundle, &known_integrity()).unwrap_err();
+        assert!(matches!(err, VerifyError::UnexpectedPredicateType(_)));
+    }
+
+    #[test]
+    fn rejects_disallowed_builder() {
+        let hex = sha512_hex(known_tarball());
+        let bundle = bundle_with(
+            "pkg:npm/foo@1.0.0",
+            &hex,
+            "https://slsa.dev/provenance/v1",
+            "https://evil.example.com/runner/",
+        );
+        let err = verify_bundle_semantics(&bundle, &known_integrity()).unwrap_err();
+        assert!(matches!(err, VerifyError::DisallowedBuilder(_)));
+    }
+
+    #[test]
+    fn rejects_missing_dsse_envelope() {
+        let bundle = json!({"mediaType": "x", "verificationMaterial": {}});
+        let err = verify_bundle_semantics(&bundle, &known_integrity()).unwrap_err();
+        assert!(matches!(err, VerifyError::Malformed(_)));
+    }
+
+    #[test]
+    fn rejects_wrong_payload_type() {
+        let statement = json!({
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [],
+            "predicateType": "https://slsa.dev/provenance/v1"
+        });
+        let payload_b64 = BASE64.encode(serde_json::to_vec(&statement).unwrap());
+        let bundle = json!({
+            "dsseEnvelope": {
+                "payload": payload_b64,
+                "payloadType": "application/vnd.not-in-toto+json",
+                "signatures": []
+            }
+        });
+        let err = verify_bundle_semantics(&bundle, &known_integrity()).unwrap_err();
+        assert!(matches!(err, VerifyError::PayloadShape(_)));
+    }
+
+    #[test]
+    fn slsa_v0_2_builder_path_still_works() {
+        // SLSA v0.2 bundles nest builder.id one level shallower.
+        let hex = sha512_hex(known_tarball());
+        let statement = json!({
+            "_type": "https://in-toto.io/Statement/v0.1",
+            "subject": [{"name": "x", "digest": {"sha512": hex}}],
+            "predicateType": "https://slsa.dev/provenance/v0.2",
+            "predicate": {
+                "builder": { "id": "https://github.com/actions/runner/v1" }
+            }
+        });
+        let payload_b64 = BASE64.encode(serde_json::to_vec(&statement).unwrap());
+        let bundle = json!({
+            "dsseEnvelope": {
+                "payload": payload_b64,
+                "payloadType": "application/vnd.in-toto+json",
+                "signatures": [{"sig": "stub"}]
+            }
+        });
+        let v = verify_bundle_semantics(&bundle, &known_integrity()).unwrap();
+        assert_eq!(v.predicate_type, "https://slsa.dev/provenance/v0.2");
+    }
+
+    #[test]
+    fn pick_slsa_bundle_selects_correct_entry() {
+        let hex = sha512_hex(known_tarball());
+        let bundle = bundle_with(
+            "x",
+            &hex,
+            "https://slsa.dev/provenance/v1",
+            "https://github.com/actions/runner/v1",
+        );
+        let attestations = json!({
+            "attestations": [
+                { "predicateType": "https://something.else/v1", "bundle": {} },
+                { "predicateType": "https://slsa.dev/provenance/v1", "bundle": bundle }
+            ]
+        });
+        let body = serde_json::to_vec(&attestations).unwrap();
+        let b = pick_slsa_bundle(&body).unwrap();
+        assert!(b.get("dsseEnvelope").is_some());
+    }
+
+    #[test]
+    fn pick_slsa_bundle_errors_when_no_slsa() {
+        let body = br#"{"attestations":[{"predicateType":"other/v1","bundle":{}}]}"#;
+        assert!(pick_slsa_bundle(body).is_err());
+    }
+}

--- a/crates/coronarium-proxy/src/sigstore_verify.rs
+++ b/crates/coronarium-proxy/src/sigstore_verify.rs
@@ -411,7 +411,10 @@ mod tests {
         let v = verify_bundle_semantics(&bundle, &known_integrity()).unwrap();
         assert_eq!(v.predicate_type, "https://slsa.dev/provenance/v1");
         assert_eq!(v.subject_sha512_hex, hex);
-        assert!(v.builder_id.starts_with("https://github.com/actions/runner/"));
+        assert!(
+            v.builder_id
+                .starts_with("https://github.com/actions/runner/")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two independent priority items from the new roadmap scoping.

### 1. Sigstore bundle semantic verification (P0-1a) — `89e21e8`

New `sigstore_verify` module that parses npm-attached Sigstore bundles, extracts the DSSE in-toto statement, and runs semantic checks:
- `subject[0].digest.sha512` vs npm `dist.integrity`
- accepted `predicateType` (SLSA v1 / v0.2)
- `builder.id` allowlist (GitHub Actions / SLSA framework / GitLab)

Closes the "stolen publish token + reused attestation from a different artifact" attack class — the subject digest would no longer match the tarball npm serves.

**Not included** (P0-1b, P0-1c — follow-up PRs):
- Fulcio cert chain / DSSE signature / Rekor SET crypto verification
- `--verify-provenance` CLI flag + proxy integration (bundle fetch loop)

This is a landing-pad PR: module is isolated, fully tested (12 tests), not yet called from the proxy / CLI.

### 2. NuGet flat-container silent auto-fallback (P1-3) — `1788d59`

Closes the last silent-fallback gap across the four ecosystems. The flat-container index (`/v3-flatcontainer/<id>/index.json`) carries no timestamps inline; we now:

- Fetch `/v3/registration5-semver1/<id>/index.json` out-of-band (new `NugetFlatContainerClient`)
- Walk inline items + follow page references up to a bounded depth
- Cache version→publish-time per package for 10 min
- Filter the flat-container `versions[]` using that oracle

Failed lookups yield empty maps → fail-open filter, but pinned `.nupkg` fetches still hard-deny at the tarball layer so stale cache can't silently admit too-young versions.

17 new tests: filter semantics, oracle extraction (incl. unlisted-sentinel / page-ref handling), client caching / page-chasing / failure modes, proxy path classification.

## Test plan

- [x] `cargo test --workspace --lib` — 145 pass (was 128, +17)
- [x] `cargo build --workspace` — clean
- [ ] End-to-end smoke with real `dotnet restore` against the proxy
- [ ] End-to-end smoke with `npm install` of a package that has provenance (once P0-1c wires CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)