### PR TITLE
feat(run): DNS round-robin drift refresh (P2-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,10 +775,17 @@ Honest assessment. Full details in [CLAUDE.md](CLAUDE.md).
   which is already meaningful (npm refuses to attach it unless
   the publish came from OIDC-authenticated CI) but the bundle
   itself isn't cryptographically verified.
-- **DNS round-robin drift**: `network.allow: example.com` resolves
-  *at startup*. If DNS returns different IPs during the run, the
-  drift goes unmatched. Short-lived CI jobs are fine; long-lived
-  daemons should periodically refresh (roadmap).
+<!-- DNS round-robin drift: addressed by `--dns-refresh-interval <secs>`
+     on `coronarium run`. Re-resolves hostname rules on the given
+     interval and additively inserts any newly-observed IPs into the
+     eBPF maps. Default is 0 (off); set to 60–300 for long-running
+     CDN-heavy jobs. Entries are never removed, so increasing the
+     rate is safe and won't kill active connections. -->
+- **CDN IP rotation across long runs**: handled by
+  `coronarium run --dns-refresh-interval <secs>`, which re-resolves
+  `network.allow` / `network.deny` hostnames every N seconds and
+  additively inserts new IPs. Off by default (0); 60–300 is typical
+  for CI jobs that run for hours behind round-robin DNS.
 
 ### Linux supervised run
 

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -411,6 +411,17 @@ pub struct RunArgs {
     #[arg(long)]
     pub html: Option<PathBuf>,
 
+    /// Re-resolve hostname-based `network.allow` / `network.deny`
+    /// rules on this interval (seconds) and additively populate the
+    /// eBPF map with any newly-observed IPs. Needed for long-running
+    /// supervised jobs behind CDN round-robin DNS: a CDN that
+    /// rotates its IP set mid-run would otherwise start hitting
+    /// addresses the map has never seen. `0` disables refresh
+    /// (default). Entries are never removed once written, so
+    /// increasing the refresh rate is safe.
+    #[arg(long, default_value_t = 0, value_name = "SECS")]
+    pub dns_refresh_interval: u64,
+
     /// Command + args to execute under supervision.
     #[arg(trailing_var_arg = true, required = true)]
     pub command: Vec<String>,
@@ -666,7 +677,12 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         args.command
     );
 
-    let supervised = loader::Supervisor::start(policy.clone(), mode).await?;
+    let supervised = loader::Supervisor::start(
+        policy.clone(),
+        mode,
+        std::time::Duration::from_secs(args.dns_refresh_interval),
+    )
+    .await?;
     let exit = supervised.run_child(&args.command).await?;
     let mut stats = supervised.shutdown().await?;
 

--- a/crates/coronarium/src/enforcer.rs
+++ b/crates/coronarium/src/enforcer.rs
@@ -3,6 +3,16 @@
 
 use crate::{cgroup::Cgroup, policy::Policy, resolve::Resolver};
 
+#[cfg(target_os = "linux")]
+use std::sync::Arc;
+#[cfg(target_os = "linux")]
+use tokio::sync::Mutex;
+
+#[cfg(target_os = "linux")]
+use crate::resolve::Endpoint;
+#[cfg(target_os = "linux")]
+use crate::resolve_refresh::{EndpointSink, Verdict};
+
 #[allow(dead_code)]
 pub struct Enforcer;
 
@@ -125,6 +135,107 @@ async fn resolve_all(
         match resolver.expand(rule).await {
             Ok(mut eps) => out.append(&mut eps),
             Err(err) => log::warn!("resolving {}: {err:#}", rule.target),
+        }
+    }
+    out
+}
+
+/// [`EndpointSink`] implementation that writes into the live NET4 /
+/// NET6 eBPF hash maps owned by the supervisor's shared `Ebpf`
+/// object. Locks the async `Mutex<Ebpf>` only for the duration of one
+/// insert, so it composes cleanly with the existing ringbuf drain
+/// task (which doesn't hold the lock either, having taken EVENTS out
+/// at startup).
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+pub struct BpfEndpointSink {
+    bpf: Arc<Mutex<aya::Ebpf>>,
+}
+
+#[cfg(target_os = "linux")]
+impl BpfEndpointSink {
+    pub fn new(bpf: Arc<Mutex<aya::Ebpf>>) -> Self {
+        Self { bpf }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl EndpointSink for BpfEndpointSink {
+    async fn insert(&self, endpoint: Endpoint, verdict: Verdict) -> anyhow::Result<()> {
+        use std::net::IpAddr;
+
+        use coronarium_common::{Ipv4Key, Ipv6Key};
+
+        let mut guard = self.bpf.lock().await;
+        match endpoint.addr {
+            IpAddr::V4(v4) => {
+                let Some(map) = guard.map_mut("NET4") else {
+                    return Ok(());
+                };
+                let mut m: aya::maps::HashMap<_, Ipv4Key, u8> = aya::maps::HashMap::try_from(map)?;
+                let key = Ipv4Key {
+                    addr: u32::from(v4).to_be(),
+                    port: endpoint.port.to_be(),
+                    _pad: 0,
+                };
+                m.insert(key, verdict.0, 0)?;
+            }
+            IpAddr::V6(v6) => {
+                let Some(map) = guard.map_mut("NET6") else {
+                    return Ok(());
+                };
+                let mut m: aya::maps::HashMap<_, Ipv6Key, u8> = aya::maps::HashMap::try_from(map)?;
+                let key = Ipv6Key {
+                    addr: v6.octets(),
+                    port: endpoint.port.to_be(),
+                    _pad: [0; 6],
+                };
+                m.insert(key, verdict.0, 0)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Read back the `(endpoint, verdict)` pairs currently populated in
+/// NET4 / NET6. Used to prime the refresh loop's `seen` set at
+/// startup so the very first tick doesn't re-write addresses that
+/// [`populate_network_maps`] already installed.
+#[cfg(target_os = "linux")]
+pub async fn current_bpf_entries(bpf: &Arc<Mutex<aya::Ebpf>>) -> Vec<(Endpoint, Verdict)> {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use coronarium_common::{Ipv4Key, Ipv6Key};
+
+    let mut out = Vec::new();
+    let guard = bpf.lock().await;
+    if let Some(map) = guard.map("NET4")
+        && let Ok(m) = aya::maps::HashMap::<_, Ipv4Key, u8>::try_from(map)
+    {
+        for r in m.iter().flatten() {
+            let (k, v) = r;
+            let addr = Ipv4Addr::from(u32::from_be(k.addr));
+            out.push((
+                Endpoint {
+                    addr: IpAddr::V4(addr),
+                    port: u16::from_be(k.port),
+                },
+                Verdict(v),
+            ));
+        }
+    }
+    if let Some(map) = guard.map("NET6")
+        && let Ok(m) = aya::maps::HashMap::<_, Ipv6Key, u8>::try_from(map)
+    {
+        for r in m.iter().flatten() {
+            let (k, v) = r;
+            out.push((
+                Endpoint {
+                    addr: IpAddr::V6(Ipv6Addr::from(k.addr)),
+                    port: u16::from_be(k.port),
+                },
+                Verdict(v),
+            ));
         }
     }
     out

--- a/crates/coronarium/src/loader.rs
+++ b/crates/coronarium/src/loader.rs
@@ -38,10 +38,14 @@ pub struct Supervisor {
     #[cfg(target_os = "linux")]
     #[allow(dead_code)]
     bpf: Option<Arc<Mutex<aya::Ebpf>>>,
+
+    /// Stop signal for the DNS refresh loop (Linux-only; `None` when
+    /// `dns_refresh` is zero or on non-Linux platforms).
+    refresh_stop: Option<crate::resolve_refresh::StopHandle>,
 }
 
 impl Supervisor {
-    pub async fn start(policy: Policy, mode: Mode) -> Result<Self> {
+    pub async fn start(policy: Policy, mode: Mode, dns_refresh: Duration) -> Result<Self> {
         let stats = Arc::new(Mutex::new(Stats::default()));
         let stop = Arc::new(AtomicBool::new(false));
         let file_matcher = Arc::new(FileMatcher::from_policy(&policy.file));
@@ -98,6 +102,47 @@ impl Supervisor {
         #[cfg(not(target_os = "linux"))]
         let _ = Resolver::from_system; // silence unused warning
 
+        // Spawn the DNS refresh loop if requested and we actually
+        // have a BPF object to write into. `refresh_stop` is None
+        // when the feature is off, which is the overwhelming default.
+        #[cfg(target_os = "linux")]
+        let refresh_stop = match (dns_refresh.is_zero(), bpf.as_ref()) {
+            (false, Some(bpf_arc)) => {
+                let resolver = Resolver::from_system()?;
+                let sink = crate::enforcer::BpfEndpointSink::new(Arc::clone(bpf_arc));
+                let loop_ = crate::resolve_refresh::RefreshLoop::new(
+                    resolver,
+                    sink,
+                    policy.network.allow.clone(),
+                    policy.network.deny.clone(),
+                    dns_refresh,
+                );
+                let stop_handle = loop_.stop_handle();
+                let mut seen = std::collections::HashSet::new();
+                // Prime `seen` with the startup population so the
+                // first tick doesn't rewrite every address.
+                let prime = crate::enforcer::current_bpf_entries(bpf_arc).await;
+                crate::resolve_refresh::RefreshLoop::<
+                    Resolver,
+                    crate::enforcer::BpfEndpointSink,
+                >::prime_seen(&mut seen, &prime);
+                tokio::task::spawn(async move {
+                    let _ = loop_.run(seen).await;
+                });
+                log::info!(
+                    "dns-refresh: scheduling re-resolution every {}s",
+                    dns_refresh.as_secs()
+                );
+                Some(stop_handle)
+            }
+            _ => None,
+        };
+        #[cfg(not(target_os = "linux"))]
+        let refresh_stop: Option<crate::resolve_refresh::StopHandle> = {
+            let _ = dns_refresh;
+            None
+        };
+
         let this = Self {
             policy,
             mode,
@@ -106,6 +151,7 @@ impl Supervisor {
             cgroup,
             #[cfg(target_os = "linux")]
             bpf: bpf.clone(),
+            refresh_stop,
         };
 
         #[cfg(target_os = "linux")]
@@ -160,6 +206,9 @@ impl Supervisor {
         // that arrived just before the child exited, then tell it to stop.
         tokio::time::sleep(Duration::from_millis(50)).await;
         self.stop.store(true, Ordering::SeqCst);
+        if let Some(s) = &self.refresh_stop {
+            s.stop();
+        }
         tokio::time::sleep(Duration::from_millis(50)).await;
         Ok(self.stats.lock().await.clone())
     }

--- a/crates/coronarium/src/main.rs
+++ b/crates/coronarium/src/main.rs
@@ -10,6 +10,7 @@ mod loader;
 mod policy;
 mod resolve;
 mod resolve_hostnames;
+mod resolve_refresh;
 
 use anyhow::Result;
 use clap::Parser;

--- a/crates/coronarium/src/resolve_refresh.rs
+++ b/crates/coronarium/src/resolve_refresh.rs
@@ -1,0 +1,555 @@
+//! Periodic DNS re-resolution for hostname-based `network.allow` /
+//! `network.deny` rules.
+//!
+//! # Problem
+//!
+//! Hostnames in a policy are resolved **once at startup** and the
+//! resulting `(IpAddr, port)` tuples are written into the NET4 / NET6
+//! eBPF maps. CDN-backed origins return a different rotation of IPs
+//! each time you query them, so a long-running supervised job can
+//! start hitting addresses the map has never seen and, under
+//! `network.default: deny`, get connections killed that the policy
+//! author clearly intended to allow.
+//!
+//! # Design
+//!
+//! - **Additive only.** We never remove an address once it has been
+//!   inserted — doing so would kill active connections that were
+//!   admitted a moment ago. The worst case is the map gains a handful
+//!   of stale entries per rotation, which the kernel looks up in O(1).
+//!   Bounded by rotation cardinality × run duration / refresh interval.
+//! - **Pure core + thin IO layer.** [`refresh_once`] is generic over
+//!   an [`EndpointResolver`] (the DNS side) and an [`EndpointSink`]
+//!   (the map writer). Both are traits so tests drive the logic with
+//!   in-memory fakes. The Linux enforcer wires a real
+//!   `hickory_resolver::TokioAsyncResolver` and an aya-HashMap sink.
+//! - **Cooperative cancellation.** [`RefreshLoop::run`] polls a
+//!   [`StopHandle`] between ticks so shutdown is prompt.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+use crate::policy::NetRule;
+use crate::resolve::Endpoint;
+
+/// Verdict byte stored in NET4 / NET6. Matches the raw constants in
+/// `coronarium_common`. Held as a newtype so the sink API can't
+/// confuse it with a random `u8`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Verdict(pub u8);
+
+/// Resolve a single rule to its current endpoint list. Abstracted so
+/// tests can inject a scripted resolver without reaching for a real
+/// hickory runtime. The real implementation is
+/// [`crate::resolve::Resolver`].
+pub trait EndpointResolver: Send + Sync {
+    fn expand(
+        &self,
+        rule: &NetRule,
+    ) -> impl std::future::Future<Output = anyhow::Result<Vec<Endpoint>>> + Send;
+}
+
+impl EndpointResolver for crate::resolve::Resolver {
+    async fn expand(&self, rule: &NetRule) -> anyhow::Result<Vec<Endpoint>> {
+        crate::resolve::Resolver::expand(self, rule).await
+    }
+}
+
+/// Destination for newly-observed endpoints. The Linux enforcer
+/// writes into the BPF hash maps; tests capture into a `Vec`.
+pub trait EndpointSink: Send + Sync {
+    /// Insert a `(endpoint, verdict)` pair. Called only for endpoints
+    /// the refresher has not seen on a previous tick — the sink may
+    /// still observe duplicates across restarts, so insert should be
+    /// idempotent. Async so implementations can lock a
+    /// `tokio::sync::Mutex` guarding shared state (the Linux sink
+    /// holds the eBPF object that way).
+    fn insert(
+        &self,
+        endpoint: Endpoint,
+        verdict: Verdict,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+}
+
+/// Apply one refresh pass across a set of `(rules, verdict)` buckets.
+/// Inserts only endpoints that are not already in `seen`; updates
+/// `seen` on success. Resolver failures are logged and skipped so a
+/// transient DNS outage doesn't poison the loop.
+pub async fn refresh_once<R: EndpointResolver, S: EndpointSink>(
+    resolver: &R,
+    buckets: &[(Verdict, &[NetRule])],
+    sink: &S,
+    seen: &mut HashSet<SeenKey>,
+) -> RefreshStats {
+    let mut stats = RefreshStats::default();
+    for (verdict, rules) in buckets {
+        for rule in *rules {
+            match resolver.expand(rule).await {
+                Ok(eps) => {
+                    for ep in eps {
+                        let key = SeenKey::of(&ep, *verdict);
+                        if seen.insert(key) {
+                            match sink.insert(ep, *verdict).await {
+                                Ok(()) => stats.added += 1,
+                                Err(e) => {
+                                    log::warn!(
+                                        "dns-refresh: sink insert failed for {}: {e:#}",
+                                        rule.target
+                                    );
+                                    // Roll back `seen` so a later tick retries.
+                                    seen.remove(&key);
+                                    stats.errors += 1;
+                                }
+                            }
+                        } else {
+                            stats.skipped += 1;
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::debug!("dns-refresh: resolve failed for {}: {e:#}", rule.target);
+                    stats.errors += 1;
+                }
+            }
+        }
+    }
+    stats
+}
+
+/// What happened during a single [`refresh_once`] pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RefreshStats {
+    /// Endpoints the sink accepted for the first time.
+    pub added: usize,
+    /// Endpoints already present in `seen`; not forwarded to the sink.
+    pub skipped: usize,
+    /// Resolver or sink errors during this pass.
+    pub errors: usize,
+}
+
+/// Hashable identity of a `(endpoint, verdict)` pair. Port is
+/// included so the same IP allowed on 443 and denied on 80 tracks
+/// two separate entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SeenKey {
+    pub addr: IpAddr,
+    pub port: u16,
+    pub verdict: u8,
+}
+
+impl SeenKey {
+    pub fn of(ep: &Endpoint, v: Verdict) -> Self {
+        Self {
+            addr: ep.addr,
+            port: ep.port,
+            verdict: v.0,
+        }
+    }
+}
+
+/// Driver that re-runs [`refresh_once`] on an interval until the stop
+/// signal fires. Cloneable via `Arc` so the supervisor can hold a
+/// handle to signal shutdown.
+pub struct RefreshLoop<R: EndpointResolver, S: EndpointSink> {
+    resolver: R,
+    sink: S,
+    allow: Vec<NetRule>,
+    deny: Vec<NetRule>,
+    interval: Duration,
+    stop: StopHandle,
+}
+
+/// Shutdown signal. Uses an [`AtomicBool`] so that `stop()` called
+/// before `run()` starts waiting is not lost, plus a [`Notify`] so
+/// the wait is cheap while the flag is false.
+#[derive(Clone, Default)]
+pub struct StopHandle {
+    inner: Arc<StopInner>,
+}
+
+#[derive(Default)]
+struct StopInner {
+    flag: AtomicBool,
+    notify: Notify,
+}
+
+impl StopHandle {
+    pub fn stop(&self) {
+        self.inner.flag.store(true, Ordering::SeqCst);
+        self.inner.notify.notify_waiters();
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.inner.flag.load(Ordering::SeqCst)
+    }
+
+    async fn notified(&self) {
+        // If stop was signalled before we registered, return immediately.
+        if self.is_stopped() {
+            return;
+        }
+        self.inner.notify.notified().await;
+    }
+}
+
+impl<R: EndpointResolver, S: EndpointSink> RefreshLoop<R, S> {
+    pub fn new(
+        resolver: R,
+        sink: S,
+        allow: Vec<NetRule>,
+        deny: Vec<NetRule>,
+        interval: Duration,
+    ) -> Self {
+        Self {
+            resolver,
+            sink,
+            allow,
+            deny,
+            interval,
+            stop: StopHandle::default(),
+        }
+    }
+
+    /// Handle to the stop signal. Call
+    /// `stop_handle.stop()` from another task to wind the loop down
+    /// at the next tick boundary. Safe to call even before `run()`
+    /// starts — the next `run()` call observes the flag immediately.
+    pub fn stop_handle(&self) -> StopHandle {
+        self.stop.clone()
+    }
+
+    /// Seed `seen` with the endpoints already written to the sink at
+    /// startup, so the first tick doesn't re-insert everything.
+    pub fn prime_seen(seen: &mut HashSet<SeenKey>, initial: &[(Endpoint, Verdict)]) {
+        for (ep, v) in initial {
+            seen.insert(SeenKey::of(ep, *v));
+        }
+    }
+
+    /// Run forever, re-resolving and inserting new endpoints every
+    /// `self.interval`, until `stop_handle()` is notified. Returns
+    /// the final `seen` set for callers that want to inspect it.
+    pub async fn run(&self, mut seen: HashSet<SeenKey>) -> HashSet<SeenKey> {
+        if self.interval.is_zero() {
+            return seen;
+        }
+        loop {
+            if self.stop.is_stopped() {
+                break;
+            }
+            tokio::select! {
+                _ = self.stop.notified() => break,
+                _ = tokio::time::sleep(self.interval) => {
+                    let buckets = [
+                        (Verdict(coronarium_common::POLICY_ALLOW), self.allow.as_slice()),
+                        (Verdict(coronarium_common::POLICY_DENY), self.deny.as_slice()),
+                    ];
+                    let stats = refresh_once(&self.resolver, &buckets, &self.sink, &mut seen).await;
+                    if stats.added > 0 {
+                        log::info!(
+                            "dns-refresh: added {} new endpoint(s), skipped {} known, {} error(s)",
+                            stats.added,
+                            stats.skipped,
+                            stats.errors
+                        );
+                    }
+                }
+            }
+        }
+        seen
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+    use std::sync::Mutex;
+
+    /// Scripted resolver: each rule target maps to a queue of
+    /// responses returned on successive calls.
+    struct ScriptedResolver {
+        responses:
+            Mutex<std::collections::HashMap<String, std::collections::VecDeque<Vec<IpAddr>>>>,
+    }
+
+    impl ScriptedResolver {
+        fn new(script: &[(&str, Vec<Vec<IpAddr>>)]) -> Self {
+            let mut m = std::collections::HashMap::new();
+            for (target, rounds) in script {
+                m.insert((*target).into(), rounds.iter().cloned().collect());
+            }
+            Self {
+                responses: Mutex::new(m),
+            }
+        }
+    }
+
+    impl EndpointResolver for ScriptedResolver {
+        async fn expand(&self, rule: &NetRule) -> anyhow::Result<Vec<Endpoint>> {
+            let mut m = self.responses.lock().unwrap();
+            let queue = m.get_mut(&rule.target).ok_or_else(|| {
+                anyhow::anyhow!("ScriptedResolver: no script for {}", rule.target)
+            })?;
+            let addrs = queue
+                .pop_front()
+                .ok_or_else(|| anyhow::anyhow!("ScriptedResolver: script exhausted"))?;
+            let ports: Vec<u16> = if rule.ports.is_empty() {
+                vec![0]
+            } else {
+                rule.ports.clone()
+            };
+            let mut out = Vec::new();
+            for addr in addrs {
+                for port in &ports {
+                    out.push(Endpoint { addr, port: *port });
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        inserted: Mutex<Vec<(IpAddr, u16, u8)>>,
+        fail_after: Mutex<Option<usize>>,
+    }
+
+    impl EndpointSink for RecordingSink {
+        async fn insert(&self, endpoint: Endpoint, verdict: Verdict) -> anyhow::Result<()> {
+            if let Some(n) = *self.fail_after.lock().unwrap() {
+                let mut ins = self.inserted.lock().unwrap();
+                if ins.len() >= n {
+                    return Err(anyhow::anyhow!("sink induced failure"));
+                }
+                ins.push((endpoint.addr, endpoint.port, verdict.0));
+            } else {
+                self.inserted
+                    .lock()
+                    .unwrap()
+                    .push((endpoint.addr, endpoint.port, verdict.0));
+            }
+            Ok(())
+        }
+    }
+
+    fn rule(target: &str, ports: &[u16]) -> NetRule {
+        NetRule {
+            target: target.into(),
+            ports: ports.to_vec(),
+        }
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[tokio::test]
+    async fn refresh_inserts_new_endpoints_and_skips_known_ones() {
+        let resolver = ScriptedResolver::new(&[(
+            "api.example.com",
+            vec![
+                vec![ip("1.2.3.4")],                // tick 1
+                vec![ip("1.2.3.4"), ip("5.6.7.8")], // tick 2: rotation adds a new IP
+                vec![ip("5.6.7.8")],                // tick 3: old IP has aged out
+            ],
+        )]);
+        let sink = RecordingSink::default();
+        let rules = [rule("api.example.com", &[443])];
+        let buckets: [(Verdict, &[NetRule]); 1] =
+            [(Verdict(coronarium_common::POLICY_ALLOW), &rules)];
+        let mut seen = HashSet::new();
+
+        let s1 = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s1.added, 1);
+        assert_eq!(s1.skipped, 0);
+
+        let s2 = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s2.added, 1, "1.2.3.4 already seen, 5.6.7.8 is new");
+        assert_eq!(s2.skipped, 1);
+
+        let s3 = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(
+            s3.added, 0,
+            "5.6.7.8 already seen, 1.2.3.4 is gone (kept in map)"
+        );
+        assert_eq!(s3.skipped, 1);
+
+        let ins = sink.inserted.lock().unwrap();
+        assert_eq!(ins.len(), 2, "sink only saw each endpoint once");
+    }
+
+    #[tokio::test]
+    async fn refresh_does_not_remove_stale_endpoints() {
+        // Add-only semantics: once 1.2.3.4 is in the sink, a later
+        // resolution returning only 5.6.7.8 must not cause a remove.
+        let resolver = ScriptedResolver::new(&[(
+            "api.example.com",
+            vec![vec![ip("1.2.3.4")], vec![ip("5.6.7.8")]],
+        )]);
+        let sink = RecordingSink::default();
+        let rules = [rule("api.example.com", &[443])];
+        let buckets: [(Verdict, &[NetRule]); 1] =
+            [(Verdict(coronarium_common::POLICY_ALLOW), &rules)];
+        let mut seen = HashSet::new();
+        let _ = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        let _ = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        let ins = sink.inserted.lock().unwrap();
+        let addrs: Vec<IpAddr> = ins.iter().map(|(a, _, _)| *a).collect();
+        assert!(addrs.contains(&ip("1.2.3.4")));
+        assert!(addrs.contains(&ip("5.6.7.8")));
+    }
+
+    #[tokio::test]
+    async fn refresh_rolls_back_seen_on_sink_failure() {
+        // If the sink rejects the insert, the endpoint stays unseen
+        // so the next tick retries.
+        let resolver = ScriptedResolver::new(&[(
+            "api.example.com",
+            vec![vec![ip("1.2.3.4")], vec![ip("1.2.3.4")]],
+        )]);
+        let sink = RecordingSink {
+            fail_after: Mutex::new(Some(0)),
+            ..Default::default()
+        };
+        let rules = [rule("api.example.com", &[443])];
+        let buckets: [(Verdict, &[NetRule]); 1] =
+            [(Verdict(coronarium_common::POLICY_ALLOW), &rules)];
+        let mut seen = HashSet::new();
+
+        let s1 = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s1.added, 0);
+        assert_eq!(s1.errors, 1);
+        assert!(seen.is_empty(), "failed insert must not stick in seen");
+
+        // Now let inserts succeed.
+        *sink.fail_after.lock().unwrap() = None;
+        let s2 = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s2.added, 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_handles_mixed_allow_and_deny_verdicts() {
+        let resolver = ScriptedResolver::new(&[
+            ("api.example.com", vec![vec![ip("1.2.3.4")]]),
+            ("evil.example.com", vec![vec![ip("9.9.9.9")]]),
+        ]);
+        let sink = RecordingSink::default();
+        let allow = [rule("api.example.com", &[443])];
+        let deny = [rule("evil.example.com", &[0])];
+        let buckets: [(Verdict, &[NetRule]); 2] = [
+            (Verdict(coronarium_common::POLICY_ALLOW), &allow),
+            (Verdict(coronarium_common::POLICY_DENY), &deny),
+        ];
+        let mut seen = HashSet::new();
+        let _ = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        let ins = sink.inserted.lock().unwrap();
+        assert_eq!(ins.len(), 2);
+        assert!(
+            ins.contains(&(ip("1.2.3.4"), 443, coronarium_common::POLICY_ALLOW)),
+            "allow entry with correct verdict"
+        );
+        assert!(
+            ins.contains(&(ip("9.9.9.9"), 0, coronarium_common::POLICY_DENY)),
+            "deny entry with correct verdict"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_counts_resolver_errors_without_aborting() {
+        let resolver = ScriptedResolver::new(&[("good.example.com", vec![vec![ip("1.2.3.4")]])]);
+        let sink = RecordingSink::default();
+        // "bad.example.com" has no script → error on expand.
+        let rules = [
+            rule("good.example.com", &[443]),
+            rule("bad.example.com", &[443]),
+        ];
+        let buckets: [(Verdict, &[NetRule]); 1] =
+            [(Verdict(coronarium_common::POLICY_ALLOW), &rules)];
+        let mut seen = HashSet::new();
+        let s = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s.added, 1);
+        assert_eq!(s.errors, 1);
+    }
+
+    #[tokio::test]
+    async fn prime_seen_prevents_initial_startup_ips_from_double_inserting() {
+        let resolver =
+            ScriptedResolver::new(&[("api.example.com", vec![vec![ip("1.2.3.4"), ip("5.6.7.8")]])]);
+        let sink = RecordingSink::default();
+        let rules = [rule("api.example.com", &[443])];
+        let buckets: [(Verdict, &[NetRule]); 1] =
+            [(Verdict(coronarium_common::POLICY_ALLOW), &rules)];
+        let mut seen = HashSet::new();
+        // Pretend startup already wrote 1.2.3.4 into the map.
+        RefreshLoop::<ScriptedResolver, RecordingSink>::prime_seen(
+            &mut seen,
+            &[(
+                Endpoint {
+                    addr: ip("1.2.3.4"),
+                    port: 443,
+                },
+                Verdict(coronarium_common::POLICY_ALLOW),
+            )],
+        );
+        let s = refresh_once(&resolver, &buckets, &sink, &mut seen).await;
+        assert_eq!(s.added, 1, "only 5.6.7.8 was new");
+        assert_eq!(s.skipped, 1);
+    }
+
+    #[test]
+    fn seen_key_distinguishes_verdict_and_port() {
+        let a = Endpoint {
+            addr: IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+            port: 443,
+        };
+        let k1 = SeenKey::of(&a, Verdict(coronarium_common::POLICY_ALLOW));
+        let k2 = SeenKey::of(&a, Verdict(coronarium_common::POLICY_DENY));
+        let k3 = SeenKey::of(
+            &Endpoint {
+                addr: a.addr,
+                port: 80,
+            },
+            Verdict(coronarium_common::POLICY_ALLOW),
+        );
+        assert_ne!(k1, k2);
+        assert_ne!(k1, k3);
+    }
+
+    #[tokio::test]
+    async fn refresh_loop_exits_promptly_on_stop_signal() {
+        let resolver = ScriptedResolver::new(&[]);
+        let sink = RecordingSink::default();
+        let loop_ = RefreshLoop::new(resolver, sink, vec![], vec![], Duration::from_millis(50));
+        let stop = loop_.stop_handle();
+        // Fire the stop signal *before* spawning, to exercise the
+        // race where stop() lands before run() registers a waiter.
+        stop.stop();
+        let handle = tokio::spawn(async move { loop_.run(HashSet::new()).await });
+        let seen = tokio::time::timeout(Duration::from_millis(500), handle)
+            .await
+            .expect("refresh loop did not exit in time")
+            .unwrap();
+        assert!(seen.is_empty());
+    }
+
+    #[tokio::test]
+    async fn zero_interval_makes_run_return_immediately() {
+        let resolver = ScriptedResolver::new(&[]);
+        let sink = RecordingSink::default();
+        let loop_ = RefreshLoop::new(
+            resolver,
+            sink,
+            vec![rule("api.example.com", &[443])],
+            vec![],
+            Duration::ZERO,
+        );
+        let seen = loop_.run(HashSet::new()).await;
+        assert!(seen.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- New `resolve_refresh` module: cross-platform pure-Rust refresh logic with `EndpointResolver` / `EndpointSink` traits (AFIT, no async-trait dep) and a race-safe `StopHandle`.
- **Add-only semantics** — IPs are never removed mid-run, so stale entries can't kill active connections.
- Linux-only `BpfEndpointSink` writes into live NET4 / NET6 eBPF maps via the supervisor's shared `Arc<Mutex<Ebpf>>`. `current_bpf_entries` primes the loop's `seen` set at startup.
- New flag: `coronarium run --dns-refresh-interval <secs>` (default 0 = off). Typical value 60-300 for hour-long CI jobs behind CDN round-robin.
- README: swap the "DNS round-robin drift" caveat for a pointer to the flag.

9 new tests (insertion, add-only, sink-failure rollback, mixed verdicts, resolver-error tolerance, prime_seen, SeenKey identity, stop-race, zero-interval).

## Test plan
- [x] `cargo test -p coronarium --bin coronarium` — 31 pass
- [x] `cargo test --workspace --lib` — 229 pass
- [x] `cargo clippy -p coronarium --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] End-to-end Linux verification of the eBPF sink path (macOS dev env can't exercise `BpfEndpointSink`; the Linux CI job will)

## Notes
- `BpfEndpointSink` / `current_bpf_entries` only build under `#[cfg(target_os = "linux")]`; macOS / Windows builds leave `refresh_stop = None` and the feature is a no-op.
- Roadmap item "Linux pre-syscall block (P0-2)" is unaffected — still deferred to a Linux session since it needs eBPF rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)