### PR TITLE
feat(proxy): PyPI HTML Simple index silent auto-fallback (P1-4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,8 @@ older deps.
   (notably `latest`) that pointed at a removed version is
   retargeted to the highest remaining semver. npm's resolver then
   picks the newest in-range surviving version — no error.
-- **pypi** — ✅ implemented for the two JSON endpoints modern pip
-  and uv actually consult:
+- **pypi** — ✅ implemented for all three metadata shapes pip / uv /
+  legacy tools consult:
   - Warehouse JSON API (`pypi.org/pypi/<pkg>/json`) — drops version
     keys from `releases` whose earliest `upload_time_iso_8601` is
     too young, plus stripping the `urls` shortcut.
@@ -81,11 +81,16 @@ older deps.
     `Accept: application/vnd.pypi.simple.v1+json`) — drops
     too-young `files[]`, prunes `versions[]` to only those with
     surviving files.
-
-  The legacy HTML Simple index (PEP 503) carries no upload time in
-  the response; it passes through unchanged. pip fall-back to
-  tarball-level `files.pythonhosted.org` deny still catches those
-  installs fail-hard.
+  - PEP 503 Simple HTML (`pypi.org/simple/<pkg>/` with
+    `Accept: text/html`) — carries no inline publish time, so the
+    rewriter consults an out-of-band lookup to the Warehouse JSON
+    API via `PypiSimpleClient` (cached per-package for 10 min).
+    Anchors whose filename-derived version is too young are dropped
+    byte-for-byte from the HTML; surrounding markup is preserved so
+    pip's tolerant parser sees the exact same document minus the
+    filtered rows. Failed lookups yield an empty map → fail-open,
+    but pinned `files.pythonhosted.org` fetches still hard-deny at
+    the tarball layer.
 - **nuget** — ✅ implemented for the **registration** endpoints
   (`api.nuget.org/v3/registration<X>*/<id>/index.json` and the
   paged `.../page/<lower>/<upper>.json`). Leaves whose

--- a/README.md
+++ b/README.md
@@ -82,12 +82,11 @@ from then on, every HTTPS request your package managers make through
 |---|---|---|
 | **crates.io** | ✅ sparse-index JSONL rewrite (drops too-young lines from `/<prefix>/<name>`) | ✅ `403` on `.crate` download to a denied version |
 | **npm** | ✅ packument rewrite (drops versions + retargets `dist-tags.latest`) | ✅ `403` on `.tgz` download |
-| **pypi** | ✅ Warehouse JSON API (`/pypi/<pkg>/json`) + PEP 691 Simple JSON | ✅ `403` on `files.pythonhosted.org` tarball download |
+| **pypi** | ✅ Warehouse JSON API (`/pypi/<pkg>/json`) + PEP 691 Simple JSON + PEP 503 Simple HTML via JSON-API lookup | ✅ `403` on `files.pythonhosted.org` tarball download |
 | **nuget** | ✅ registration-page rewrite (`/v3/registration*/...`) + flat-container index via registration lookup | ✅ `403` on `.nupkg` download |
 
-The legacy HTML Simple index (pypi) still passes through unchanged
-(no inline publish time); pinned fetches downstream fail hard at the
-tarball layer.
+All four ecosystems' metadata paths now rewrite silently — pnpm-style
+`minimumReleaseAge` across the board, no fail-hard in the common case.
 
 ---
 
@@ -766,14 +765,10 @@ Honest assessment. Full details in [CLAUDE.md](CLAUDE.md).
 
 ### Proxy
 
-- **pypi HTML Simple index** (PEP 503) is passed through unmodified
-  — the HTML has no upload time inline, so silent filtering would
-  require a separate JSON lookup. Pinned fetches downstream on
-  `files.pythonhosted.org` still hard-deny. Modern pip/uv prefer
-  the JSON endpoints anyway.
-<!-- nuget flat-container is now silently filtered via an out-of-band
-     registration-endpoint lookup (cached in-proxy for 10 min). No
-     limitation to document here anymore. -->
+<!-- pypi HTML Simple index (PEP 503) and nuget flat-container are
+     now silently filtered via out-of-band JSON-API / registration
+     lookups (cached in-proxy for 10 min). No limitation to document
+     here anymore. -->
 - **Sigstore bundle verification** (not just claim presence) is a
   roadmap item. `--require-provenance` currently checks that the
   `dist.attestations.provenance.predicateType` field is non-empty,

--- a/crates/coronarium-proxy/src/lib.rs
+++ b/crates/coronarium-proxy/src/lib.rs
@@ -10,6 +10,7 @@ pub mod osv;
 pub mod osv_mirror;
 pub mod parser;
 pub mod proxy;
+pub mod pypi_simple_client;
 pub mod rewrite;
 pub mod rewrite_npm;
 pub mod rewrite_nuget;
@@ -29,4 +30,7 @@ pub use rewrite_nuget::{
     NugetRewriteStats, extract_publish_times_from_registration, rewrite_nuget_flatcontainer,
     rewrite_nuget_registration,
 };
-pub use rewrite_pypi::{PypiRewriteStats, rewrite_pypi_json_api, rewrite_pypi_simple_json};
+pub use rewrite_pypi::{
+    PypiRewriteStats, extract_publish_times_from_pypi_json, rewrite_pypi_json_api,
+    rewrite_pypi_simple_html, rewrite_pypi_simple_json,
+};

