### PR TITLE
loader: hint at sudo PATH-strip when child spawn fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,11 @@ steps:
 
   - if: runner.os == 'Linux'
     run: |
-      sudo -E "$CORONARIUM_BIN" run \
+      # `sudo -E` preserves env *except* PATH (sudo always replaces
+      # it with secure_path). `env "PATH=$PATH"` re-injects the
+      # runner user's PATH so the supervised child can find tools
+      # installed outside /usr/bin (pnpm, cargo, rustup toolchains).
+      sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
         --policy  "$CORONARIUM_POLICY" \
         --mode    "$CORONARIUM_MODE" \
         --log     "$CORONARIUM_LOG" \

--- a/crates/coronarium/src/loader.rs
+++ b/crates/coronarium/src/loader.rs
@@ -202,8 +202,8 @@ impl Supervisor {
             // rustup-installed toolchains, …). Surface the workaround
             // in the error rather than letting users debug it raw.
             let is_relative = !std::path::Path::new(program).is_absolute();
-            let under_sudo = std::env::var_os("SUDO_USER").is_some()
-                || std::env::var_os("SUDO_UID").is_some();
+            let under_sudo =
+                std::env::var_os("SUDO_USER").is_some() || std::env::var_os("SUDO_UID").is_some();
             if is_relative && under_sudo {
                 format!(
                     "spawning {program}: not found on sudo's PATH. \

--- a/crates/coronarium/src/loader.rs
+++ b/crates/coronarium/src/loader.rs
@@ -194,10 +194,31 @@ impl Supervisor {
         #[cfg(not(target_os = "linux"))]
         let _ = cgroup_path;
 
-        let status = cmd
-            .status()
-            .await
-            .with_context(|| format!("spawning {program}"))?;
+        let status = cmd.status().await.with_context(|| {
+            // sudo replaces PATH with secure_path even with `-E`, so a
+            // non-absolute program name run under sudo will look up
+            // against /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            // and miss anything installed elsewhere (pnpm, cargo,
+            // rustup-installed toolchains, …). Surface the workaround
+            // in the error rather than letting users debug it raw.
+            let is_relative = !std::path::Path::new(program).is_absolute();
+            let under_sudo = std::env::var_os("SUDO_USER").is_some()
+                || std::env::var_os("SUDO_UID").is_some();
+            if is_relative && under_sudo {
+                format!(
+                    "spawning {program}: not found on sudo's PATH. \
+                     sudo strips PATH (`-E` doesn't preserve it); pass it \
+                     explicitly with `sudo -E env \"PATH=$PATH\" {} ...` \
+                     or use an absolute path",
+                    std::env::current_exe()
+                        .ok()
+                        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                        .unwrap_or_else(|| "coronarium".into()),
+                )
+            } else {
+                format!("spawning {program}")
+            }
+        })?;
         Ok(status.code().unwrap_or(1))
     }
 


### PR DESCRIPTION
## Summary
The README's CI example wraps a supervised step like

```yaml
sudo -E "$CORONARIUM_BIN" run --policy ... -- pnpm test
```

…but `sudo` always replaces `PATH` with `secure_path` (even with `-E` — PATH is treated specially), so any tool installed outside `/usr/bin` (pnpm, cargo, rustup-managed toolchains, GitHub-Actions-installed binaries) fails to spawn with a bare:

```
Error: spawning pnpm

Caused by:
    No such file or directory (os error 2)
```

Hit on a real downstream consumer in [reg-viz/reg-cli#650](https://github.com/reg-viz/reg-cli/pull/650).

This PR:

- **`crates/coronarium/src/loader.rs`**: when the child fails to spawn, detect `SUDO_USER` / `SUDO_UID` + non-absolute program and extend the error message to point at the workaround.
- **`README.md`**: update the eBPF-supervised CI example to use `sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run …` so users don't fall into this in the first place.

The supervised commands inside this repo's own `ci.yml` / `consumer-smoke.yml` always wrap with `/bin/sh -c '…'` and absolute paths, so they don't trip the bug — that's why CI is green today.

## Example output after this change
Before:
```
Error: spawning pnpm

Caused by:
    No such file or directory (os error 2)
```

After:
```
Error: spawning pnpm: not found on sudo's PATH. sudo strips PATH (`-E`
doesn't preserve it); pass it explicitly with
`sudo -E env "PATH=$PATH" coronarium ...` or use an absolute path

Caused by:
    No such file or directory (os error 2)
```

## Test plan
- [x] `cargo check -p coronarium`
- [ ] CI green
- [ ] Manually verify the new error text by running `sudo -E coronarium run -- pnpm test` on a runner where pnpm is on the user PATH but not on sudo's secure_path
- [ ] README example pasted into a fresh workflow finds `cargo` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)