### PR TITLE
feat(run): env.allow / env.deny — scrub envp before exec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,20 @@ when acting on the repo.
 2. **Write tests first.** The codebase intentionally designs IO
    behind traits (Prompter, Notifier, EventSource, ViolationHandler)
    so unit tests can pin behaviour without spawning real processes.
-3. Run the fast local loop:
+3. **Mandatory before every commit / PR push.** All three must
+   pass cleanly — no warnings, no skipped tests, no "I'll fix it
+   in a follow-up". If any of them fail, fix the cause before
+   committing; do not push red.
    ```bash
-   cargo test -p coronarium-core           # pure-Rust core
-   cargo clippy --workspace --all-targets -- -D warnings
    cargo fmt --all -- --check
+   cargo clippy --workspace --all-targets -- -D warnings
+   cargo test --workspace
    ```
+   Tip: run `cargo fmt --all` (without `--check`) first to apply
+   the formatter, then re-run with `--check` to confirm. Clippy is
+   gated with `-D warnings` so a new lint blocks merge — don't
+   silence with `#[allow(...)]` unless the lint is genuinely wrong
+   for the code in question, and explain why in a comment.
 4. Open a PR, let CI cover the Linux+Windows+consumer-smoke runs.
 5. Tag `v0.X.Y` on main to release; `release.yml` owns the rest.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,24 @@ and registry clients. To add a new ecosystem:
    `.github/workflows/ci.yml`.
 6. Bump the "supported" table in README.
 
+## Pre-commit gate (non-negotiable)
+
+Every commit pushed to a branch — by a human or an agent — must pass
+all three of the following, with no warnings or failures:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+This is the same set CI runs, just locally. Fix the cause; don't
+push red and don't `#[allow(...)]` away a clippy lint without a
+comment explaining why the lint is wrong for that code. If a test
+is genuinely flaky (e.g. nanos-based tmpdir collisions under
+parallel runs) re-run once and, if it still fails, fix the flake
+in a separate commit rather than ignoring it.
+
 ## Testing conventions
 
 - **Test-first whenever possible.** Handler traits are specifically

--- a/README.md
+++ b/README.md
@@ -512,6 +512,16 @@ file:
 process:
   deny_exec:
     - /usr/bin/nc