--- a/crates/coronarium-proxy/src/proxy.rs
+++ b/crates/coronarium-proxy/src/proxy.rs
@@ -22,10 +22,13 @@ use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
 use crate::nuget_flatcontainer_client::NugetFlatContainerClient;
 use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
+use crate::pypi_simple_client::PypiSimpleClient;
 use crate::rewrite::rewrite_crates_index_jsonl;
 use crate::rewrite_npm::{NpmRewriteOptions, rewrite_npm_packument_with};
 use crate::rewrite_nuget::{rewrite_nuget_flatcontainer, rewrite_nuget_registration};
-use crate::rewrite_pypi::{rewrite_pypi_json_api, rewrite_pypi_simple_json};
+use crate::rewrite_pypi::{
+    rewrite_pypi_json_api, rewrite_pypi_simple_html, rewrite_pypi_simple_json,
+};
 
 pub struct ProxyConfig {
     pub listen: SocketAddr,
@@ -182,6 +185,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         last_path: None,
         require_provenance: cfg.require_provenance,
         nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
+        pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -230,6 +234,10 @@ struct CoronariumHandler {
     /// endpoint so we can silently filter the flat-container index
     /// (which has no dates inline).
     nuget_flat: NugetFlatContainerClient,
+    /// Looks up per-package publish times from the Warehouse JSON
+    /// API so we can silently filter the PEP 503 HTML Simple index
+    /// (which has no dates inline).
+    pypi_simple: PypiSimpleClient,
 }
 
 impl HttpHandler for CoronariumHandler {
@@ -367,37 +375,55 @@ impl HttpHandler for CoronariumHandler {
                 }
                 out
             }
-            RewriteTarget::PypiSimpleJson => {
-                // PEP 691 Simple JSON and PEP 503 HTML share the
-                // `/simple/<pkg>/` path — distinguish by Content-Type.
-                // Anything other than `application/vnd.pypi.simple.v1+json`
-                // (the only JSON shape we currently handle) passes through.
-                let is_simple_json = parts
+            RewriteTarget::PypiSimpleIndex(pkg) => {
+                // PEP 691 JSON vs PEP 503 HTML share the same path;
+                // Content-Type is the source of truth.
+                let ct = parts
                     .headers
                     .get(http::header::CONTENT_TYPE)
                     .and_then(|h| h.to_str().ok())
-                    .map(|ct| {
-                        let ct = ct.to_ascii_lowercase();
-                        ct.contains("application/vnd.pypi.simple.v1+json")
-                            || ct.contains("application/vnd.pypi.simple.latest+json")
-                    })
-                    .unwrap_or(false);
-                if !is_simple_json {
-                    log::debug!("pypi-rewrite(simple): pass-through (non-JSON Content-Type)");
+                    .map(|s| s.to_ascii_lowercase())
+                    .unwrap_or_default();
+                if ct.contains("application/vnd.pypi.simple.v1+json")
+                    || ct.contains("application/vnd.pypi.simple.latest+json")
+                {
+                    let (out, stats) =
+                        rewrite_pypi_simple_json(&collected, self.decider.min_age, now);
+                    if stats.dropped > 0 {
+                        log::info!(
+                            "pypi-rewrite(simple-json): dropped {} file(s), kept {}",
+                            stats.dropped,
+                            stats.kept
+                        );
+                    }
+                    out
+                } else if ct.contains("text/html") || ct.contains("application/xhtml") {
+                    // PEP 503 HTML: no inline publish times. Look them
+                    // up out-of-band from the Warehouse JSON API,
+                    // cached per package. A failed lookup yields an
+                    // empty map, so the filter fails open — the
+                    // downstream `files.pythonhosted.org` tarball-deny
+                    // path still catches too-young pins.
+                    let oracle = self.pypi_simple.lookup(&pkg).await;
+                    let (out, stats) =
+                        rewrite_pypi_simple_html(&collected, self.decider.min_age, now, |v| {
+                            oracle.get(v).copied()
+                        });
+                    if stats.dropped > 0 {
+                        log::info!(
+                            "pypi-rewrite(simple-html): dropped {} anchor(s), kept {} for {pkg}",
+                            stats.dropped,
+                            stats.kept
+                        );
+                    }
+                    out
+                } else {
+                    log::debug!("pypi-rewrite(simple): pass-through (unknown Content-Type {ct:?})");
                     return Response::from_parts(
                         parts,
                         Body::from(http_body_util::Full::new(collected)),
                     );
                 }
-                let (out, stats) = rewrite_pypi_simple_json(&collected, self.decider.min_age, now);
-                if stats.dropped > 0 {
-                    log::info!(
-                        "pypi-rewrite(simple): dropped {} file(s), kept {}",
-                        stats.dropped,
-                        stats.kept
-                    );
-                }
-                out
             }
             RewriteTarget::NugetRegistration => {
                 let (out, stats) =
@@ -448,7 +474,12 @@ enum RewriteTarget {
     CratesSparse,
     NpmPackument,
     PypiJsonApi,
-    PypiSimpleJson,
+    /// Simple index (`/simple/<pkg>/`) — PEP 691 JSON *or* PEP 503
+    /// HTML, decided at response time by Content-Type. The String is
+    /// the un-normalized package name from the URL path; the HTML
+    /// path hands it to [`PypiSimpleClient`] for the out-of-band
+    /// publish-time lookup.
+    PypiSimpleIndex(String),
     NugetRegistration,
     /// Flat-container index (`/v3-flatcontainer/<id>/index.json`).
     /// The String is the lower-cased package id, captured here so the
@@ -477,12 +508,13 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
         if is_pypi_json_api_path(path) {
             return Some(RewriteTarget::PypiJsonApi);
         }
-        if is_pypi_simple_path(path) {
+        if let Some(pkg) = parse_pypi_simple_pkg(path) {
             // We can't distinguish HTML vs JSON by path alone — the
             // client's Accept header decides, and the upstream
             // response's Content-Type confirms. The handler inspects
-            // Content-Type at rewrite time and skips HTML bodies.
-            return Some(RewriteTarget::PypiSimpleJson);
+            // Content-Type at rewrite time and dispatches HTML vs
+            // JSON vs pass-through accordingly.
+            return Some(RewriteTarget::PypiSimpleIndex(pkg));
         }
     }
     if host.eq_ignore_ascii_case("api.nuget.org") {
@@ -543,14 +575,16 @@ fn is_pypi_json_api_path(path: &str) -> bool {
 }
 
 /// `GET /simple/<pkg>/` — PEP 503 simple index (HTML) or PEP 691 JSON.
-fn is_pypi_simple_path(path: &str) -> bool {
+/// Returns the raw `<pkg>` segment from the path so the handler can
+/// pass it to the out-of-band publish-time lookup client.
+fn parse_pypi_simple_pkg(path: &str) -> Option<String> {
     let path = path.split('?').next().unwrap_or(path);
-    if let Some(rest) = path.strip_prefix("/simple/") {
-        let rest = rest.trim_end_matches('/');
-        !rest.is_empty() && !rest.contains('/')
-    } else {
-        false
+    let rest = path.strip_prefix("/simple/")?;
+    let rest = rest.trim_end_matches('/');
+    if rest.is_empty() || rest.contains('/') {
+        return None;
     }
+    Some(rest.to_string())
 }
 
 fn is_npm_packument_path(path: &str) -> bool {
@@ -645,11 +679,22 @@ mod tests {
 
     #[test]
     fn pypi_simple_path_matches_index_shape() {
-        assert!(is_pypi_simple_path("/simple/requests/"));
-        assert!(is_pypi_simple_path("/simple/requests"));
-        assert!(!is_pypi_simple_path("/simple/requests/2.32.4/"));
-        assert!(!is_pypi_simple_path("/simple/"));
-        assert!(!is_pypi_simple_path("/pypi/requests/json"));
+        assert_eq!(
+            parse_pypi_simple_pkg("/simple/requests/").as_deref(),
+            Some("requests")
+        );
+        assert_eq!(
+            parse_pypi_simple_pkg("/simple/requests").as_deref(),
+            Some("requests")
+        );
+        assert_eq!(
+            parse_pypi_simple_pkg("/simple/Flask-SQLAlchemy/").as_deref(),
+            Some("Flask-SQLAlchemy"),
+            "raw casing preserved — client normalizes on lookup"
+        );
+        assert_eq!(parse_pypi_simple_pkg("/simple/requests/2.32.4/"), None);
+        assert_eq!(parse_pypi_simple_pkg("/simple/"), None);
+        assert_eq!(parse_pypi_simple_pkg("/pypi/requests/json"), None);
     }
 
     #[test]
@@ -730,7 +775,7 @@ mod tests {
         );
         assert_eq!(
             classify_response(Some("pypi.org"), Some("/simple/requests/")),
-            Some(RewriteTarget::PypiSimpleJson)
+            Some(RewriteTarget::PypiSimpleIndex("requests".into()))
         );
         assert_eq!(classify_response(Some("pypi.org"), Some("/")), None);
         // NuGet registration.

--- a/crates/coronarium-proxy/src/pypi_simple_client.rs
+++ b/crates/coronarium-proxy/src/pypi_simple_client.rs
@@ -1,0 +1,274 @@
+//! Out-of-band lookup that gives the PEP 503 HTML rewriter the
+//! publish times it needs.
+//!
+//! The Simple HTML index (`/simple/<pkg>/` with `Accept: text/html`)
+//! lists each file as a bare `<a>` tag and carries no publish time.
+//! The Warehouse JSON API (`/pypi/<pkg>/json`) carries the full
+//! release history with per-file `upload_time_iso_8601`. This module
+//! fetches the latter on first touch, extracts a `version →
+//! earliest-upload` map, and caches it for [`CACHE_TTL`].
+//!
+//! Cache semantics match [`crate::nuget_flatcontainer_client`]: on a
+//! stale or missing lookup we return an empty map, which the HTML
+//! rewriter treats as fail-open (no version filtering). For pinned
+//! too-young tarballs the `files.pythonhosted.org` hard-deny path
+//! still catches the install.
+
+use std::collections::HashMap;
+use std::io::Read as _;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+
+use crate::rewrite_pypi::extract_publish_times_from_pypi_json;
+
+/// Max lifetime of a cached JSON-API lookup. Matches the NuGet
+/// flat-container client so both silent-fallback paths have the
+/// same "how quickly does a new release become visible" profile.
+const CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+
+const JSON_API_BASE: &str = "https://pypi.org/pypi";
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    data: Arc<HashMap<String, DateTime<Utc>>>,
+    fetched: Instant,
+}
+
+type FetchFn = dyn Fn(&str) -> Result<Vec<u8>, String> + Send + Sync;
+
+/// Thread-safe lookup client. Clone-cheap: internally Arc-wrapped.
+#[derive(Clone)]
+pub struct PypiSimpleClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    cache: Mutex<HashMap<String, CacheEntry>>,
+    user_agent: String,
+    fetcher: Box<FetchFn>,
+}
+
+impl PypiSimpleClient {
+    pub fn new(user_agent: impl Into<String>) -> Self {
+        let ua = user_agent.into();
+        let ua_for_fetch = ua.clone();
+        Self {
+            inner: Arc::new(Inner {
+                cache: Mutex::new(HashMap::new()),
+                user_agent: ua,
+                fetcher: Box::new(move |url| fetch_blocking(url, &ua_for_fetch)),
+            }),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_fetcher<F>(fetcher: F) -> Self
+    where
+        F: Fn(&str) -> Result<Vec<u8>, String> + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(Inner {
+                cache: Mutex::new(HashMap::new()),
+                user_agent: "test".into(),
+                fetcher: Box::new(fetcher),
+            }),
+        }
+    }
+
+    /// Return the cached publish-times map for `package`, fetching
+    /// from the JSON API when cache is empty or stale. On any
+    /// failure returns an empty map.
+    pub async fn lookup(&self, package: &str) -> Arc<HashMap<String, DateTime<Utc>>> {
+        if let Some(cached) = self.get_fresh(package) {
+            return cached;
+        }
+        let client = self.clone();
+        let id = normalize_name(package);
+        let map = tokio::task::spawn_blocking(move || client.refresh_now(&id))
+            .await
+            .unwrap_or_default();
+        let arc = Arc::new(map);
+        self.put(package, Arc::clone(&arc));
+        arc
+    }
+
+    /// Blocking sibling of [`Self::lookup`]. Tests call this directly.
+    pub fn lookup_blocking(&self, package: &str) -> Arc<HashMap<String, DateTime<Utc>>> {
+        if let Some(cached) = self.get_fresh(package) {
+            return cached;
+        }
+        let id = normalize_name(package);
+        let arc = Arc::new(self.refresh_now(&id));
+        self.put(package, Arc::clone(&arc));
+        arc
+    }
+
+    fn get_fresh(&self, package: &str) -> Option<Arc<HashMap<String, DateTime<Utc>>>> {
+        let key = normalize_name(package);
+        let cache = self.inner.cache.lock().ok()?;
+        let entry = cache.get(&key)?;
+        if entry.fetched.elapsed() < CACHE_TTL {
+            Some(Arc::clone(&entry.data))
+        } else {
+            None
+        }
+    }
+
+    fn put(&self, package: &str, data: Arc<HashMap<String, DateTime<Utc>>>) {
+        let key = normalize_name(package);
+        if let Ok(mut cache) = self.inner.cache.lock() {
+            cache.insert(
+                key,
+                CacheEntry {
+                    data,
+                    fetched: Instant::now(),
+                },
+            );
+        }
+    }
+
+    fn refresh_now(&self, package_normalized: &str) -> HashMap<String, DateTime<Utc>> {
+        let url = format!("{JSON_API_BASE}/{package_normalized}/json");
+        match (self.inner.fetcher)(&url) {
+            Ok(body) => extract_publish_times_from_pypi_json(&body),
+            Err(e) => {
+                log::debug!("pypi-simple: JSON API fetch failed for {package_normalized}: {e}");
+                HashMap::new()
+            }
+        }
+    }
+
+    pub fn user_agent(&self) -> &str {
+        &self.inner.user_agent
+    }
+}
+
+/// PEP 503 normalized project name: lowercase, runs of
+/// `-`/`_`/`.` collapsed to a single `-`. Used for cache keying and
+/// for the JSON API URL path. Both PyPI and pip apply the same rule.
+fn normalize_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_sep = false;
+    for c in name.chars() {
+        if c == '-' || c == '_' || c == '.' {
+            if !prev_sep && !out.is_empty() {
+                out.push('-');
+                prev_sep = true;
+            }
+        } else {
+            out.push(c.to_ascii_lowercase());
+            prev_sep = false;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn fetch_blocking(url: &str, ua: &str) -> Result<Vec<u8>, String> {
+    let resp = ureq::get(url)
+        .set("user-agent", ua)
+        .set("accept", "application/json")
+        .timeout(Duration::from_millis(3000))
+        .call()
+        .map_err(|e| e.to_string())?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut buf)
+        .map_err(|e| e.to_string())?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn releases_body(pairs: &[(&str, &str)]) -> Vec<u8> {
+        let mut rels = serde_json::Map::new();
+        for (v, t) in pairs {
+            rels.insert(
+                (*v).into(),
+                json!([{ "filename": format!("pkg-{v}.tar.gz"), "upload_time_iso_8601": t }]),
+            );
+        }
+        serde_json::to_vec(&json!({ "info": {}, "releases": rels })).unwrap()
+    }
+
+    #[test]
+    fn lookup_hits_json_api_and_returns_publish_times() {
+        let client = PypiSimpleClient::with_fetcher(|url| {
+            assert!(url.contains("/pypi/requests/json"), "url was {url}");
+            Ok(releases_body(&[
+                ("2.0.0", "2024-01-01T00:00:00Z"),
+                ("2.1.0", "2024-06-01T00:00:00Z"),
+            ]))
+        });
+        let map = client.lookup_blocking("requests");
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("2.0.0"));
+        assert!(map.contains_key("2.1.0"));
+    }
+
+    #[test]
+    fn lookup_caches_subsequent_calls() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        let client = PypiSimpleClient::with_fetcher(move |_| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            Ok(releases_body(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+        });
+        let _ = client.lookup_blocking("pkg");
+        let _ = client.lookup_blocking("pkg");
+        let _ = client.lookup_blocking("PKG"); // normalized-same → cache hit
+        let _ = client.lookup_blocking("p.k.g"); // normalized to "p-k-g" → different
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn lookup_network_failure_returns_empty_map_and_caches_it() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_c = Arc::clone(&hits);
+        let client = PypiSimpleClient::with_fetcher(move |_| {
+            hits_c.fetch_add(1, Ordering::SeqCst);
+            Err("connection refused".into())
+        });
+        let map = client.lookup_blocking("pkg");
+        assert!(map.is_empty());
+        let _ = client.lookup_blocking("pkg");
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn lookup_uses_normalized_name_in_url_path() {
+        let client = PypiSimpleClient::with_fetcher(|url| {
+            // PEP 503: `Flask-SQLAlchemy` → `flask-sqlalchemy`
+            assert!(url.contains("/pypi/flask-sqlalchemy/json"), "url was {url}");
+            Ok(releases_body(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+        });
+        let _ = client.lookup_blocking("Flask_SQLAlchemy");
+    }
+
+    #[tokio::test]
+    async fn async_lookup_uses_blocking_executor() {
+        let client = PypiSimpleClient::with_fetcher(|_| {
+            Ok(releases_body(&[("1.0.0", "2024-01-01T00:00:00Z")]))
+        });
+        let map = client.lookup("pkg").await;
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn normalize_collapses_separator_runs() {
+        assert_eq!(normalize_name("Flask"), "flask");
+        assert_eq!(normalize_name("Flask_SQLAlchemy"), "flask-sqlalchemy");
+        assert_eq!(normalize_name("foo...bar"), "foo-bar");
+        assert_eq!(normalize_name("foo-_.bar"), "foo-bar");
+        assert_eq!(normalize_name("zope.interface"), "zope-interface");
+    }
+}

--- a/crates/coronarium-proxy/src/rewrite_pypi.rs
+++ b/crates/coronarium-proxy/src/rewrite_pypi.rs
@@ -14,11 +14,14 @@
 //!    a top-level `versions: [...]` listing. We filter `files[]`
 //!    per-file on `upload-time`.
 //!
-//! The Simple index HTML (PEP 503) is a separate story: it has no
-//! upload time in the response, so we'd need an out-of-band lookup.
-//! Modern pip/uv prefer the JSON endpoints anyway, so we leave HTML
-//! as pass-through for now (the `files.pythonhosted.org` tarball
-//! deny still catches too-young fetches there, just fail-hard).
+//! 3. **Simple index (PEP 503 HTML)**: `GET /simple/<pkg>/` with
+//!    `Accept: text/html` — bare `<a href="…file…">filename</a>`
+//!    rows, no publish time in the response. We drop anchors whose
+//!    filename-derived version is too young per an out-of-band
+//!    oracle populated from the JSON API (see
+//!    [`crate::pypi_simple_client::PypiSimpleClient`]). Unknown
+//!    versions are left alone — the `files.pythonhosted.org`
+//!    tarball-deny path catches young pins downstream.
 //!
 //! Pure + synchronous; unit tests cover every branch.
 
@@ -90,6 +93,31 @@ pub fn rewrite_pypi_json_api(
 
     let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
     (out, stats)
+}
+
+/// Extract `{version → earliest upload_time}` from a Warehouse JSON
+/// API body (`/pypi/<pkg>/json`). Used by the HTML rewriter's
+/// out-of-band oracle. Returns an empty map if the body can't be
+/// parsed or has no `releases` object.
+pub fn extract_publish_times_from_pypi_json(
+    body: &[u8],
+) -> std::collections::HashMap<String, DateTime<Utc>> {
+    let mut out = std::collections::HashMap::new();
+    let Ok(doc): Result<Value, _> = serde_json::from_slice(body) else {
+        return out;
+    };
+    let Some(releases) = doc.get("releases").and_then(Value::as_object) else {
+        return out;
+    };
+    for (vers, files) in releases {
+        let Some(files) = files.as_array() else {
+            continue;
+        };
+        if let Some(t) = earliest_upload_time_json_api(files) {
+            out.insert(vers.clone(), t);
+        }
+    }
+    out
 }
 
 fn earliest_upload_time_json_api(files: &[Value]) -> Option<DateTime<Utc>> {
@@ -167,6 +195,221 @@ pub fn rewrite_pypi_simple_json(
 
     let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
     (out, stats)
+}
+
+/// Rewrite a PEP 503 Simple HTML index (`/simple/<pkg>/` with
+/// `Accept: text/html`). For each `<a href="…">filename</a>` entry,
+/// consult `oracle(version)` for the publish time and drop the
+/// entire anchor (plus one optional trailing `<br>`/`<br/>` and
+/// newline) when it is younger than `min_age`. All other HTML —
+/// doctype, head, wrapping body, PEP 691 data-* attributes — is
+/// left byte-for-byte identical so pip's tolerant parser sees the
+/// exact same document minus the filtered rows.
+///
+/// `oracle` is expected to be populated out-of-band (see
+/// [`crate::pypi_simple_client::PypiSimpleClient`]) by hitting
+/// `/pypi/<pkg>/json` once per package. Entries whose version the
+/// oracle doesn't know are left alone — the files.pythonhosted.org
+/// tarball-deny path catches young pins downstream.
+pub fn rewrite_pypi_simple_html<F>(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+    oracle: F,
+) -> (Vec<u8>, PypiRewriteStats)
+where
+    F: Fn(&str) -> Option<DateTime<Utc>>,
+{
+    let mut stats = PypiRewriteStats::default();
+    let Ok(s) = std::str::from_utf8(body) else {
+        log::debug!("pypi-rewrite(html): pass-through, body not UTF-8");
+        return (body.to_vec(), stats);
+    };
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // Look for the start of the next anchor element. Case-
+        // insensitive match on `<a` followed by whitespace or `>`.
+        if let Some(anchor_start) = find_anchor_start(&bytes[i..]) {
+            let abs = i + anchor_start;
+            out.extend_from_slice(&bytes[i..abs]);
+            // Find the closing `</a>` (also case-insensitive).
+            let remainder = &bytes[abs..];
+            let Some(close_rel) = find_case_insensitive(remainder, b"</a>") else {
+                // Malformed — emit the rest and stop scanning for anchors.
+                out.extend_from_slice(remainder);
+                break;
+            };
+            let anchor_end = abs + close_rel + b"</a>".len();
+            let anchor = std::str::from_utf8(&bytes[abs..anchor_end]).unwrap_or("");
+
+            // Extract href + filename + version. Unknown / malformed
+            // entries default to keep.
+            let drop = anchor_drop_decision(anchor, &oracle, now, cutoff);
+            if drop {
+                stats.dropped += 1;
+                // Eat one optional trailing `<br>` or `<br/>` plus
+                // up to one newline so we don't leave stray markup.
+                let mut next = anchor_end;
+                next = eat_optional_br(bytes, next);
+                next = eat_optional_newline(bytes, next);
+                i = next;
+            } else {
+                stats.kept += 1;
+                out.extend_from_slice(&bytes[abs..anchor_end]);
+                i = anchor_end;
+            }
+        } else {
+            out.extend_from_slice(&bytes[i..]);
+            i = bytes.len();
+        }
+    }
+    (out, stats)
+}
+
+fn anchor_drop_decision<F>(
+    anchor: &str,
+    oracle: &F,
+    now: DateTime<Utc>,
+    cutoff: chrono::Duration,
+) -> bool
+where
+    F: Fn(&str) -> Option<DateTime<Utc>>,
+{
+    let Some(href) = extract_href_value(anchor) else {
+        return false;
+    };
+    let filename = url_basename_no_fragment(&href);
+    let Some(version) = extract_version_from_filename(filename) else {
+        return false;
+    };
+    let Some(t) = oracle(&version) else {
+        return false;
+    };
+    (now - t) < cutoff
+}
+
+/// Find the first `<a` that starts an anchor tag (followed by
+/// whitespace or `>`). Returns byte offset or None.
+fn find_anchor_start(hay: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    while i + 2 <= hay.len() {
+        if hay[i] == b'<'
+            && (hay[i + 1] == b'a' || hay[i + 1] == b'A')
+            && i + 2 < hay.len()
+            && (hay[i + 2].is_ascii_whitespace() || hay[i + 2] == b'>')
+        {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn find_case_insensitive(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || hay.len() < needle.len() {
+        return None;
+    }
+    'outer: for i in 0..=hay.len() - needle.len() {
+        for (k, nb) in needle.iter().enumerate() {
+            if !hay[i + k].eq_ignore_ascii_case(nb) {
+                continue 'outer;
+            }
+        }
+        return Some(i);
+    }
+    None
+}
+
+fn eat_optional_br(bytes: &[u8], start: usize) -> usize {
+    let rest = &bytes[start..];
+    // Skip a run of ASCII spaces/tabs between `</a>` and `<br>`.
+    let mut k = 0;
+    while k < rest.len() && (rest[k] == b' ' || rest[k] == b'\t') {
+        k += 1;
+    }
+    // Match `<br`, any attributes up to `>`, optional `/` before `>`.
+    if rest.len() >= k + 3
+        && rest[k] == b'<'
+        && (rest[k + 1] == b'b' || rest[k + 1] == b'B')
+        && (rest[k + 2] == b'r' || rest[k + 2] == b'R')
+        && let Some(gt) = rest[k + 3..].iter().position(|&b| b == b'>')
+    {
+        return start + k + 3 + gt + 1;
+    }
+    start
+}
+
+fn eat_optional_newline(bytes: &[u8], start: usize) -> usize {
+    if start < bytes.len() && bytes[start] == b'\r' {
+        if start + 1 < bytes.len() && bytes[start + 1] == b'\n' {
+            return start + 2;
+        }
+        return start + 1;
+    }
+    if start < bytes.len() && bytes[start] == b'\n' {
+        return start + 1;
+    }
+    start
+}
+
+/// Pull the `href` attribute value out of an anchor element string.
+/// Supports both double- and single-quoted values. Returns the raw
+/// attribute value without any HTML-entity decoding (PEP 503 URLs
+/// don't contain entity-encoded characters in practice).
+fn extract_href_value(anchor: &str) -> Option<String> {
+    let bytes = anchor.as_bytes();
+    let mut i = 0;
+    while i + 5 <= bytes.len() {
+        // Match `href` case-insensitively at a word boundary.
+        let at_boundary = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+        if at_boundary
+            && bytes[i..].len() >= 4
+            && bytes[i].eq_ignore_ascii_case(&b'h')
+            && bytes[i + 1].eq_ignore_ascii_case(&b'r')
+            && bytes[i + 2].eq_ignore_ascii_case(&b'e')
+            && bytes[i + 3].eq_ignore_ascii_case(&b'f')
+        {
+            let mut j = i + 4;
+            // Skip whitespace then `=`.
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j >= bytes.len() || bytes[j] != b'=' {
+                i += 1;
+                continue;
+            }
+            j += 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            let quote = bytes.get(j).copied()?;
+            if quote != b'"' && quote != b'\'' {
+                return None;
+            }
+            j += 1;
+            let start = j;
+            while j < bytes.len() && bytes[j] != quote {
+                j += 1;
+            }
+            if j >= bytes.len() {
+                return None;
+            }
+            return Some(std::str::from_utf8(&bytes[start..j]).ok()?.to_string());
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extract the filename portion of a PyPI file URL: path basename,
+/// stripped of any `#sha256=…` fragment and `?query`.
+fn url_basename_no_fragment(url: &str) -> &str {
+    let before_fragment = url.split('#').next().unwrap_or(url);
+    let before_query = before_fragment.split('?').next().unwrap_or(before_fragment);
+    before_query.rsplit('/').next().unwrap_or(before_query)
 }
 
 /// Cheap-and-cheerful "pull the version out of a PyPI filename":
@@ -384,5 +627,177 @@ mod tests {
         );
         assert_eq!(extract_version_from_filename("weird.txt"), None);
         assert_eq!(extract_version_from_filename(""), None);
+    }
+
+    // ---------- Simple HTML (PEP 503) ----------
+
+    fn simple_html(rows: &[&str]) -> String {
+        let mut s = String::from(
+            "<!DOCTYPE html>\n<html><head><title>Links for pkg</title></head><body>\n",
+        );
+        for r in rows {
+            s.push_str(r);
+            s.push('\n');
+        }
+        s.push_str("</body></html>\n");
+        s
+    }
+
+    fn oracle_from(
+        pairs: &[(&str, DateTime<Utc>)],
+    ) -> impl Fn(&str) -> Option<DateTime<Utc>> + use<> {
+        let map: std::collections::HashMap<String, DateTime<Utc>> =
+            pairs.iter().map(|(v, t)| ((*v).into(), *t)).collect();
+        move |v| map.get(v).copied()
+    }
+
+    #[test]
+    fn simple_html_drops_young_anchors_keeps_old() {
+        let now = utc(2025, 1, 10);
+        let oracle = oracle_from(&[
+            ("1.0.0", utc(2024, 1, 1)),
+            ("2.0.0", utc(2025, 1, 9)), // young
+        ]);
+        let body = simple_html(&[
+            r#"<a href="https://files.pythonhosted.org/packages/aa/pkg-1.0.0.tar.gz#sha256=abc">pkg-1.0.0.tar.gz</a><br/>"#,
+            r#"<a href="https://files.pythonhosted.org/packages/bb/pkg-2.0.0.tar.gz#sha256=def">pkg-2.0.0.tar.gz</a><br/>"#,
+        ]);
+        let (out, stats) =
+            rewrite_pypi_simple_html(body.as_bytes(), min_age_hours(168), now, oracle);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("pkg-1.0.0.tar.gz"));
+        assert!(!s.contains("pkg-2.0.0.tar.gz"));
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 1);
+        // Surrounding markup intact.
+        assert!(s.contains("<!DOCTYPE html>"));
+        assert!(s.contains("</body></html>"));
+    }
+
+    #[test]
+    fn simple_html_keeps_anchors_with_unknown_version() {
+        // Oracle returns None → we can't judge, leave it. The
+        // tarball-deny path catches these downstream.
+        let now = utc(2025, 1, 10);
+        let oracle = oracle_from(&[]);
+        let body = simple_html(&[
+            r#"<a href="https://files.pythonhosted.org/packages/aa/pkg-2.0.0.tar.gz">pkg-2.0.0.tar.gz</a><br/>"#,
+        ]);
+        let (out, stats) =
+            rewrite_pypi_simple_html(body.as_bytes(), min_age_hours(168), now, oracle);
+        assert!(String::from_utf8(out).unwrap().contains("pkg-2.0.0.tar.gz"));
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 1);
+    }
+
+    #[test]
+    fn simple_html_keeps_anchors_without_parseable_filename() {
+        // href points to something that isn't an sdist/wheel — we
+        // can't extract a version, so keep it.
+        let now = utc(2025, 1, 10);
+        let oracle = oracle_from(&[("1.0.0", utc(2025, 1, 9))]);
+        let body = simple_html(&[r#"<a href="https://example.com/weird.txt">weird.txt</a>"#]);
+        let (out, stats) =
+            rewrite_pypi_simple_html(body.as_bytes(), min_age_hours(168), now, oracle);
+        assert!(String::from_utf8(out).unwrap().contains("weird.txt"));
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn simple_html_handles_single_quoted_and_mixed_case_attrs() {
+        let now = utc(2025, 1, 10);
+        let oracle = oracle_from(&[("2.0.0", utc(2025, 1, 9))]);
+        let body = "<!DOCTYPE html>\n<HTML><BODY>\n<A HREF='https://files.pythonhosted.org/packages/xx/pkg-2.0.0.tar.gz'>pkg-2.0.0.tar.gz</A>\n</BODY></HTML>\n";
+        let (out, stats) =
+            rewrite_pypi_simple_html(body.as_bytes(), min_age_hours(168), now, oracle);
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("pkg-2.0.0.tar.gz"));
+        assert!(s.contains("</BODY></HTML>"));
+        assert_eq!(stats.dropped, 1);
+    }
+
+    #[test]
+    fn simple_html_preserves_pep691_data_attrs_on_kept_anchors() {
+        // PEP 691 adds data-* attributes (data-dist-info-metadata,
+        // data-requires-python, data-yanked). They must survive on
+        // anchors we keep.
+        let now = utc(2025, 1, 10);
+        let oracle = oracle_from(&[("1.0.0", utc(2024, 1, 1))]);
+        let body = simple_html(&[
+            r#"<a href="https://files.pythonhosted.org/packages/aa/pkg-1.0.0.tar.gz" data-requires-python="&gt;=3.8" data-yanked="">pkg-1.0.0.tar.gz</a>"#,
+        ]);
+        let (out, _) = rewrite_pypi_simple_html(body.as_bytes(), min_age_hours(168), now, oracle);
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("data-requires-python"));
+        assert!(s.contains("data-yanked"));
+    }
+
+    #[test]
+    fn simple_html_empty_body_passes_through() {
+        let (out, stats) =
+            rewrite_pypi_simple_html(b"", min_age_hours(168), utc(2025, 1, 10), oracle_from(&[]));
+        assert_eq!(out, b"");
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 0);
+    }
+
+    #[test]
+    fn simple_html_malformed_anchor_does_not_lose_trailing_content() {
+        // `<a ...` without `</a>` — we stop anchor scanning but keep
+        // the rest of the body verbatim.
+        let body = "<body>\n<a href=\"x.tar.gz\">oops (never closed)\n</body>";
+        let (out, stats) = rewrite_pypi_simple_html(
+            body.as_bytes(),
+            min_age_hours(168),
+            utc(2025, 1, 10),
+            oracle_from(&[]),
+        );
+        assert_eq!(String::from_utf8(out).unwrap(), body);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn simple_html_non_utf8_body_passes_through() {
+        let body = b"\xff\xfe\xfa garbage";
+        let (out, stats) =
+            rewrite_pypi_simple_html(body, min_age_hours(168), utc(2025, 1, 10), oracle_from(&[]));
+        assert_eq!(out, body);
+        assert_eq!(stats.dropped, 0);
+    }
+
+    #[test]
+    fn url_basename_strips_fragment_and_query() {
+        assert_eq!(
+            url_basename_no_fragment(
+                "https://files.pythonhosted.org/packages/aa/pkg-1.0.0.tar.gz#sha256=abc"
+            ),
+            "pkg-1.0.0.tar.gz"
+        );
+        assert_eq!(
+            url_basename_no_fragment("https://x/y/pkg-2.0.0.tar.gz?foo=bar"),
+            "pkg-2.0.0.tar.gz"
+        );
+        assert_eq!(
+            url_basename_no_fragment("pkg-1.0.0.tar.gz"),
+            "pkg-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn extract_href_handles_both_quote_styles_and_whitespace() {
+        assert_eq!(
+            extract_href_value(r#"<a href="x">y</a>"#).as_deref(),
+            Some("x")
+        );
+        assert_eq!(
+            extract_href_value(r#"<a href = 'z'>y</a>"#).as_deref(),
+            Some("z")
+        );
+        assert_eq!(
+            extract_href_value(r#"<a HREF="ALLCAPS">y</a>"#).as_deref(),
+            Some("ALLCAPS")
+        );
+        // No href at all.
+        assert_eq!(extract_href_value(r#"<a class="foo">y</a>"#), None);
     }
 }


### PR DESCRIPTION
## Summary

- New `PypiSimpleClient`: out-of-band lookup to Warehouse JSON API (`/pypi/<pkg>/json`) to fill in the publish times missing from the PEP 503 HTML index. 10 min per-package cache, fail-open on errors.
- New `rewrite_pypi_simple_html`: byte-level anchor filter that drops `<a>` rows for too-young versions while preserving surrounding HTML / PEP 691 data-* attributes byte-for-byte.
- `proxy.rs` branches on Content-Type: JSON → existing PEP 691 filter, HTML → new HTML filter, else pass-through.
- README + CLAUDE.md: drop the "HTML Simple index passes through" caveat — all four ecosystems now silently auto-fallback across both metadata shapes.

161 tests pass (+16 new).

## Test plan
- [x] `cargo test -p coronarium-proxy --lib` → 161 pass
- [x] `cargo clippy -p coronarium-proxy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --workspace --lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)