### PR TITLE
actions: new `coronarium actions audit` for SHA-pin static analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,12 +214,16 @@ of value-per-implementation-cost.
    compromised dependency rewriting `.git/config` or source files
    during install. Detection-only initially; could escalate to
    git-revert in `--action revert` mode.
-10. **Floating-tag → SHA-pin static check** — new subcommand
-    `coronarium actions audit <workflow.yml>` that flags any
-    `uses: foo/bar@v1` (mutable ref) and recommends the SHA-pinned
-    form. StepSecurity's "secure-repo" runs this server-side; we'd
-    do it locally + in `coronarium deps check`-style CI mode.
-    No new infra needed — pure parser + GitHub API resolve.
+10. **Floating-tag → SHA-pin static check** — ✅ implemented in v0.21
+    as `coronarium actions audit <workflow.yml...>`. Walks every
+    `uses:` in `jobs.<id>.steps[]` and `jobs.<id>.uses` (reusable
+    workflow callers) and classifies each as Ok (40-char hex SHA,
+    local action, or docker `@sha256:` digest), Warn (first-party
+    `actions/*` / `github/*` with a mutable tag — risky but lower
+    blast radius), or Error (third-party with a mutable tag/branch).
+    Text + JSON output, `--strict` escalates Warn → Error. Tag→SHA
+    auto-resolution via the GitHub API is deferred — it requires
+    auth and turns the offline tool into a network one.
 11. **Per-step / per-PID source attribution** — today the JSON log
     has `pid` + `comm`, but harden-runner's value-add is being
     able to say "this outbound call came from `npm install

--- a/README.md
+++ b/README.md
@@ -456,6 +456,37 @@ coronarium deps watch ~/code --min-age 7d --notifier stdout
 See [packaging/macos/README.md](packaging/macos/README.md) for the
 launchd plist.
 
+### `actions audit`
+
+Static analysis for `.github/workflows/*.yml`. Walks every `uses:`
+in the workflow and flags any reference that isn't pinned to a
+40-char commit SHA — the supply-chain analogue of an unpinned
+dependency. Offline, no GitHub API calls.
+
+```bash
+coronarium actions audit .github/workflows/*.yml
+
+# Machine-readable.
+coronarium actions audit --format json .github/workflows/ci.yml
+
+# Treat first-party (actions/*, github/*) mutable refs as blocking
+# too — useful once you've already pinned all your third-party deps.
+coronarium actions audit --strict .github/workflows/*.yml
+```
+
+Severity:
+
+| | when |
+|---|---|
+| **error** | third-party action with mutable tag/branch (`foo/bar@v1`, `foo/bar@main`) |
+| **warn**  | first-party (`actions/*`, `github/*`) mutable tag, or docker image without `@sha256:` digest |
+| **ok**    | 40-char SHA pin, local action (`./...`), docker image with digest |
+
+Exit code: `1` when at least one error is present (or any warn,
+under `--strict`); `0` otherwise. Composite-action `action.yml`
+files are ignored — only workflow files (those with a top-level
+`jobs:` block) are walked.
+
 ### `run`
 
 Wraps a command under eBPF (Linux) / ETW (Windows) supervision and

