### PR TITLE
stats/policy: keep denied samples + reject unenforceable file.deny in block mode

### DIFF
--- a/crates/coronarium-core/src/policy.rs
+++ b/crates/coronarium-core/src/policy.rs
@@ -218,6 +218,45 @@ impl Policy {
         }
     }
 
+    /// Reject policy shapes that would silently mis-enforce. Unlike
+    /// [`Self::lint`], these are hard errors — the supervisor must
+    /// refuse to start rather than let the operator believe a rule is
+    /// active when it isn't.
+    ///
+    /// `effective_mode` is the post-CLI-override mode (e.g. `--mode
+    /// block` over an audit-default policy file). Validation only
+    /// trips when the *effective* mode is block, since audit runs are
+    /// allowed to exceed enforcement-layer limits — they're just
+    /// reporting.
+    ///
+    /// Currently checks:
+    ///
+    /// - `file.deny.len() > FILE_DENY_MAX_ENTRIES` under
+    ///   `mode: block`. The kernel-side prefix map only holds 8 slots;
+    ///   entries past the cap get audit-tagged (`denied: true` in the
+    ///   JSON log) but the kernel never fires `bpf_send_signal` on
+    ///   them. The audit tag still counts toward `stats.denied`,
+    ///   tripping the block-mode non-zero exit *without* the offender
+    ///   actually being killed — a failure mode that's nearly
+    ///   impossible to debug from logs alone.
+    pub fn validate(&self, effective_mode: Mode) -> Result<()> {
+        use coronarium_common::FILE_DENY_MAX_ENTRIES;
+        if matches!(effective_mode, Mode::Block)
+            && self.file.deny.len() > FILE_DENY_MAX_ENTRIES as usize
+        {
+            bail!(
+                "file.deny has {} entries but kernel-side block supports at most {} \
+                 (mode: block). Entries past the cap would be audit-tagged but not \
+                 actually blocked, while still tripping the non-zero exit — refusing \
+                 to start. Either trim the list, split into multiple policies, or \
+                 run with `--mode audit`.",
+                self.file.deny.len(),
+                FILE_DENY_MAX_ENTRIES,
+            );
+        }
+        Ok(())
+    }
+
     /// Spot obviously-redundant policy shapes. Kept small on purpose —
     /// prefer clear docs over implicit behaviour.
     ///
@@ -500,6 +539,31 @@ network:
             !msgs.iter().any(|m| m.contains("file.deny")),
             "got: {msgs:?}"
         );