+
+env:
+  # Scrub the env block before the child execs. Real prevention,
+  # not a tripwire — `Command::env_clear()` happens before
+  # `execve`, so the child (and its postinstall grandchildren)
+  # literally cannot read what's been stripped.
+  default: pass                  # `pass` keeps everything not on `deny`;
+                                 # `clear` flips it to allowlist mode
+  allow: [PATH, HOME, "GITHUB_*"]
+  deny: ["AWS_*", "*_TOKEN", "*_SECRET", NPM_TOKEN]
 ```
 
 **First-time setup pattern** — run in `mode: audit` once, inspect

--- a/crates/coronarium-core/src/lib.rs
+++ b/crates/coronarium-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod stats;
 
 pub use events::Event;
 pub use policy::{
-    DefaultDecision, FilePolicy, Mode, NetRule, NetworkPolicy, Policy, ProcessPolicy,
+    DefaultDecision, EnvDefault, EnvPolicy, FilePolicy, Mode, NetRule, NetworkPolicy, Policy,
+    ProcessPolicy,
 };
 pub use stats::Stats;

--- a/crates/coronarium-core/src/policy.rs
+++ b/crates/coronarium-core/src/policy.rs
@@ -354,16 +354,20 @@ mod tests {
     #[test]
     fn env_is_active_only_when_configured() {
         assert!(!EnvPolicy::default().is_active());
-        assert!(EnvPolicy {
-            default: EnvDefault::Clear,
-            ..Default::default()
-        }
-        .is_active());
-        assert!(EnvPolicy {
-            deny: vec!["X".into()],
-            ..Default::default()
-        }
-        .is_active());
+        assert!(
+            EnvPolicy {
+                default: EnvDefault::Clear,
+                ..Default::default()
+            }
+            .is_active()
+        );
+        assert!(
+            EnvPolicy {
+                deny: vec!["X".into()],
+                ..Default::default()
+            }
+            .is_active()
+        );
     }
 
     #[test]

--- a/crates/coronarium-core/src/policy.rs
+++ b/crates/coronarium-core/src/policy.rs
@@ -32,6 +32,8 @@ pub struct Policy {
     pub file: FilePolicy,
     #[serde(default)]
     pub process: ProcessPolicy,
+    #[serde(default)]
+    pub env: EnvPolicy,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -68,6 +70,124 @@ pub struct ProcessPolicy {
     pub deny_exec: Vec<String>,
 }
 
+/// What to do with environment variables that match neither `allow`
+/// nor `deny`. `pass` (default) is "supervisor only strips what `deny`
+/// names"; `clear` flips it to allowlist semantics — anything not on
+/// `allow` is removed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EnvDefault {
+    #[default]
+    Pass,
+    Clear,
+}
+
+/// Filter the environment block before exec'ing the child. Patterns
+/// are matched against the env-var **name** and support a single `*`
+/// wildcard per segment (e.g. `AWS_*`, `*_TOKEN`, `GITHUB_*_PATH`).
+///
+/// `deny` always wins over `allow`. With `default: pass` the supervisor
+/// only strips `deny`-matched names; with `default: clear` it starts
+/// from an empty env and keeps only `allow`-matched names (then still
+/// honours `deny` on top, in case `allow` was broader).
+///
+/// Unlike eBPF-backed deny lists, this is genuine **prevention**: the
+/// child never sees the value, because `Command::env_clear` happens
+/// before `execve`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EnvPolicy {
+    #[serde(default)]
+    pub default: EnvDefault,
+    #[serde(default)]
+    pub allow: Vec<String>,
+    #[serde(default)]
+    pub deny: Vec<String>,
+}
+
+impl EnvPolicy {
+    /// True when the policy would change *something* about the child's
+    /// env. `false` means the supervisor can safely skip the env_clear
+    /// dance and inherit untouched.
+    pub fn is_active(&self) -> bool {
+        !matches!(self.default, EnvDefault::Pass) || !self.allow.is_empty() || !self.deny.is_empty()
+    }
+
+    /// Apply the policy to a parent environment, returning the
+    /// `(kept, removed_keys)` pair. `removed_keys` is the set of names
+    /// that *were* in the parent env but were stripped — useful for
+    /// audit logging. Names matching nothing in either list are kept
+    /// or dropped according to `default`.
+    pub fn resolve<I, K, V>(&self, parent: I) -> (Vec<(String, String)>, Vec<String>)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut kept = Vec::new();
+        let mut removed = Vec::new();
+        for (k, v) in parent {
+            let name: String = k.into();
+            let value: String = v.into();
+            let denied = self.deny.iter().any(|p| glob_match(p, &name));
+            let allowed = self.allow.iter().any(|p| glob_match(p, &name));
+            let keep = if denied {
+                false
+            } else if allowed {
+                true
+            } else {
+                matches!(self.default, EnvDefault::Pass)
+            };
+            if keep {
+                kept.push((name, value));
+            } else {
+                removed.push(name);
+            }
+        }
+        removed.sort();
+        (kept, removed)
+    }
+}
+
+/// Glob match on env-var names. Supports `*` (matches any run of
+/// characters, including empty); literal otherwise. We intentionally
+/// don't pull in the `glob` crate — names are ASCII-ish and the
+/// patterns we care about (`AWS_*`, `*_TOKEN`, `GITHUB_*_PATH`) all
+/// fit this minimal grammar.
+fn glob_match(pattern: &str, name: &str) -> bool {
+    // Fast path: no wildcard.
+    if !pattern.contains('*') {
+        return pattern == name;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut cursor = 0usize;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            if !name[cursor..].starts_with(part) {
+                return false;
+            }
+            cursor += part.len();
+        } else if i == parts.len() - 1 {
+            // Last literal segment must align with the end of the name.
+            if !name[cursor..].ends_with(part) {
+                return false;
+            }
+            // And it has to come *after* `cursor`.
+            if name.len() < cursor + part.len() {
+                return false;
+            }
+        } else {
+            match name[cursor..].find(part) {
+                Some(pos) => cursor += pos + part.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
 impl Policy {
     pub fn from_file(path: &Path) -> Result<Self> {
         let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
@@ -94,6 +214,7 @@ impl Policy {
                 ..Default::default()
             },
             process: ProcessPolicy::default(),
+            env: EnvPolicy::default(),
         }
     }
 
@@ -143,6 +264,120 @@ mod tests {
         assert!(p.network.allow.is_empty());
         assert!(p.file.deny.is_empty());
         assert!(p.process.deny_exec.is_empty());
+        assert_eq!(p.env.default, EnvDefault::Pass);
+        assert!(p.env.allow.is_empty());
+        assert!(p.env.deny.is_empty());
+        assert!(!p.env.is_active());
+    }
+
+    #[test]
+    fn env_glob_match_basics() {
+        assert!(glob_match("PATH", "PATH"));
+        assert!(!glob_match("PATH", "PATHX"));
+        assert!(glob_match("AWS_*", "AWS_SECRET_ACCESS_KEY"));
+        assert!(glob_match("AWS_*", "AWS_"));
+        assert!(!glob_match("AWS_*", "AW"));
+        assert!(glob_match("*_TOKEN", "NPM_TOKEN"));
+        assert!(glob_match("*_TOKEN", "_TOKEN"));
+        assert!(!glob_match("*_TOKEN", "TOKEN"));
+        assert!(glob_match("GITHUB_*_PATH", "GITHUB_STEP_PATH"));
+        assert!(glob_match("GITHUB_*_PATH", "GITHUB__PATH"));
+        assert!(!glob_match("GITHUB_*_PATH", "GITHUB_STEP"));
+        assert!(glob_match("*", "ANYTHING"));
+        assert!(glob_match("*", ""));
+    }
+
+    #[test]
+    fn env_resolve_default_pass_strips_only_deny() {
+        let p = EnvPolicy {
+            default: EnvDefault::Pass,
+            allow: vec![],
+            deny: vec!["*_TOKEN".into(), "AWS_*".into()],
+        };
+        let parent = [
+            ("PATH", "/usr/bin"),
+            ("HOME", "/root"),
+            ("NPM_TOKEN", "abc"),
+            ("AWS_SECRET_ACCESS_KEY", "xyz"),
+        ];
+        let (kept, removed) = p.resolve(parent);
+        let names: Vec<_> = kept.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"PATH"));
+        assert!(names.contains(&"HOME"));
+        assert!(!names.contains(&"NPM_TOKEN"));
+        assert!(!names.contains(&"AWS_SECRET_ACCESS_KEY"));
+        assert_eq!(removed, vec!["AWS_SECRET_ACCESS_KEY", "NPM_TOKEN"]);
+    }
+
+    #[test]
+    fn env_resolve_default_clear_keeps_only_allow() {
+        let p = EnvPolicy {
+            default: EnvDefault::Clear,
+            allow: vec!["PATH".into(), "HOME".into(), "GITHUB_*".into()],
+            deny: vec![],
+        };
+        let parent = [
+            ("PATH", "/usr/bin"),
+            ("HOME", "/root"),
+            ("GITHUB_TOKEN", "ghp"),
+            ("GITHUB_STEP_SUMMARY", "/tmp/x"),
+            ("AWS_SECRET_ACCESS_KEY", "xyz"),
+            ("RANDOM", "1"),
+        ];
+        let (kept, removed) = p.resolve(parent);
+        let names: Vec<_> = kept.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(names.contains(&"PATH"));
+        assert!(names.contains(&"HOME"));
+        assert!(names.contains(&"GITHUB_TOKEN"));
+        assert!(names.contains(&"GITHUB_STEP_SUMMARY"));
+        assert!(!names.contains(&"AWS_SECRET_ACCESS_KEY"));
+        assert!(!names.contains(&"RANDOM"));
+        assert!(removed.contains(&"AWS_SECRET_ACCESS_KEY".to_string()));
+        assert!(removed.contains(&"RANDOM".to_string()));
+    }
+
+    #[test]
+    fn env_resolve_deny_wins_over_allow() {
+        let p = EnvPolicy {
+            default: EnvDefault::Clear,
+            allow: vec!["GITHUB_*".into()],
+            deny: vec!["GITHUB_TOKEN".into()],
+        };
+        let parent = [("GITHUB_TOKEN", "ghp"), ("GITHUB_STEP_SUMMARY", "/tmp")];
+        let (kept, removed) = p.resolve(parent);
+        let names: Vec<_> = kept.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!names.contains(&"GITHUB_TOKEN"));
+        assert!(names.contains(&"GITHUB_STEP_SUMMARY"));
+        assert_eq!(removed, vec!["GITHUB_TOKEN"]);
+    }
+
+    #[test]
+    fn env_is_active_only_when_configured() {
+        assert!(!EnvPolicy::default().is_active());
+        assert!(EnvPolicy {
+            default: EnvDefault::Clear,
+            ..Default::default()
+        }
+        .is_active());
+        assert!(EnvPolicy {
+            deny: vec!["X".into()],
+            ..Default::default()
+        }
+        .is_active());
+    }
+
+    #[test]
+    fn parses_yaml_env_section() {
+        let y = r#"
+env:
+  default: clear
+  allow: [PATH, HOME, "GITHUB_*"]
+  deny: ["*_TOKEN", "AWS_*"]
+"#;
+        let p: Policy = serde_yaml::from_str(y).unwrap();
+        assert_eq!(p.env.default, EnvDefault::Clear);
+        assert_eq!(p.env.allow, vec!["PATH", "HOME", "GITHUB_*"]);
+        assert_eq!(p.env.deny, vec!["*_TOKEN", "AWS_*"]);
     }
 
     #[test]

--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -215,8 +215,26 @@ pub fn run() -> Result<()> {
     // them. Resolve via `where`-backed lookup so the supervised
     // command matches what users see in their shell.
     let resolved = resolve_program(program);
-    let status = Command::new(&resolved)
-        .args(rest)
+    let mut child_cmd = Command::new(&resolved);
+    child_cmd.args(rest);
+
+    // Apply env policy before spawn (real prevention — child's process
+    // env block is the one we hand it, not the inherited one).
+    if policy.env.is_active() {
+        let parent: Vec<(String, String)> = std::env::vars().collect();
+        let (kept, removed) = policy.env.resolve(parent);
+        child_cmd.env_clear();
+        child_cmd.envs(kept);
+        if !removed.is_empty() {
+            log::info!(
+                "env policy: stripped {} variable(s) from child env: {}",
+                removed.len(),
+                removed.join(", ")
+            );
+        }
+    }
+
+    let status = child_cmd
         .status()
         .with_context(|| {
             format!(

--- a/crates/coronarium/src/loader.rs
+++ b/crates/coronarium/src/loader.rs
@@ -176,6 +176,25 @@ impl Supervisor {
         let mut cmd = Command::new(program);
         cmd.args(rest);
 
+        // Apply env policy *before* spawn. This is genuine prevention,
+        // not tripwire: the child's execve sees an envp we control. Any
+        // grandchildren (postinstall scripts, etc.) inherit the scrubbed
+        // set automatically, so a stripped AWS_SECRET_ACCESS_KEY stays
+        // stripped all the way down.
+        if self.policy.env.is_active() {
+            let parent: Vec<(String, String)> = std::env::vars().collect();
+            let (kept, removed) = self.policy.env.resolve(parent);
+            cmd.env_clear();
+            cmd.envs(kept);
+            if !removed.is_empty() {
+                log::info!(
+                    "env policy: stripped {} variable(s) from child env: {}",
+                    removed.len(),
+                    removed.join(", ")
+                );
+            }
+        }
+
         // Enroll the child into our cgroup *before* it execs. On Linux we use
         // pre_exec; other platforms just run the command unconfined.
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Adds an `env:` section to the `run` policy that filters the environment block before the supervised child execs. Implemented on both Linux (`coronarium`) and Windows (`coronarium-win`), so the same policy file works everywhere.

```yaml
env:
  default: pass                  # pass | clear
  allow: [PATH, HOME, "GITHUB_*"]
  deny:  ["AWS_*", "*_TOKEN", "*_SECRET", NPM_TOKEN]
