### PR TITLE
enforcer: friendly error when policy overflows the BPF NET maps

### DIFF
--- a/crates/coronarium/src/enforcer.rs
+++ b/crates/coronarium/src/enforcer.rs
@@ -79,12 +79,38 @@ async fn populate_network_maps(
 ) -> anyhow::Result<()> {
     use std::net::IpAddr;
 
+    use anyhow::Context;
     use coronarium_common::{Ipv4Key, Ipv6Key, POLICY_ALLOW, POLICY_DENY};
 
     // Pre-resolve every rule's endpoints *before* touching the maps so that a
     // transient DNS failure doesn't leave half-populated state.
     let allow = resolve_all(resolver, &policy.network.allow).await;
     let deny = resolve_all(resolver, &policy.network.deny).await;
+
+    // Pre-flight: each (addr, port) becomes one entry in the BPF map.
+    // The maps are sized via `HashMap::with_max_entries(BPF_NET_MAP_CAPACITY)`
+    // in the eBPF program. Going over yields a bare `bpf_map_update_elem
+    // failed: Argument list too long` from aya — surface a clearly
+    // diagnosable error before we even start updating instead.
+    let (v4_count, v6_count) = endpoint_counts(&allow, &deny);
+    if v4_count > BPF_NET_MAP_CAPACITY {
+        anyhow::bail!(
+            "policy network rules expand to {v4_count} IPv4 (addr,port) pairs, \
+             but the eBPF NET4 map is sized for {BPF_NET_MAP_CAPACITY}. \
+             Common cause: a wide CIDR like Cloudflare's /12s — coronarium \
+             enumerates every host into the map and CDN ranges overflow it \
+             quickly. Use hostname rules (kept fresh by --dns-refresh-interval) \
+             or narrower CIDRs."
+        );
+    }
+    if v6_count > BPF_NET_MAP_CAPACITY {
+        anyhow::bail!(
+            "policy network rules expand to {v6_count} IPv6 (addr,port) pairs, \
+             but the eBPF NET6 map is sized for {BPF_NET_MAP_CAPACITY}. \
+             Use hostname rules or narrower CIDRs (an IPv6 /112 is the \
+             tightest CIDR that fits unconditionally)."
+        );
+    }
 
     // deny wins if the same (addr, port) appears on both lists.
     if let Some(map) = bpf.map_mut("NET4") {
@@ -100,7 +126,13 @@ async fn populate_network_maps(
                     port: ep.port.to_be(),
                     _pad: 0,
                 };
-                m.insert(key, verdict, 0)?;
+                m.insert(key, verdict, 0).with_context(|| {
+                    format!(
+                        "writing {v4}:{} to NET4 map (capacity {BPF_NET_MAP_CAPACITY}); \
+                         policy may exceed map size",
+                        ep.port,
+                    )
+                })?;
             }
         }
     }
@@ -118,11 +150,39 @@ async fn populate_network_maps(
                     port: ep.port.to_be(),
                     _pad: [0; 6],
                 };
-                m.insert(key, verdict, 0)?;
+                m.insert(key, verdict, 0).with_context(|| {
+                    format!(
+                        "writing [{v6}]:{} to NET6 map (capacity {BPF_NET_MAP_CAPACITY}); \
+                         policy may exceed map size",
+                        ep.port,
+                    )
+                })?;
             }
         }
     }
     Ok(())
+}
+
+/// Mirror of `HashMap::with_max_entries(...)` in `crates/coronarium-ebpf`'s
+/// `NET4` / `NET6` declarations. Keep in sync with the eBPF side.
+#[cfg(target_os = "linux")]
+const BPF_NET_MAP_CAPACITY: usize = 1024;
+
+#[cfg(target_os = "linux")]
+fn endpoint_counts(
+    allow: &[crate::resolve::Endpoint],
+    deny: &[crate::resolve::Endpoint],
+) -> (usize, usize) {
+    use std::net::IpAddr;
+    let mut v4 = 0usize;
+    let mut v6 = 0usize;
+    for ep in allow.iter().chain(deny.iter()) {
+        match ep.addr {
+            IpAddr::V4(_) => v4 += 1,
+            IpAddr::V6(_) => v6 += 1,
+        }
+    }
+    (v4, v6)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/coronarium/src/resolve.rs
+++ b/crates/coronarium/src/resolve.rs
@@ -19,7 +19,12 @@ pub struct Endpoint {
 }
 
 /// Cap the number of /N expansions we're willing to materialise into the map.
-/// A /16 is ~65k entries; beyond that the user should pick a tighter prefix.
+///
+/// Note: the eBPF `NET4` / `NET6` maps in `crates/coronarium-ebpf` are
+/// only sized for 1024 entries each *total*, so even one CIDR at this
+/// cap will overflow the map at attach time. Enforcer-side does the
+/// real bookkeeping (and bails with a friendly message) — the cap here
+/// is just to keep the per-rule allocation bounded.
 const MAX_CIDR_EXPANSION: usize = 65_536;
 
 pub struct Resolver {


### PR DESCRIPTION
## Summary
A wide CIDR (e.g. Cloudflare's /12s) currently makes the supervisor fail at eBPF attach time with a cryptic:

\`\`\`
Error: eBPF programs failed to attach in block mode; refusing to run unprotected.
attaching programs: \`bpf_map_update_elem\` failed: Argument list too long (os error 7)
\`\`\`

…with no hint that the cause is the policy itself exceeding the BPF map size. The userspace cap in \`resolve.rs\` (\`MAX_CIDR_EXPANSION = 65_536\`) suggests up to 65536 entries per CIDR are fine, while the actual \`NET4\` / \`NET6\` maps are declared as \`HashMap::with_max_entries(1024)\` — 64× smaller. Easy footgun.

This PR:

1. **Pre-flight check in \`coronarium::enforcer\`**: counts the v4/v6 endpoints the resolved \`network.allow\` + \`network.deny\` would write, compares against the mirrored \`BPF_NET_MAP_CAPACITY\` constant, and bails *before* touching the BPF maps with:

   \`\`\`
   Error: policy network rules expand to 460000 IPv4 (addr,port) pairs,
   but the eBPF NET4 map is sized for 1024. Common cause: a wide CIDR
   like Cloudflare's /12s — coronarium enumerates every host into the
   map and CDN ranges overflow it quickly. Use hostname rules (kept
   fresh by --dns-refresh-interval) or narrower CIDRs.
   \`\`\`

2. **Per-insert \`with_context\`** as a safety net — if anything slips past pre-flight, the surfaced error names the offending \`addr:port\` and the capacity, not just \`Argument list too long\`.

3. **Doc note on \`MAX_CIDR_EXPANSION\`** so the next reader knows the 65536 per-CIDR cap is much larger than the BPF map can actually hold.

## Origin
Surfaced from a downstream block-mode policy in [reg-viz/reg-cli#650](https://github.com/reg-viz/reg-cli/pull/650). The repo's CI tried to whitelist Cloudflare's full published v4/v6 ranges to cover \`registry.npmjs.org\`'s anycast pool and hit this immediately.

## Out of scope
The underlying limitation — that NET4/NET6 are flat hashmaps of (addr, port) keys, so prefix-style allows are inexpressible without enumeration — needs an LPM-trie redesign. Filing as a separate issue/PR; this one just makes the failure mode debuggable.

## Test plan
- [x] \`cargo check -p coronarium\`
- [x] \`cargo fmt --check\`
- [ ] Manually verify: load a policy with a /12 allow, see the new error instead of \`bpf_map_update_elem failed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)