### PR TITLE
report/suggest: enriched step summary + policy suggest from audit log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,66 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 5. **macOS live block** — either a Network Extension (heavy, needs
    signing) or an HTTPS proxy (see #2).
 
+### harden-runner parity gaps (tracked but not yet scheduled)
+
+These are features `step-security/harden-runner` ships that
+coronarium currently does not. Listed roughly in descending order
+of value-per-implementation-cost.
+
+6. **Enriched `$GITHUB_STEP_SUMMARY`** — ✅ implemented in v0.20.
+   The supervisor now writes per-host (Connect), per-path (Open),
+   and per-binary (Exec) top-N tables into the step summary,
+   marking denied rows with ❌ so reviewers can spot the offending
+   destinations directly on the run page without downloading the
+   JSON log.
+7. **`coronarium policy suggest <audit-log.json>`** — ✅ implemented
+   in v0.20. Reads a JSON audit log (typically produced by an
+   audit-mode run) and emits a starter `policy.yml` with every
+   observed host/port pair on `network.allow`, observed file
+   parents on `file.allow`, and observed exec'd binaries listed
+   under a commented `# observed_exec` block. Reduces the "stare
+   at the log and hand-craft the policy" friction that today
+   blocks teams from flipping `mode: audit` → `mode: block`.
+8. **SNI-based egress in the proxy** — extend `coronarium proxy`
+   to honour a `network.allow` style hostname list at the CONNECT
+   layer (parse SNI from the TLS ClientHello, match against the
+   policy, return 403 on miss). Today the eBPF path enforces by
+   resolved IP, which loses against CDN rotation; doing it at the
+   proxy gives FQDN/wildcard semantics that match what
+   harden-runner users expect (`*.githubusercontent.com:443`
+   etc.). Doable on top of the existing hudsucker stack; depends
+   on `install-gate` already being on the user's shell.
+9. **Workspace tamper detection** — at `run` start, snapshot the
+   git index + working tree hashes for files under `$GITHUB_WORKSPACE`;
+   at exit, diff and flag any files that were modified by the
+   supervised step but weren't expected to change (e.g. by
+   comparing against a per-step manifest). Goal: catch a
+   compromised dependency rewriting `.git/config` or source files
+   during install. Detection-only initially; could escalate to
+   git-revert in `--action revert` mode.
+10. **Floating-tag → SHA-pin static check** — new subcommand
+    `coronarium actions audit <workflow.yml>` that flags any
+    `uses: foo/bar@v1` (mutable ref) and recommends the SHA-pinned
+    form. StepSecurity's "secure-repo" runs this server-side; we'd
+    do it locally + in `coronarium deps check`-style CI mode.
+    No new infra needed — pure parser + GitHub API resolve.
+11. **Per-step / per-PID source attribution** — today the JSON log
+    has `pid` + `comm`, but harden-runner's value-add is being
+    able to say "this outbound call came from `npm install
+    foo@1.2.3`'s postinstall script". Achievable by walking the
+    process tree at event time and attaching the originating
+    package manager argv to the event record. Linux-first via
+    `/proc/<pid>/status` PPid chain.
+
+Explicitly **out of scope** (different product philosophy, not
+a missing feature):
+
+- Centralised SaaS dashboard / cross-runner correlation. coronarium
+  is local-first; the JSON log + HTML report are the artefacts.
+- Automatic runner hardening (sudo disabling, immutable rootfs).
+  We don't take destructive actions on the runner without an
+  explicit opt-in.
+
 ## Crate layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -524,9 +524,23 @@ env:
   deny: ["AWS_*", "*_TOKEN", "*_SECRET", NPM_TOKEN]
 ```
 
-**First-time setup pattern** — run in `mode: audit` once, inspect
-the JSON log, add actually-needed entries to `allow:`, flip to
-`mode: block` when the log is clean.
+**First-time setup pattern** — run in `mode: audit` once, then let
+`policy suggest` turn the log into a starter policy, prune by hand,
+and flip to `mode: block`:
+
+```bash
+coronarium run --mode audit --log audit.json -- cargo test
+coronarium policy suggest audit.json -o .github/coronarium.yml
+$EDITOR .github/coronarium.yml      # remove anything you don't want allowed
+coronarium run -p .github/coronarium.yml --mode block -- cargo test
+```
+
+`suggest` populates `network.allow` (one entry per host:port observed,
+hostnames preferred over raw IPs) and `file.allow` (one entry per
+parent directory observed). Exec targets are surfaced as a
+commented `# observed_exec:` block — `process.deny_exec` is
+deliberately left empty because the suggester can't know which of
+the binaries the build actually wanted.
 
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm

--- a/crates/coronarium-core/src/events.rs
+++ b/crates/coronarium-core/src/events.rs
@@ -1,25 +1,38 @@
 //! Event enum shared between Linux eBPF decoder and Windows ETW parser.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Event {
     Exec {
+        #[serde(default)]
         pid: u32,
+        #[serde(default)]
         uid: u32,
+        #[serde(default)]
         comm: String,
+        #[serde(default)]
         filename: String,
+        #[serde(default)]
         argv0: String,
+        #[serde(default)]
         denied: bool,
     },
     Connect {
+        #[serde(default)]
         pid: u32,
+        #[serde(default)]
         uid: u32,
+        #[serde(default)]
         comm: String,
+        #[serde(default)]
         daddr: String,
+        #[serde(default)]
         dport: u16,
+        #[serde(default)]
         protocol: u16,
+        #[serde(default)]
         denied: bool,
         /// Reverse-DNS of `daddr` (PTR record) when known. Populated
         /// best-effort by the userspace supervisor after all events
@@ -29,11 +42,17 @@ pub enum Event {
         hostname: Option<String>,
     },
     Open {
+        #[serde(default)]
         pid: u32,
+        #[serde(default)]
         uid: u32,
+        #[serde(default)]
         comm: String,
+        #[serde(default)]
         filename: String,
+        #[serde(default)]
         flags: u32,
+        #[serde(default)]
         denied: bool,
     },
 }

--- a/crates/coronarium-core/src/lib.rs
+++ b/crates/coronarium-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod matcher;
 pub mod policy;
 pub mod report;
 pub mod stats;
