### PR TITLE
coronarium-win: resolve program via PATHEXT before spawn

### DIFF
--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -209,10 +209,25 @@ pub fn run() -> Result<()> {
         None
     };
 
-    let status = Command::new(program)
+    // Rust's `Command::new` on Windows does NOT honour PATHEXT, so a
+    // bare `pnpm` (a `.cmd` shim from pnpm/action-setup), `yarn`,
+    // `npm`, etc. would fail to spawn even though `where pnpm` finds
+    // them. Resolve via `where`-backed lookup so the supervised
+    // command matches what users see in their shell.
+    let resolved = resolve_program(program);
+    let status = Command::new(&resolved)
         .args(rest)
         .status()
-        .with_context(|| format!("spawning {program}"))?;
+        .with_context(|| {
+            format!(
+                "spawning {program}{}",
+                if resolved.as_os_str() == std::ffi::OsStr::new(program) {
+                    ": program not found on PATH (PATHEXT-aware lookup via `where` returned nothing)"
+                } else {
+                    ""
+                }
+            )
+        })?;
 
     // Drain tail events. ETW is async; bursts take a second or so to
     // percolate through the buffering path into our callback.


### PR DESCRIPTION
## Summary
On Windows, `std::process::Command::new("pnpm")` calls CreateProcess which only matches `<name>.exe` — PATHEXT is not consulted. So a bare `pnpm` (installed by `pnpm/action-setup` as `pnpm.cmd`), `yarn`, `npm`, or any other `.cmd` shim fails to spawn under coronarium-win with:

```
[INFO  coronarium_win::win] starting coronarium-win (mode=Audit, command=["pnpm", "test"])
Error: spawning pnpm

Caused by:
    program not found
```

…even though the user's shell finds it fine.

`crates/coronarium-win/src/firewall.rs` already exposes `resolve_program()` — a `where`-backed lookup that does PATHEXT — and `win.rs` already imports it for installing firewall block rules. This PR routes the supervised-run spawn through the same helper, so `pnpm test`, `yarn build`, `npm test`, etc. just work without users having to wrap with `cmd /c "..."` or hand-resolve absolute paths.

The error message is also tightened: when `where` returns nothing the spawn error now says so explicitly.

## Origin
Surfaced from a downstream consumer adopting `bokuweb/coronarium@v0` in [reg-viz/reg-cli#650](https://github.com/reg-viz/reg-cli/pull/650). The Linux side of the same problem (sudo PATH-strip) was the just-merged #37; this is its Windows counterpart.

## Test plan
- [ ] `windows-smoke.yml` keeps passing — its existing tests use `whoami` / `powershell` / `curl.exe` (all `.exe`s, so the previous code path was fine and the new code path returns the same absolute path).
- [ ] Manually verify: on `windows-latest` runner, `coronarium-win.exe --policy ... -- pnpm test` resolves the pnpm `.cmd` shim (needs PATHEXT-only entry).
- [ ] Add a Windows `pnpm` smoke if regressions land later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)