### PR TITLE
ci(consumer-smoke): re-enable on PR now that v0.32.0 is published under sakimori

### DIFF
--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -16,12 +16,6 @@ permissions:
 
 jobs:
   use-as-action:
-    # The `bokuweb/sakimori@v0` published action still ships the pre-rename
-    # `coronarium-*.tar.gz` assets and exports `CORONARIUM_BIN`; on a
-    # pull_request run from this branch the workflow references
-    # `$SAKIMORI_BIN` and fails. Re-enable on PR after the first release
-    # under the new name has been cut.
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -127,8 +121,6 @@ jobs:
     # Complement the audit-mode happy path with a block-mode run that
     # asserts the published action actually makes CI fail when a deny
     # happens. Runs alongside use-as-action (doesn't need its results).
-    # Skipped on PR for the same reason as use-as-action above.
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -164,9 +156,7 @@ jobs:
 
   use-as-action-windows:
     # Proves `bokuweb/sakimori@v0` also works on windows-latest, using
-    # the same inputs / env contract as the Linux job above. Skipped on
-    # PR for the same reason as use-as-action above.
-    if: github.event_name != 'pull_request'
+    # the same inputs / env contract as the Linux job above.
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`bokuweb/sakimori@v0` now resolves to the freshly-cut v0.32.0
release, which ships `sakimori-*.tar.gz` assets and exports
`SAKIMORI_BIN`. The env-var mismatch that motivated the PR-skip
in #45 is gone, so we can re-run the consumer smoke against actual
PRs again.

Drops the `if: github.event_name != 'pull_request'` gates on
`use-as-action`, `block-as-action`, and `use-as-action-windows`.

The two `if: github.event_name == 'pull_request'` gates further
down are intentionally kept — they guard the PR-comment sub-action
that only makes sense on `pull_request` events.

## Test plan

- [x] This PR itself running consumer-smoke against `bokuweb/sakimori@v0`
      = v0.32.0 = the post-rebrand release
- [x] No code changes outside `.github/workflows/consumer-smoke.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)