--- a/crates/coronarium-core/src/actions.rs
+++ b/crates/coronarium-core/src/actions.rs
@@ -1,0 +1,442 @@
+//! GitHub Actions workflow auditor — flags `uses:` refs that point at
+//! a mutable tag/branch instead of an immutable commit SHA.
+//!
+//! A floating tag (`@v4`, `@main`, `@latest`) is the supply-chain
+//! analogue of an unpinned dependency: the action author can move
+//! the tag at any time and your workflow silently picks up the new
+//! code on the next run. The defence is the same as everywhere else
+//! in the ecosystem — pin to the exact commit SHA, ideally with a
+//! comment naming the tag for human readability:
+//!
+//! ```yaml
+//! - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   # v4.1.1
+//! ```
+//!
+//! Findings are emitted with a coarse severity:
+//!
+//! - [`Severity::Error`]: a mutable ref where pinning is unambiguous
+//!   — third-party action with `@v1` / `@main` / `@<branch>`.
+//! - [`Severity::Warn`]: first-party (`actions/*`, `github/*`) with
+//!   a mutable ref. Still risky, but GitHub-owned actions have a
+//!   stronger publish process so we don't fail builds by default.
+//! - [`Severity::Ok`]: 40-char hex SHA, local action (`./...`), or a
+//!   docker image reference with a digest.
+//!
+//! Out of scope (intentionally): walking `action.yml` composite
+//! action files, resolving tags to SHAs via the GitHub API
+//! (offline tool), and detecting `actions/*` published from a fork.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Ok,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Finding {
+    /// Job id from the YAML (`jobs.<this>`).
+    pub job: String,
+    /// Step name (`name:`) when present, else the step's own `uses:`
+    /// echoed back. `None` means the `uses:` was at job-level —
+    /// i.e. a reusable-workflow call rather than a step.
+    pub step: Option<String>,
+    /// The raw `uses:` value as written in the workflow.
+    pub uses: String,
+    pub severity: Severity,
+    pub message: String,
+}
+
+impl Finding {
+    pub fn is_blocking(&self) -> bool {
+        matches!(self.severity, Severity::Error)
+    }
+}
+
+/// Audit a single workflow YAML document. Returns one [`Finding`]
+/// per `uses:` value encountered (including OK ones, so callers
+/// can show "N actions, M pinned" stats if they want).
+pub fn audit_yaml(yaml: &str) -> Result<Vec<Finding>> {
+    let doc: serde_yaml::Value = serde_yaml::from_str(yaml).context("parsing workflow YAML")?;
+    let jobs = match doc.get("jobs").and_then(|v| v.as_mapping()) {
+        Some(m) => m,
+        // `action.yml` (composite action) and other non-workflow
+        // YAMLs have no `jobs:` block — nothing to audit. Empty
+        // result is the right answer; the caller decides whether
+        // to treat that as a problem.
+        None => return Ok(Vec::new()),
+    };
+
+    let mut out = Vec::new();
+    // BTreeMap iter would be nicer but serde_yaml gives us a
+    // Mapping (insertion-ordered) — iterate in source order so
+    // findings line up with the file.
+    for (job_id, job_val) in jobs {
+        let job_id = job_id.as_str().unwrap_or("<non-string>").to_string();
+        let job_map = match job_val.as_mapping() {
+            Some(m) => m,
+            None => continue,
+        };
+
+        // Reusable workflow call: `jobs.<id>.uses: org/repo/...@ref`.
+        if let Some(uses) = job_map
+            .get(serde_yaml::Value::String("uses".into()))
+            .and_then(|v| v.as_str())
+        {
+            out.push(classify_finding(job_id.clone(), None, uses));
+        }
+
+        // Regular job: `jobs.<id>.steps[].uses`.
+        if let Some(steps) = job_map
+            .get(serde_yaml::Value::String("steps".into()))
+            .and_then(|v| v.as_sequence())
+        {
+            for step in steps {
+                let step_map = match step.as_mapping() {
+                    Some(m) => m,
+                    None => continue,
+                };
+                let uses = match step_map
+                    .get(serde_yaml::Value::String("uses".into()))
+                    .and_then(|v| v.as_str())
+                {
+                    Some(u) => u,
+                    // `run:` step or anything else without `uses` —
+                    // not in scope for the SHA-pin auditor.
+                    None => continue,
+                };
+                let name = step_map
+                    .get(serde_yaml::Value::String("name".into()))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                out.push(classify_finding(job_id.clone(), name, uses));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Aggregate stats over a flat finding list — handy for the CLI
+/// summary line without re-walking the vector.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct Summary {
+    pub total: usize,
+    pub ok: usize,
+    pub warn: usize,
+    pub error: usize,
+    pub by_owner: BTreeMap<String, usize>,
+}
+
+impl Summary {
+    pub fn from_findings(findings: &[Finding]) -> Self {
+        let mut s = Summary {
+            total: findings.len(),
+            ..Self::default()
+        };
+        for f in findings {
+            match f.severity {
+                Severity::Ok => s.ok += 1,
+                Severity::Warn => s.warn += 1,
+                Severity::Error => s.error += 1,
+            }
+            if let Some(owner) = owner_of(&f.uses) {
+                *s.by_owner.entry(owner.to_string()).or_default() += 1;
+            }
+        }
+        s
+    }
+}
+
+fn classify_finding(job: String, step: Option<String>, uses: &str) -> Finding {
+    let (severity, message) = classify(uses);
+    Finding {
+        job,
+        step,
+        uses: uses.to_string(),
+        severity,
+        message,
+    }
+}
+
+/// Decide whether a `uses:` value is acceptable.
+///
+/// The rules, in order:
+/// 1. Local action (`./...`, `../...`) — OK, nothing to pin.
+/// 2. Docker image with a `@sha256:…` digest — OK; bare `:tag` is
+///    Warn (Docker tags are mutable but not in the same trust
+///    model as a GitHub-hosted action).
+/// 3. `<owner>/<repo>...@<ref>`:
+///    - `<ref>` is 40 hex chars → OK.
+///    - `<ref>` looks like a version tag or branch:
+///      - first-party owner → Warn
+///      - third-party owner → Error
+/// 4. Anything else (no `@`, malformed) → Warn — we'd rather
+///    surface than silently accept.
+pub fn classify(uses: &str) -> (Severity, String) {
+    let trimmed = uses.trim();
+    if trimmed.starts_with("./") || trimmed.starts_with("../") {
+        return (Severity::Ok, "local action; no pin needed".into());
+    }
+    if let Some(rest) = trimmed.strip_prefix("docker://") {
+        return classify_docker(rest);
+    }
+    let (path, reference) = match trimmed.split_once('@') {
+        Some((p, r)) => (p, r),
+        None => {
+            return (
+                Severity::Warn,
+                format!("no `@<ref>` — cannot tell what version `{trimmed}` resolves to"),
+            );
+        }
+    };
+    if is_sha40(reference) {
+        return (Severity::Ok, "pinned to commit SHA".into());
+    }
+    let owner = path.split('/').next().unwrap_or("");
+    let first_party = matches!(owner, "actions" | "github");
+    let sev = if first_party {
+        Severity::Warn
+    } else {
+        Severity::Error
+    };
+    let kind = if looks_like_branch(reference) {
+        "branch"
+    } else {
+        "tag"
+    };
+    (
+        sev,
+        format!(
+            "mutable {kind} `{reference}` on {} action `{path}` — pin to a 40-char commit SHA \
+             (e.g. `{path}@<sha>  # {reference}`)",
+            if first_party {
+                "first-party"
+            } else {
+                "third-party"
+            }
+        ),
+    )
+}
+
+fn classify_docker(rest: &str) -> (Severity, String) {
+    if rest.contains("@sha256:") {
+        (Severity::Ok, "docker image pinned by digest".into())
+    } else if rest.contains(':') {
+        (
+            Severity::Warn,
+            format!("docker image `{rest}` uses a mutable tag — pin with `@sha256:…`"),
+        )
+    } else {
+        (
+            Severity::Warn,
+            format!("docker image `{rest}` has no tag/digest — defaults to `:latest`"),
+        )
+    }
+}
+
+fn is_sha40(s: &str) -> bool {
+    s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Heuristic: `main`, `master`, `develop`, `dev`, `trunk`, `latest`,
+/// or any single-word name without a leading `v` and no dots. Used
+/// only to make the message read better — severity is the same
+/// either way.
+fn looks_like_branch(reference: &str) -> bool {
+    matches!(
+        reference,
+        "main" | "master" | "develop" | "dev" | "trunk" | "latest" | "HEAD"
+    ) || (!reference.starts_with('v') && !reference.contains('.'))
+}
+
+fn owner_of(uses: &str) -> Option<&str> {
+    let rest = uses.strip_prefix("docker://").unwrap_or(uses);
+    let path = rest.split_once('@').map(|(p, _)| p).unwrap_or(rest);
+    if path.starts_with('.') {
+        return None;
+    }
+    path.split('/').next().filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_sha_pinned_third_party_is_ok() {
+        let (sev, _) = classify("foo/bar@b4ffde65f46336ab88eb53be808477a3936bae11");
+        assert_eq!(sev, Severity::Ok);
+    }
+
+    #[test]
+    fn classify_third_party_v_tag_is_error() {
+        let (sev, msg) = classify("foo/bar@v1");
+        assert_eq!(sev, Severity::Error);
+        assert!(msg.contains("third-party"));
+        assert!(msg.contains("v1"));
+        assert!(msg.contains("foo/bar@<sha>"));
+    }
+
+    #[test]
+    fn classify_first_party_v_tag_is_warn_not_error() {
+        // `actions/checkout@v4` is the canonical example. Risky but
+        // not "fail the build" risky — first-party publish is
+        // tightly controlled. Ratchet later if we want to be strict.
+        let (sev, _) = classify("actions/checkout@v4");
+        assert_eq!(sev, Severity::Warn);
+        let (sev, _) = classify("github/codeql-action/init@v3");
+        assert_eq!(sev, Severity::Warn);
+    }
+
+    #[test]
+    fn classify_branch_ref_says_branch_in_message() {
+        let (sev, msg) = classify("foo/bar@main");
+        assert_eq!(sev, Severity::Error);
+        assert!(msg.contains("branch"), "msg = {msg}");
+    }
+
+    #[test]
+    fn classify_local_action_is_ok() {
+        let (sev, _) = classify("./.github/actions/setup");
+        assert_eq!(sev, Severity::Ok);
+        let (sev, _) = classify("../shared/build");
+        assert_eq!(sev, Severity::Ok);
+    }
+
+    #[test]
+    fn classify_docker_with_digest_is_ok_else_warn() {
+        let (sev, _) = classify(
+            "docker://alpine@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+        assert_eq!(sev, Severity::Ok);
+        let (sev, _) = classify("docker://alpine:3.19");
+        assert_eq!(sev, Severity::Warn);
+        let (sev, _) = classify("docker://alpine");
+        assert_eq!(sev, Severity::Warn);
+    }
+
+    #[test]
+    fn classify_missing_ref_is_warn_not_silent_pass() {
+        // Without `@<ref>` GitHub Actions resolves to the default
+        // branch — the most-mutable possible target. Don't silently
+        // ignore this.
+        let (sev, msg) = classify("foo/bar");
+        assert_eq!(sev, Severity::Warn);
+        assert!(msg.contains("no `@<ref>`"));
+    }
+
+    #[test]
+    fn classify_sha_lowercase_only_uppercase_still_ok() {
+        // GitHub stores SHAs lowercase but humans paste either case.
+        let (sev, _) = classify("foo/bar@B4FFDE65F46336AB88EB53BE808477A3936BAE11");
+        assert_eq!(sev, Severity::Ok);
+    }
+
+    #[test]
+    fn classify_sha_too_short_is_treated_as_tag() {
+        // Short SHAs are technically valid in git but Actions
+        // resolves them via the API and they can become ambiguous;
+        // treat as a tag for safety.
+        let (sev, _) = classify("foo/bar@b4ffde6");
+        assert_eq!(sev, Severity::Error);
+    }
+
+    #[test]
+    fn audit_yaml_walks_jobs_and_steps_in_source_order() {
+        let yaml = r#"
+name: ci
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+      - uses: foo/bar@b4ffde65f46336ab88eb53be808477a3936bae11
+  deploy:
+    uses: org/repo/.github/workflows/release.yml@v1
+"#;
+        let f = audit_yaml(yaml).unwrap();
+        // 3 step uses + 1 reusable workflow uses; the run-only step
+        // is not listed.
+        assert_eq!(f.len(), 4, "findings: {f:#?}");
+
+        // Order: build's three steps first, then deploy.
+        assert_eq!(f[0].uses, "actions/checkout@v4");
+        assert_eq!(f[0].job, "build");
+        assert_eq!(f[0].step, None); // no `name:` set
+        assert_eq!(f[0].severity, Severity::Warn);
+
+        assert_eq!(f[1].uses, "dtolnay/rust-toolchain@stable");
+        assert_eq!(f[1].step.as_deref(), Some("setup rust"));
+        assert_eq!(f[1].severity, Severity::Error);
+
+        assert_eq!(f[2].severity, Severity::Ok);
+
+        // Reusable workflow at job-level: step is None, severity
+        // depends on third-party-ness.
+        assert_eq!(f[3].job, "deploy");
+        assert_eq!(f[3].step, None);
+        assert_eq!(f[3].severity, Severity::Error);
+    }
+
+    #[test]
+    fn audit_yaml_returns_empty_on_non_workflow_yaml() {
+        // `action.yml` doesn't have a `jobs:` block — out of scope.
+        let yaml = r#"
+name: my action
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+"#;
+        let f = audit_yaml(yaml).unwrap();
+        assert!(
+            f.is_empty(),
+            "composite actions are out of scope for v1; got {f:#?}"
+        );
+    }
+
+    #[test]
+    fn summary_aggregates_severity_and_owners() {
+        let yaml = r#"
+on: [push]
+jobs:
+  a:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: foo/bar@v1
+      - uses: foo/baz@b4ffde65f46336ab88eb53be808477a3936bae11
+"#;
+        let f = audit_yaml(yaml).unwrap();
+        let s = Summary::from_findings(&f);
+        assert_eq!(s.total, 3);
+        assert_eq!(s.ok, 1);
+        assert_eq!(s.warn, 1);
+        assert_eq!(s.error, 1);
+        assert_eq!(s.by_owner.get("actions").copied(), Some(1));
+        assert_eq!(s.by_owner.get("foo").copied(), Some(2));
+    }
+
+    #[test]
+    fn is_blocking_only_for_error_severity() {
+        let mk = |s: Severity| Finding {
+            job: "j".into(),
+            step: None,
+            uses: "x".into(),
+            severity: s,
+            message: String::new(),
+        };
+        assert!(!mk(Severity::Ok).is_blocking());
+        assert!(!mk(Severity::Warn).is_blocking());
+        assert!(mk(Severity::Error).is_blocking());
+    }
+}

--- a/crates/coronarium-core/src/lib.rs
+++ b/crates/coronarium-core/src/lib.rs
@@ -11,6 +11,7 @@
 //! reports. Anything that needs eBPF / ETW / OS-specific APIs stays in
 //! the respective binary crates.
 
+pub mod actions;
 pub mod deps;
 pub mod events;
 pub mod html;

--- a/crates/coronarium/src/cli.rs
+++ b/crates/coronarium/src/cli.rs
@@ -93,6 +93,45 @@ pub enum Command {
         #[command(subcommand)]
         cmd: PolicyCommand,
     },
+    /// Static analysis of GitHub Actions workflow files. Currently
+    /// just `audit`, which flags `uses:` refs that aren't pinned to
+    /// a 40-char commit SHA.
+    Actions {
+        #[command(subcommand)]
+        cmd: ActionsCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ActionsCommand {
+    /// Walk one or more workflow YAMLs and report every `uses:`
+    /// pointing at a mutable tag/branch instead of a commit SHA.
+    /// Exits non-zero when at least one Error-severity finding
+    /// is present (third-party `@v1` style); first-party warnings
+    /// don't fail by default — pass `--strict` to escalate them.
+    Audit(ActionsAuditArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct ActionsAuditArgs {
+    /// Workflow YAML files to audit. Pass `.github/workflows/*.yml`
+    /// from your shell to glob — we don't expand globs ourselves.
+    #[arg(required = true)]
+    pub files: Vec<PathBuf>,
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: ActionsFormat,
+    /// Treat first-party (`actions/*`, `github/*`) mutable refs as
+    /// blocking too. Default is to warn for first-party, error for
+    /// third-party, on the theory that GitHub's own publish
+    /// pipeline is harder to compromise than a random vendor's.
+    #[arg(long)]
+    pub strict: bool,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum ActionsFormat {
+    Text,
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -612,7 +651,97 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Policy {
             cmd: PolicyCommand::Suggest(args),
         } => run_policy_suggest(args),
+        Command::Actions {
+            cmd: ActionsCommand::Audit(args),
+        } => run_actions_audit(args),
     }
+}
+
+fn run_actions_audit(args: ActionsAuditArgs) -> Result<()> {
+    use coronarium_core::actions::{Finding, Severity, Summary, audit_yaml};
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct PerFile<'a> {
+        file: &'a std::path::Path,
+        findings: &'a [Finding],
+        summary: Summary,
+    }
+
+    let mut all: Vec<(PathBuf, Vec<Finding>)> = Vec::new();
+    for path in &args.files {
+        let yaml =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let findings = audit_yaml(&yaml).with_context(|| format!("auditing {}", path.display()))?;
+        all.push((path.clone(), findings));
+    }
+
+    // `--strict` rewrites Warn → Error in-place so both the printed
+    // output and the exit code reflect the user's choice.
+    if args.strict {
+        for (_, findings) in &mut all {
+            for f in findings {
+                if f.severity == Severity::Warn {
+                    f.severity = Severity::Error;
+                }
+            }
+        }
+    }
+
+    let mut blocking = 0usize;
+    match args.format {
+        ActionsFormat::Json => {
+            let payload: Vec<PerFile<'_>> = all
+                .iter()
+                .map(|(p, f)| PerFile {
+                    file: p.as_path(),
+                    findings: f,
+                    summary: Summary::from_findings(f),
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+            blocking = all
+                .iter()
+                .flat_map(|(_, f)| f.iter())
+                .filter(|f| f.is_blocking())
+                .count();
+        }
+        ActionsFormat::Text => {
+            for (path, findings) in &all {
+                let summary = Summary::from_findings(findings);
+                println!(
+                    "{}  ({} ok, {} warn, {} error)",
+                    path.display(),
+                    summary.ok,
+                    summary.warn,
+                    summary.error
+                );
+                for f in findings {
+                    if matches!(f.severity, Severity::Ok) {
+                        continue;
+                    }
+                    let tag = match f.severity {
+                        Severity::Error => "ERROR",
+                        Severity::Warn => "warn ",
+                        Severity::Ok => "ok   ",
+                    };
+                    let where_ = match &f.step {
+                        Some(name) => format!("{}/{name}", f.job),
+                        None => f.job.clone(),
+                    };
+                    println!("  {tag}  {where_}: {}", f.message);
+                    if f.is_blocking() {
+                        blocking += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    if blocking > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 fn run_policy_suggest(args: PolicySuggestArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

Closes harden-runner parity gap #10 from the roadmap.

New subcommand `coronarium actions audit <workflow.yml...>` walks
every `uses:` in `jobs.<id>.steps[]` and `jobs.<id>.uses` (reusable
workflow callers) and flags references that aren't pinned to a
40-char commit SHA. Pure offline static analysis — no GitHub API
calls.

Severity ladder:

| sev | when |
|---|---|
| **error** | third-party action with mutable tag/branch (`foo/bar@v1`, `foo/bar@main`) |
| **warn**  | first-party (`actions/*`, `github/*`) mutable tag, or docker image without `@sha256:` digest |
| **ok**    | 40-char SHA pin, local action (`./...`), docker `@sha256:` reference |

`--strict` escalates Warn → Error. Text + JSON output. Exits non-zero
when at least one error remains.

Smoke-tested against this repo's own workflows — it correctly
surfaces 17 errors (mostly `dtolnay/rust-toolchain@stable|nightly`
and the `docker/*` family on `@v3`/`@v6`) plus a long warn list of
`actions/checkout@v4` etc.

Composite-action `action.yml` files (no top-level `jobs:` block) are
intentionally treated as out-of-scope — they return an empty
findings list rather than parse errors.

Tag→SHA auto-resolution via the GitHub API is deferred; it would
turn the tool into a network one and require auth.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 13 new unit tests in `coronarium-core::actions` (107 total in core, all green)
- [x] Manual run against `.github/workflows/*.yml` produced expected findings + exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)