+    }
+
+    #[test]
+    fn validate_rejects_too_many_file_deny_in_block_mode() {
+        let mut p = Policy::permissive_audit();
+        p.file.default = DefaultDecision::Allow;
+        for i in 0..9 {
+            p.file.deny.push(format!("/x/{i}"));
+        }
+        // Audit mode: reporting-only, allowed to exceed the cap.
+        assert!(p.validate(Mode::Audit).is_ok());
+        // Block mode: silent mis-enforcement — must refuse.
+        let err = p.validate(Mode::Block).unwrap_err().to_string();
+        assert!(err.contains("file.deny"), "got: {err}");
+        assert!(err.contains("9"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_accepts_exactly_the_kernel_cap() {
+        use coronarium_common::FILE_DENY_MAX_ENTRIES;
+        let mut p = Policy::permissive_audit();
+        for i in 0..FILE_DENY_MAX_ENTRIES {
+            p.file.deny.push(format!("/x/{i}"));
+        }
+        assert!(p.validate(Mode::Block).is_ok());
     }
 
     #[test]

--- a/crates/coronarium-core/src/stats.rs
+++ b/crates/coronarium-core/src/stats.rs
@@ -19,22 +19,52 @@ pub const TOTAL_SAMPLE_CAP: usize = 256;
 impl Stats {
     /// Merge an already-parsed event into the stats. Returns whether the
     /// event was kept in the sample buffer (for callers that want to know).
+    ///
+    /// Denied events are prioritised: if the per-kind or total cap is
+    /// already full, an incoming denied event displaces the oldest
+    /// non-denied sample (preferring same-kind) so the offending paths
+    /// still surface in the report. Without this, a flood of benign
+    /// events early in a run (e.g. pnpm install's first thousand
+    /// openat()s) crowds out the actual offenders that fired the
+    /// block-mode exit, leaving operators with "N denied" and no clue
+    /// which paths.
     pub fn ingest(&mut self, ev: Event) -> bool {
         self.observed += 1;
-        if ev.denied() {
+        let denied = ev.denied();
+        if denied {
             self.denied += 1;
         }
-        let existing = self
-            .samples
-            .iter()
-            .filter(|s| s.kind_tag() == ev.kind_tag())
-            .count();
-        if existing < PER_KIND_CAP && self.samples.len() < TOTAL_SAMPLE_CAP {
+        let kind = ev.kind_tag();
+        let same_kind = self.samples.iter().filter(|s| s.kind_tag() == kind).count();
+        let kind_room = same_kind < PER_KIND_CAP;
+        let total_room = self.samples.len() < TOTAL_SAMPLE_CAP;
+        if kind_room && total_room {
             self.samples.push(ev);
-            true
-        } else {
-            false
+            return true;
         }
+
+        if denied {
+            // Prefer evicting an older non-denied sample of the same
+            // kind (keeps inter-kind ratios honest). If the total cap
+            // is the binding constraint, fall back to any non-denied.
+            let victim = self
+                .samples
+                .iter()
+                .position(|s| !s.denied() && s.kind_tag() == kind)
+                .or_else(|| {
+                    if !total_room {
+                        self.samples.iter().position(|s| !s.denied())
+                    } else {
+                        None
+                    }
+                });
+            if let Some(idx) = victim {
+                self.samples.remove(idx);
+                self.samples.push(ev);
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -86,6 +116,45 @@ mod tests {
         // Later-kind events can still get a sample slot up to their cap.
         s.ingest(exec());
         assert_eq!(s.samples.len(), PER_KIND_CAP + 1);
+    }
+
+    #[test]
+    fn denied_events_displace_older_non_denied_when_kind_full() {
+        // Simulate a flood of benign opens followed by a real deny.
+        // Without prioritisation the deny would be dropped on the
+        // floor and the report would say "1 denied" with no path.
+        let mut s = Stats::default();
+        for i in 0..PER_KIND_CAP {
+            s.ingest(open(&format!("/benign/{i}"), false));
+        }
+        // Cap full — next benign drops.
+        assert!(!s.ingest(open("/benign/extra", false)));
+        // But a denied open displaces an older benign of the same kind.
+        assert!(s.ingest(open("/etc/shadow", true)));
+        assert_eq!(s.samples.len(), PER_KIND_CAP);
+        assert!(
+            s.samples
+                .iter()
+                .any(|e| matches!(e, Event::Open { filename, denied: true, .. } if filename == "/etc/shadow")),
+            "denied sample must survive — operators need the offender path"
+        );
+        assert_eq!(s.denied, 1);
+        assert_eq!(s.observed, PER_KIND_CAP as u64 + 2);
+    }
+
+    #[test]
+    fn denied_events_dropped_only_when_no_non_denied_to_evict() {
+        // Pathological: every sample slot is already a denied event.
+        // We don't unbound memory, so the new denied event is dropped.
+        let mut s = Stats::default();
+        for i in 0..PER_KIND_CAP {
+            s.ingest(open(&format!("/x/{i}"), true));
+        }
+        assert_eq!(s.samples.len(), PER_KIND_CAP);
+        assert!(!s.ingest(open("/y", true)));
+        // But the denied counter still increments — it tracks all
+        // denials, regardless of whether the sample buffer kept one.
+        assert_eq!(s.denied, PER_KIND_CAP as u64 + 1);
     }
 
     #[test]

--- a/crates/coronarium-win/src/win.rs
+++ b/crates/coronarium-win/src/win.rs
@@ -92,6 +92,7 @@ pub fn run() -> Result<()> {
         Some(CliMode::Block) => Mode::Block,
         None => policy.mode,
     };
+    policy.validate(mode)?;
     for w in policy.lint() {
         log::warn!("{w}");
     }

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -433,6 +433,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::CheckPolicy { policy } => {
             let p = policy::Policy::from_file(&policy)
                 .with_context(|| format!("loading {}", policy.display()))?;
+            p.validate(p.mode)?;
             for w in p.lint() {
                 eprintln!("warning: {w}");
             }
@@ -669,6 +670,7 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         Some(Mode::Block) => policy::Mode::Block,
         None => policy.mode,
     };
+    policy.validate(mode)?;
     for w in policy.lint() {
         log::warn!("{w}");
     }


### PR DESCRIPTION
## Summary

Two debuggability traps surfaced when a block-mode CI run exited with
\`7016 denied\` and no offender path:

- **Sample bias** — \`Stats::ingest\` filled the per-kind / total sample
  buffer from the *earliest* events. Under \`pnpm install\` that means
  thousands of benign \`openat()\`s land before the actually-denied path
  shows up, and the JSON log + HTML report carry zero offending
  filenames. Now denied events displace the oldest non-denied sample
  of the same kind once caps fill, so the offender survives even when
  buried mid-stream. Memory stays bounded.

- **Audit-only past slot 8 trips block mode** — the kernel-side
  \`FILE_DENY_PREFIX\` map holds 8 entries; anything past the cap gets
  \`denied: true\` audit-tagged in userspace but the kernel never fires
  \`bpf_send_signal\`. The tag still increments \`stats.denied\`, so
  block-mode exits non-zero **without** the offender being killed — a
  near-impossible failure mode to debug. Added \`Policy::validate\`,
  called from the run / check-policy / Windows entry points after the
  effective mode is resolved: refuse to start when \`mode: block\` and
  \`file.deny.len() > FILE_DENY_MAX_ENTRIES\`. Audit mode is unaffected.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (new tests cover same-kind eviction,
  the all-denied no-eviction case, and validate accept/reject around
  the kernel cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)