+pub mod suggest;
 
 pub use events::Event;
 pub use policy::{

--- a/crates/coronarium-core/src/report.rs
+++ b/crates/coronarium-core/src/report.rs
@@ -4,6 +4,8 @@
 //! - optional HTML report (via [`crate::html`])
 
 use std::{
+    collections::BTreeMap,
+    fmt::Write as _,
     fs::OpenOptions,
     io::{self, Write},
     path::Path,
@@ -11,7 +13,13 @@ use std::{
 
 use anyhow::Result;
 
-use crate::{html, policy::Policy, stats::Stats};
+use crate::{events::Event, html, policy::Policy, stats::Stats};
+
+/// How many rows we surface per breakdown table in the step summary.
+/// Picked to fit comfortably in a GitHub run page without scrolling
+/// while still showing the long tail of "wait, what's that"
+/// destinations that motivate a human to look at the policy.
+const SUMMARY_TOP_N: usize = 10;
 
 pub struct ReportArgs<'a> {
     /// Destination for the JSON log. `"-"` means stdout.
@@ -61,25 +69,8 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
     // --- $GITHUB_STEP_SUMMARY markdown ---
     if let Some(path) = args.summary {
         let mut f = OpenOptions::new().create(true).append(true).open(path)?;
-        let lost_note = if stats.lost > 0 {
-            format!(
-                "\n> ⚠️ {} events were dropped due to ring-buffer overflow; \
-                 totals may undercount.",
-                stats.lost
-            )
-        } else {
-            String::new()
-        };
-        writeln!(
-            f,
-            "## coronarium\n\n\
-             | metric | count |\n\
-             |---|---:|\n\
-             | observed | **{}** |\n\
-             | denied   | **{}** |\n\
-             | lost     | {} |\n{lost_note}\n",
-            stats.observed, stats.denied, stats.lost,
-        )?;
+        let body = render_step_summary(args.command, stats);
+        writeln!(f, "{body}")?;
     }
 
     // --- HTML ---
@@ -94,4 +85,301 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the markdown blob written to `$GITHUB_STEP_SUMMARY`.
+///
+/// The previous version was just a totals table. Real harden-runner
+/// users want to see *what* the supervised step talked to, so this
+/// adds three top-N breakdown tables (network destinations, file
+/// paths, exec'd binaries) with denied rows flagged. Sample buffer
+/// caps live in `stats::PER_KIND_CAP` — the tables can undercount
+/// if a single kind floods, but `stats.observed` / `stats.denied`
+/// totals are exact and shown above.
+pub fn render_step_summary(command: &str, stats: &Stats) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "## coronarium\n");
+    let _ = writeln!(out, "Command: `{}`\n", escape_pipe(command));
+    let _ = writeln!(out, "| metric | count |");
+    let _ = writeln!(out, "|---|---:|");
+    let _ = writeln!(out, "| observed | **{}** |", stats.observed);
+    let _ = writeln!(out, "| denied   | **{}** |", stats.denied);
+    let _ = writeln!(out, "| lost     | {} |", stats.lost);
+    if stats.lost > 0 {
+        let _ = writeln!(
+            out,
+            "\n> ⚠️ {} events were dropped due to ring-buffer overflow; \
+             totals above are accurate but the breakdown tables below \
+             may undercount.",
+            stats.lost
+        );
+    }
+
+    push_breakdown_table(
+        &mut out,
+        "Network — outbound connects",
+        "destination",
+        connect_breakdown(&stats.samples),
+    );
+    push_breakdown_table(
+        &mut out,
+        "Files — opened paths",
+        "path",
+        path_breakdown(&stats.samples),
+    );
+    push_breakdown_table(
+        &mut out,
+        "Processes — execve targets",
+        "binary",
+        exec_breakdown(&stats.samples),
+    );
+    out
+}
+
+/// One row in a breakdown table: label, total occurrences, and how
+/// many of those were denied. The denied count is what makes the
+/// row worth surfacing — a row of `(github.com:443, 12, 0)` reads
+/// very differently from `(some-cdn.cn:443, 12, 12)`.
+#[derive(Debug, Clone)]
+struct BreakdownRow {
+    label: String,
+    count: u64,
+    denied: u64,
+}
+
+fn push_breakdown_table(out: &mut String, title: &str, col: &str, rows: Vec<BreakdownRow>) {
+    if rows.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n### {title}\n");
+    let _ = writeln!(out, "| | {col} | count | denied |");
+    let _ = writeln!(out, "|:-:|---|---:|---:|");
+    for r in rows.iter().take(SUMMARY_TOP_N) {
+        let mark = if r.denied > 0 { "❌" } else { "·" };
+        let _ = writeln!(
+            out,
+            "| {mark} | `{}` | {} | {} |",
+            escape_pipe(&r.label),
+            r.count,
+            r.denied,
+        );
+    }
+    if rows.len() > SUMMARY_TOP_N {
+        let _ = writeln!(
+            out,
+            "\n_… {} more rows omitted; full list is in the JSON log._",
+            rows.len() - SUMMARY_TOP_N
+        );
+    }
+}
+
+fn connect_breakdown(samples: &[Event]) -> Vec<BreakdownRow> {
+    let mut acc: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for ev in samples {
+        if let Event::Connect {
+            daddr,
+            dport,
+            denied,
+            hostname,
+            ..
+        } = ev
+        {
+            let host = hostname.as_deref().unwrap_or(daddr.as_str());
+            let key = format!("{host}:{dport}");
+            let e = acc.entry(key).or_default();
+            e.0 += 1;
+            if *denied {
+                e.1 += 1;
+            }
+        }
+    }
+    finalise(acc)
+}
+
+fn path_breakdown(samples: &[Event]) -> Vec<BreakdownRow> {
+    let mut acc: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for ev in samples {
+        if let Event::Open {
+            filename, denied, ..
+        } = ev
+        {
+            let e = acc.entry(filename.clone()).or_default();
+            e.0 += 1;
+            if *denied {
+                e.1 += 1;
+            }
+        }
+    }
+    finalise(acc)
+}
+
+fn exec_breakdown(samples: &[Event]) -> Vec<BreakdownRow> {
+    let mut acc: BTreeMap<String, (u64, u64)> = BTreeMap::new();
+    for ev in samples {
+        if let Event::Exec {
+            filename, denied, ..
+        } = ev
+        {
+            let e = acc.entry(filename.clone()).or_default();
+            e.0 += 1;
+            if *denied {
+                e.1 += 1;
+            }
+        }
+    }
+    finalise(acc)
+}
+
+/// Sort breakdown rows: denied-first (so offenders bubble to the
+/// top of the truncated table), then by raw count desc, then label
+/// asc for stable output.
+fn finalise(acc: BTreeMap<String, (u64, u64)>) -> Vec<BreakdownRow> {
+    let mut rows: Vec<BreakdownRow> = acc
+        .into_iter()
+        .map(|(label, (count, denied))| BreakdownRow {
+            label,
+            count,
+            denied,
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        (b.denied > 0)
+            .cmp(&(a.denied > 0))
+            .then(b.count.cmp(&a.count))
+            .then(a.label.cmp(&b.label))
+    });
+    rows
+}
+
+/// Markdown table cells are pipe-delimited; escape any literal `|`
+/// in commands or paths so a malicious filename can't break the
+/// table layout (or, more realistically, so a `bash -c "foo | bar"`
+/// command line renders correctly).
+fn escape_pipe(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev_connect(host: Option<&str>, daddr: &str, dport: u16, denied: bool) -> Event {
+        Event::Connect {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            daddr: daddr.into(),
+            dport,
+            protocol: 6,
+            denied,
+            hostname: host.map(|s| s.into()),
+        }
+    }
+    fn ev_open(filename: &str, denied: bool) -> Event {
+        Event::Open {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: filename.into(),
+            flags: 0,
+            denied,
+        }
+    }
+    fn ev_exec(filename: &str, denied: bool) -> Event {
+        Event::Exec {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: filename.into(),
+            argv0: filename.into(),
+            denied,
+        }
+    }
+
+    #[test]
+    fn summary_includes_totals_and_breakdown_tables() {
+        let mut stats = Stats::default();
+        stats.ingest(ev_connect(Some("api.github.com"), "1.1.1.1", 443, false));
+        stats.ingest(ev_connect(Some("api.github.com"), "1.1.1.1", 443, false));
+        stats.ingest(ev_connect(None, "8.8.8.8", 53, true));
+        stats.ingest(ev_open("/etc/hosts", false));
+        stats.ingest(ev_exec("/bin/sh", false));
+
+        let s = render_step_summary("npm install", &stats);
+        // Header + command line.
+        assert!(s.contains("## coronarium"));
+        assert!(s.contains("`npm install`"));
+        // Totals.
+        assert!(s.contains("| observed | **5** |"));
+        assert!(s.contains("| denied   | **1** |"));
+        // All three breakdowns rendered.
+        assert!(s.contains("### Network"));
+        assert!(s.contains("`api.github.com:443`"));
+        assert!(s.contains("### Files"));
+        assert!(s.contains("`/etc/hosts`"));
+        assert!(s.contains("### Processes"));
+        assert!(s.contains("`/bin/sh`"));
+    }
+
+    #[test]
+    fn denied_rows_get_marker_and_sort_first() {
+        let mut stats = Stats::default();
+        // Two benign rows with high count, one denied with low count.
+        // Denied must still appear ahead of the benign row.
+        for _ in 0..5 {
+            stats.ingest(ev_connect(Some("good.example"), "1.1.1.1", 443, false));
+        }
+        stats.ingest(ev_connect(Some("evil.example"), "9.9.9.9", 443, true));
+
+        let s = render_step_summary("cmd", &stats);
+        let evil_pos = s.find("evil.example").expect("evil row present");
+        let good_pos = s.find("good.example").expect("good row present");
+        assert!(
+            evil_pos < good_pos,
+            "denied row must sort before benign row in step summary"
+        );
+        assert!(s.contains("❌"));
+    }
+
+    #[test]
+    fn empty_breakdowns_are_skipped() {
+        // Only one kind of event — the other two tables should not
+        // appear at all (avoid noisy "Files\n| | path |" empty
+        // headers in the summary).
+        let mut stats = Stats::default();
+        stats.ingest(ev_open("/x", false));
+        let s = render_step_summary("cmd", &stats);
+        assert!(s.contains("### Files"));
+        assert!(!s.contains("### Network"));
+        assert!(!s.contains("### Processes"));
+    }
+
+    #[test]
+    fn pipe_in_command_is_escaped_so_table_doesnt_break() {
+        let stats = Stats::default();
+        let s = render_step_summary("bash -c 'foo | bar'", &stats);
+        assert!(s.contains(r"bash -c 'foo \| bar'"));
+    }
+
+    #[test]
+    fn top_n_truncates_with_remainder_note() {
+        let mut stats = Stats::default();
+        for i in 0..(SUMMARY_TOP_N + 5) {
+            stats.ingest(ev_open(&format!("/tmp/file-{i}"), false));
+        }
+        let s = render_step_summary("cmd", &stats);
+        assert!(s.contains("more rows omitted"));
+    }
+
+    #[test]
+    fn lost_events_get_warning_banner() {
+        let mut stats = Stats {
+            lost: 7,
+            ..Stats::default()
+        };
+        stats.ingest(ev_open("/x", false));
+        let s = render_step_summary("cmd", &stats);
+        assert!(s.contains("⚠️"));
+        assert!(s.contains("7 events were dropped"));
+    }
 }

--- a/crates/coronarium-core/src/suggest.rs
+++ b/crates/coronarium-core/src/suggest.rs
@@ -1,0 +1,352 @@
+//! Audit-log → starter-policy generator.
+//!
+//! Reads a JSON audit log produced by `coronarium run --log foo.json`
+//! (one or more pretty-printed objects with a `samples` array) and
+//! emits a [`Policy`] covering every observed Connect / Open event,
+//! plus a commented-out list of every observed Exec target.
+//!
+//! The intended workflow:
+//!
+//! ```text
+//! 1. coronarium run --mode audit --log audit.json -- <build cmd>
+//! 2. coronarium policy suggest audit.json -o policy.yml
+//! 3. <review / prune policy.yml>
+//! 4. coronarium run -p policy.yml --mode block -- <build cmd>
+//! ```
+//!
+//! Aggregation rules:
+//! - **Network**: one `NetRule` per `(hostname-or-ip, sorted ports)`.
+//!   Hostname wins over the bare IP when present (matches what a
+//!   human would write).
+//! - **File**: one entry per **parent directory** of the observed
+//!   filename, deduped — a per-file allow list would be unusably
+//!   noisy and break the moment any tool writes to a temp basename.
+//! - **Exec**: surfaced as a commented `# observed_exec:` block at
+//!   the end of the YAML so the operator can paste names into
+//!   `process.deny_exec` after review. We deliberately do **not**
+//!   auto-populate `deny_exec` — every exec the audit captured is
+//!   by definition something the build wanted to run.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::{
+    events::Event,
+    policy::{DefaultDecision, FilePolicy, Mode, NetRule, NetworkPolicy, Policy, ProcessPolicy},
+};
+
+/// What `suggest_from_samples` returns. The `Policy` is what would
+/// serialise straight to YAML; `observed_execs` is the post-serialisation
+/// commented block the CLI appends.
+#[derive(Debug, Clone)]
+pub struct Suggestion {
+    pub policy: Policy,
+    /// Sorted, deduped list of every `Exec` target seen. Surfaced as
+    /// a `# observed_exec:` YAML comment so the operator can choose
+    /// what (if anything) to deny.
+    pub observed_execs: Vec<String>,
+}
+
+/// Build a starter [`Policy`] from a flat slice of [`Event`]s.
+pub fn suggest_from_samples(samples: &[Event]) -> Suggestion {
+    // (target → set of ports). BTreeMap so the YAML output is stable.
+    let mut net: BTreeMap<String, BTreeSet<u16>> = BTreeMap::new();
+    let mut file_dirs: BTreeSet<String> = BTreeSet::new();
+    let mut execs: BTreeSet<String> = BTreeSet::new();
+
+    for ev in samples {
+        match ev {
+            Event::Connect {
+                daddr,
+                dport,
+                hostname,
+                ..
+            } => {
+                let target = hostname.clone().unwrap_or_else(|| daddr.clone());
+                if target.is_empty() {
+                    continue;
+                }
+                net.entry(target).or_default().insert(*dport);
+            }
+            Event::Open { filename, .. } => {
+                if filename.is_empty() {
+                    continue;
+                }
+                file_dirs.insert(parent_dir(filename));
+            }
+            Event::Exec { filename, .. } => {
+                if !filename.is_empty() {
+                    execs.insert(filename.clone());
+                }
+            }
+        }
+    }
+
+    let allow: Vec<NetRule> = net
+        .into_iter()
+        .map(|(target, ports)| NetRule {
+            target,
+            ports: ports.into_iter().collect(),
+        })
+        .collect();
+
+    let policy = Policy {
+        mode: Mode::Audit,
+        network: NetworkPolicy {
+            default: DefaultDecision::Deny,
+            allow,
+            deny: Vec::new(),
+        },
+        file: FilePolicy {
+            default: DefaultDecision::Allow,
+            allow: file_dirs.into_iter().collect(),
+            deny: Vec::new(),
+        },
+        process: ProcessPolicy::default(),
+        env: Default::default(),
+    };
+
+    Suggestion {
+        policy,
+        observed_execs: execs.into_iter().collect(),
+    }
+}
+
+/// Read a `coronarium run --log <file>` audit log and return the
+/// suggested policy. The log is a stream of pretty-printed JSON
+/// objects (one per `report::write` call); we parse them iteratively
+/// and concatenate every object's `samples` array.
+pub fn suggest_from_log(path: &Path) -> Result<Suggestion> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading audit log {}", path.display()))?;
+    let samples = parse_log_samples(&text)
+        .with_context(|| format!("parsing audit log {}", path.display()))?;
+    Ok(suggest_from_samples(&samples))
+}
+
+/// Render a [`Suggestion`] as a YAML document ready to drop in as a
+/// policy file. The commented `# observed_exec:` block is appended
+/// only when at least one exec was seen.
+pub fn format_yaml(s: &Suggestion) -> Result<String> {
+    let mut out = String::new();
+    out.push_str("# Generated by `coronarium policy suggest`. Review before enforcing.\n");
+    out.push_str(&serde_yaml::to_string(&s.policy)?);
+    if !s.observed_execs.is_empty() {
+        out.push_str("\n# observed_exec — every binary execve()'d during the audit run.\n");
+        out.push_str("# Move any of these into `process.deny_exec:` to block them.\n");
+        for e in &s.observed_execs {
+            out.push_str("#   - ");
+            out.push_str(e);
+            out.push('\n');
+        }
+    }
+    Ok(out)
+}
+
+#[derive(Deserialize)]
+struct LogChunk {
+    #[serde(default)]
+    samples: Vec<Event>,
+}
+
+pub fn parse_log_samples(text: &str) -> Result<Vec<Event>> {
+    let mut out = Vec::new();
+    let de = serde_json::Deserializer::from_str(text);
+    for chunk in de.into_iter::<LogChunk>() {
+        let chunk = chunk?;
+        out.extend(chunk.samples);
+    }
+    Ok(out)
+}
+
+/// Parent directory of `path`, with a trailing `/` so it reads as a
+/// prefix in the policy. Falls back to the whole path when there's
+/// no separator (e.g. bare basenames coming out of a chrooted run).
+fn parent_dir(path: &str) -> String {
+    match path.rfind('/') {
+        Some(0) => "/".to_string(),
+        Some(i) => path[..=i].to_string(),
+        None => path.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn connect(host: Option<&str>, daddr: &str, dport: u16) -> Event {
+        Event::Connect {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            daddr: daddr.into(),
+            dport,
+            protocol: 6,
+            denied: false,
+            hostname: host.map(|s| s.into()),
+        }
+    }
+    fn open(filename: &str) -> Event {
+        Event::Open {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: filename.into(),
+            flags: 0,
+            denied: false,
+        }
+    }
+    fn exec(filename: &str) -> Event {
+        Event::Exec {
+            pid: 1,
+            uid: 0,
+            comm: "x".into(),
+            filename: filename.into(),
+            argv0: filename.into(),
+            denied: false,
+        }
+    }
+
+    #[test]
+    fn parent_dir_handles_root_basename_and_nested() {
+        assert_eq!(parent_dir("/etc/hosts"), "/etc/");
+        assert_eq!(parent_dir("/foo"), "/");
+        assert_eq!(parent_dir("bare"), "bare");
+        assert_eq!(parent_dir("/a/b/c/d.txt"), "/a/b/c/");
+    }
+
+    #[test]
+    fn connect_groups_by_target_and_sorts_ports() {
+        let evs = vec![
+            connect(Some("api.github.com"), "140.82.121.6", 443),
+            connect(Some("api.github.com"), "140.82.121.6", 80),
+            connect(None, "1.2.3.4", 22),
+        ];
+        let s = suggest_from_samples(&evs);
+        let allow = &s.policy.network.allow;
+        assert_eq!(allow.len(), 2);
+        let gh = allow.iter().find(|r| r.target == "api.github.com").unwrap();
+        assert_eq!(gh.ports, vec![80, 443], "ports must be sorted ascending");
+        let raw = allow.iter().find(|r| r.target == "1.2.3.4").unwrap();
+        assert_eq!(raw.ports, vec![22]);
+    }
+
+    #[test]
+    fn connect_prefers_hostname_over_ip_when_both_present() {
+        let evs = vec![
+            connect(Some("api.github.com"), "140.82.121.6", 443),
+            connect(None, "140.82.121.6", 443),
+        ];
+        let s = suggest_from_samples(&evs);
+        // Hostname-keyed entry exists; the same (ip,443) is also kept
+        // separately because we can't safely assume the IP-only event
+        // resolves to the same name.
+        assert!(
+            s.policy
+                .network
+                .allow
+                .iter()
+                .any(|r| r.target == "api.github.com")
+        );
+        assert!(
+            s.policy
+                .network
+                .allow
+                .iter()
+                .any(|r| r.target == "140.82.121.6")
+        );
+    }
+
+    #[test]
+    fn open_collapses_to_parent_directories() {
+        let evs = vec![
+            open("/usr/lib/libc.so.6"),
+            open("/usr/lib/ld-linux.so.2"),
+            open("/etc/hosts"),
+        ];
+        let s = suggest_from_samples(&evs);
+        let allow = &s.policy.file.allow;
+        assert!(allow.contains(&"/usr/lib/".to_string()));
+        assert!(allow.contains(&"/etc/".to_string()));
+        // Two distinct files under /usr/lib collapsed into one entry.
+        assert_eq!(allow.iter().filter(|p| *p == "/usr/lib/").count(), 1);
+    }
+
+    #[test]
+    fn exec_targets_are_observation_only_not_denied() {
+        let evs = vec![exec("/bin/sh"), exec("/usr/bin/curl"), exec("/bin/sh")];
+        let s = suggest_from_samples(&evs);
+        // Never auto-populated into deny_exec.
+        assert!(s.policy.process.deny_exec.is_empty());
+        // Surfaced as observation, deduped + sorted.
+        assert_eq!(s.observed_execs, vec!["/bin/sh", "/usr/bin/curl"]);
+    }
+
+    #[test]
+    fn empty_targets_are_skipped() {
+        let evs = vec![
+            connect(Some(""), "", 443), // empty everywhere
+            open(""),
+            exec(""),
+        ];
+        let s = suggest_from_samples(&evs);
+        assert!(s.policy.network.allow.is_empty());
+        assert!(s.policy.file.allow.is_empty());
+        assert!(s.observed_execs.is_empty());
+    }
+
+    #[test]
+    fn parses_concatenated_pretty_printed_chunks() {
+        // Two appends — what you get from running `coronarium run`
+        // twice with the same `--log` path.
+        let blob = r#"{
+  "observed": 1,
+  "denied": 0,
+  "lost": 0,
+  "samples": [
+    {"kind": "connect", "pid": 1, "uid": 0, "comm": "c",
+     "daddr": "1.1.1.1", "dport": 443, "protocol": 6, "denied": false}
+  ]
+}
+{
+  "observed": 1,
+  "denied": 0,
+  "lost": 0,
+  "samples": [
+    {"kind": "open", "pid": 2, "uid": 0, "comm": "c",
+     "filename": "/etc/hosts", "flags": 0, "denied": false}
+  ]
+}"#;
+        let evs = parse_log_samples(blob).expect("two valid chunks");
+        assert_eq!(evs.len(), 2);
+    }
+
+    #[test]
+    fn format_yaml_includes_observed_exec_block_only_when_present() {
+        let with_exec = Suggestion {
+            policy: Policy {
+                mode: Mode::Audit,
+                network: NetworkPolicy::default(),
+                file: FilePolicy::default(),
+                process: ProcessPolicy::default(),
+                env: Default::default(),
+            },
+            observed_execs: vec!["/bin/sh".into()],
+        };
+        let s = format_yaml(&with_exec).unwrap();
+        assert!(s.contains("# observed_exec"));
+        assert!(s.contains("/bin/sh"));
+
+        let without = Suggestion {
+            observed_execs: Vec::new(),
+            ..with_exec
+        };
+        let s = format_yaml(&without).unwrap();
+        assert!(!s.contains("observed_exec"));
+    }
+}

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -86,6 +86,33 @@ pub enum Command {
     /// $HTTPS_PROXY, rc-file block, and daemon unit. Exits non-zero
     /// if any critical check fails.
     Doctor(DoctorArgs),
+    /// Policy authoring helpers (suggest a starter policy from an
+    /// audit-mode log, etc.). `check-policy` (the validation
+    /// subcommand) lives at the top level for backwards compatibility.
+    Policy {
+        #[command(subcommand)]
+        cmd: PolicyCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum PolicyCommand {
+    /// Read a JSON audit log (typically produced by
+    /// `coronarium run --mode audit --log foo.json`) and emit a
+    /// starter `policy.yml` covering every observed connect / open.
+    /// Exec targets are surfaced as a commented `# observed_exec`
+    /// block so you can pick which to deny — the suggester never
+    /// auto-populates `process.deny_exec`.
+    Suggest(PolicySuggestArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct PolicySuggestArgs {
+    /// Audit log to read. Use `-` for stdin.
+    pub log: PathBuf,
+    /// Where to write the suggested policy. Defaults to stdout.
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -582,7 +609,35 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::InstallGate {
             cmd: InstallGateCommand::Uninstall(args),
         } => run_install_gate_uninstall(args),
+        Command::Policy {
+            cmd: PolicyCommand::Suggest(args),
+        } => run_policy_suggest(args),
     }
+}
+
+fn run_policy_suggest(args: PolicySuggestArgs) -> Result<()> {
+    let suggestion = if args.log.as_os_str() == "-" {
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading audit log from stdin")?;
+        let samples = coronarium_core::suggest::parse_log_samples(&buf)
+            .context("parsing audit log JSON from stdin")?;
+        coronarium_core::suggest::suggest_from_samples(&samples)
+    } else {
+        coronarium_core::suggest::suggest_from_log(&args.log)?
+    };
+    let yaml = coronarium_core::suggest::format_yaml(&suggestion)?;
+    match args.output {
+        Some(path) => {
+            std::fs::write(&path, yaml)
+                .with_context(|| format!("writing suggested policy to {}", path.display()))?;
+            eprintln!("coronarium: wrote suggested policy to {}", path.display());
+        }
+        None => print!("{yaml}"),
+    }
+    Ok(())
 }
 
 fn run_install_gate_install(args: InstallGateInstallArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

Closes two `step-security/harden-runner` parity gaps that came up
in the gap analysis:

- **Enriched `$GITHUB_STEP_SUMMARY`** — `report::render_step_summary`
  now writes per-destination Network / per-path Files / per-binary
  Processes top-N tables into the step summary. Denied rows are
  flagged with ❌ and sorted to the top of the truncated table so
  the offending destinations surface even when the long tail of
  benign opens fills the rest. Pipe characters in commands and
  paths are escaped so a hostile filename can't break the table.
- **`coronarium policy suggest <audit.json>`** — new subcommand
  that reads a `coronarium run --mode audit --log foo.json` log
  and emits a starter `policy.yml`. `network.allow` gets one entry
  per `host:port` observed (hostname preferred over IP);
  `file.allow` gets one entry per parent directory observed;
  exec targets are surfaced as a commented `# observed_exec:`
  block so the operator can hand-pick what to deny — the
  suggester never auto-populates `process.deny_exec`. Reads from
  `-` as stdin too.

The remaining harden-runner gaps (SNI-based egress at the proxy,
workspace tamper detection, floating-tag → SHA-pin static check,
per-PID source attribution) are tracked under a new
"harden-runner parity gaps" section in CLAUDE.md so they don't
get lost. SaaS dashboard and automatic runner hardening are
explicitly listed as out-of-scope.

Side effect: `Event` gains a `Deserialize` derive (was
`Serialize`-only) so the audit log can round-trip through
`policy suggest`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 14 new unit tests (8 in `suggest`,
      6 in `report`) on top of existing 80; all green
- [x] Smoke: `echo '{...samples...}' | coronarium policy suggest -`
      produces a sane YAML with hostname-keyed allow entries and
      a commented exec block

🤖 Generated with [Claude Code](https://claude.com/claude-code)