```

Unlike eBPF deny-lists this is genuine **prevention**, not a tripwire: `Command::env_clear()` happens before `execve`, so the child — and any postinstall grandchildren that inherit its env — literally cannot read what's been stripped. This closes the env-exfil gap in the supply-chain story: proxy at the input, env scrub on the material, `network.deny` on the egress.

### Semantics

- Patterns match the env-var **name** with a single `*` wildcard per segment (`AWS_*`, `*_TOKEN`, `GITHUB_*_PATH`). No `glob` crate dep — the grammar we need is tiny.
- `deny` always wins over `allow`.
- `default: pass` (default) keeps everything not on `deny`; `default: clear` flips to allowlist mode (only `allow`-matched names survive).
- Stripped names are logged at `info` level for forensics; values are **never** logged (per CLAUDE.md "don't put secrets in log output").
- When the env section is absent or empty, the supervisor inherits the parent env untouched — no behaviour change for existing users.

### Why this and not in-process `getenv` hooks

Discussed in the design thread: per-libc uprobe hooks (Tetragon style) are fragile across glibc/musl/static/Go and would need `bpf_override_return` for enforcement, which is already on the roadmap as a CONFIG_BPF_KPROBE_OVERRIDE-gated item. envp-scrub at the supervisor boundary is portable, deterministic, and already covers the realistic supply-chain threat model where the leak path is `process.env.X` → HTTPS POST.

## Test plan

- [x] `cargo test -p coronarium-core --lib` — 74/74 passing, including 7 new tests covering glob match, `pass`/`clear` resolution, deny-wins precedence, `is_active`, and YAML parsing.
- [x] `cargo build -p coronarium` (Linux supervisor) — clean.
- [x] `cargo clippy -p coronarium-core --lib -- -D warnings` — clean.
- [ ] Smoke test on a real Linux box: `coronarium run -p policy.yml -- env | grep AWS_` should print nothing when `deny: ["AWS_*"]` is set.
- [ ] Smoke test on Windows: same idea via `cmd /c set`.