### PR TITLE
cli: default --dns-refresh-interval to 15s

### DIFF
--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -413,13 +413,14 @@ pub struct RunArgs {
 
     /// Re-resolve hostname-based `network.allow` / `network.deny`
     /// rules on this interval (seconds) and additively populate the
-    /// eBPF map with any newly-observed IPs. Needed for long-running
-    /// supervised jobs behind CDN round-robin DNS: a CDN that
-    /// rotates its IP set mid-run would otherwise start hitting
-    /// addresses the map has never seen. `0` disables refresh
-    /// (default). Entries are never removed once written, so
-    /// increasing the refresh rate is safe.
-    #[arg(long, default_value_t = 0, value_name = "SECS")]
+    /// eBPF map with any newly-observed IPs. Needed for supervised
+    /// jobs behind round-robin DNS (github.com, registry.npmjs.org,
+    /// most CDNs): the IPs returned by a fresh DNS query mid-run
+    /// can differ from the ones captured at startup, so without
+    /// refresh the second connect to the same hostname can be
+    /// denied with `Operation not permitted`. Entries are never
+    /// removed once written. `0` disables refresh entirely.
+    #[arg(long, default_value_t = 15, value_name = "SECS")]
     pub dns_refresh_interval: u64,
 
     /// Command + args to execute under supervision.


### PR DESCRIPTION
## Summary
Hostname-based \`network.allow\` rules are the dominant CI usage (github.com, registry.npmjs.org, index.crates.io, …), and every one of those hostnames is round-robin DNS. With the previous default of \`0\` (refresh disabled), a supervised run that resolves \`github.com\` at startup, then a few seconds later does a second connect that DNS-resolves to a different IP, would have the second connect denied with \`Operation not permitted\` from the cgroup eBPF hook.

Concretely: in [reg-viz/reg-cli#650](https://github.com/reg-viz/reg-cli/pull/650), the supervised script does \`git clone https://github.com/reg-viz/reg-cli-report-ui\` (success — IP A in the BPF map) and then \`cargo test\` which fetches \`bokuweb/image-diff-rs\` from github.com (failure — DNS now returns IP B not in map):

\`\`\`
warning: spurious network error (3 tries remaining): failed to connect to
   github.com: Operation not permitted; class=Os (2)
\`\`\`

This is a footgun copy-pasters of the README CI example all hit the moment they switch to \`mode: block\`.

Default to \`15\` seconds instead. Entries are written additively (never removed), so the only cost is a few extra DNS lookups per minute. 15s covers typical short-running CI matrices without piling up many refreshes; users who really do have an IP-only allow list can opt out with \`--dns-refresh-interval 0\`.

## Test plan
- [x] \`cargo check -p coronarium\`
- [x] \`cargo fmt --check\`
- [ ] reg-cli#650 re-runs green after this lands + a fresh release

🤖 Generated with [Claude Code](https://claude.com/claude-code)