### PR TITLE
ci: harden-runner with per-workflow egress allowlists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ jobs:
   userspace:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            index.crates.io:443
+            static.crates.io:443
+            crates.io:443
+            registry.npmjs.org:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            api.nuget.org:443
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,6 +129,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: userspace
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            index.crates.io:443
+            static.crates.io:443
+            crates.io:443
+            registry.npmjs.org:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            api.nuget.org:443
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --release -p coronarium
@@ -244,6 +274,22 @@ jobs:
   ebpf:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            index.crates.io:443
+            static.crates.io:443
+            crates.io:443
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -277,6 +323,27 @@ jobs:
             arch: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
+      # NB: this job's e2e tests deliberately open connections so
+      # coronarium's eBPF hooks can deny them (1.1.1.1, 8.8.8.8,
+      # example.com, 93.184.216.34). Harden-runner must therefore
+      # *allow* those endpoints — the kernel-side block we're
+      # verifying happens inside `coronarium run`, not at the
+      # runner egress layer.
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            index.crates.io:443
+            static.crates.io:443
+            crates.io:443
+            example.com:443
+            1.1.1.1:443
+            8.8.8.8:443
+            93.184.216.34:80
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       # Build the userspace binary natively on this runner's arch.

--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -18,6 +18,18 @@ jobs:
   use-as-action:
     runs-on: ubuntu-latest
     steps:
+      # 1.1.1.1, 8.8.8.8 are the audit-mode deny targets — the curl
+      # below has to actually reach them so coronarium can audit (and
+      # tag denied) the connect at the eBPF layer.
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            1.1.1.1:443
+            8.8.8.8:443
       - uses: actions/checkout@v4
 
       # The exact pattern third-party consumers will write.
@@ -123,6 +135,17 @@ jobs:
     # happens. Runs alongside use-as-action (doesn't need its results).
     runs-on: ubuntu-latest
     steps:
+      # The block-mode test attempts http://93.184.216.34 specifically
+      # so coronarium's eBPF can deny the connect; allow it through
+      # harden-runner so the kernel hook sees the syscall.
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            93.184.216.34:80
       - uses: actions/checkout@v4
       - uses: bokuweb/coronarium@v0
         with:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -12,6 +12,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,26 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            ghcr.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            pkg-containers.githubusercontent.com:443
+            actions-results-receiver-production.githubapp.com:443
+            results-receiver.actions.githubusercontent.com:443
+            deb.debian.org:80
+            security.debian.org:80
+            static.crates.io:443
+            index.crates.io:443
+            crates.io:443
+            static.rust-lang.org:443
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -30,6 +30,13 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
       - uses: actions/checkout@v4
         with:
           ref: main

--- a/.github/workflows/osv-mirror.yml
+++ b/.github/workflows/osv-mirror.yml
@@ -35,6 +35,14 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Checkout main (for the producer script)
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,23 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            static.rust-lang.org:443
+            index.crates.io:443
+            static.crates.io:443
+            crates.io:443
+            archive.ubuntu.com:80
+            security.ubuntu.com:80
+            azure.archive.ubuntu.com:80
+            ports.ubuntu.com:80
+            esm.ubuntu.com:443
+            motd.ubuntu.com:443
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
@@ -139,6 +156,14 @@ jobs:
     needs: [build-linux, build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
@@ -163,6 +188,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.ref_name, '-')"
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/typosquat-data.yml
+++ b/.github/workflows/typosquat-data.yml
@@ -32,6 +32,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v2
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            hugovk.dev:443
+            crates.io:443
+            anvaka.github.io:443
+            azuresearch-usnc.nuget.org:443
       - uses: actions/checkout@v4
         with:
           ref: main


### PR DESCRIPTION
## Summary
- Adds `step-security/harden-runner@v2` (`egress-policy: block`) to every Linux job across the 8 workflows.
- Each job's `allowed-endpoints` lists only the hostnames it actually contacts: GitHub APIs, `static.rust-lang.org`, `*.crates.io`, the four registry hosts the proxy/deps tests probe, Ubuntu/Debian apt mirrors, GHCR + Docker Hub for the image build, `storage.googleapis.com` for OSV, the typosquat ranking sources, etc.
- Smoke jobs deliberately allow the test target IPs (1.1.1.1, 8.8.8.8, 93.184.216.34, example.com) so coronarium's own eBPF hooks can still see and deny those connects — kernel-side enforcement is what those tests verify, not runner egress.
- Windows / macOS jobs (`windows-smoke.yml`, `windows-*` and `macos-*` matrix arms in `release.yml` / `consumer-smoke.yml`) are unchanged: harden-runner only supports Ubuntu runners.

## Caveats / follow-ups
- `@v2` floats; consider pinning to a specific commit SHA once you've verified a green run.
- The allowlists are best-effort from reading the workflow source. If a job fails with an `Egress policy violation`, the harden-runner job summary lists the exact host:port that was blocked — add it to the relevant `allowed-endpoints` and push again. Running the workflow once in `egress-policy: audit` first is also a fine way to derive the truth.

## Test plan
- [ ] Push triggers `ci`, `dco`, `consumer-smoke` — confirm they pass under `block` mode
- [ ] Tag a release candidate to exercise `release.yml`, `docker.yml`, `homebrew-formula.yml`
- [ ] Wait for one cron firing of `osv-mirror.yml` and `typosquat-data.yml`
- [ ] Inspect each job's harden-runner summary for "no policy violations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)