### PR TITLE
events: decode pid from header.tgid (POSIX PID), not header.pid (kernel TID)

### DIFF
--- a/crates/sakimori/src/events.rs
+++ b/crates/sakimori/src/events.rs
@@ -1,5 +1,14 @@
 //! Decoding ring-buffer frames produced by the eBPF side into [`Event`].
 //! The enum itself lives in `sakimori-core` so Windows shares it.
+//!
+//! Note: every decode below intentionally reads `header.tgid`, not
+//! `header.pid`. The eBPF side splits `bpf_get_current_pid_tgid()`
+//! into the kernel's two senses — `header.pid` is the kernel's
+//! per-thread `task->pid` (= TID), `header.tgid` is `task->tgid`
+//! (= the POSIX process ID, which is what `getpid()` /
+//! `std::process::id()` returns). Users who read the audit log
+//! expect the latter, and the supervisor-self filter in
+//! `loader::ingest` only works against the latter.
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
@@ -28,7 +37,7 @@ pub fn decode(bytes: &[u8]) -> Option<Event> {
 fn decode_exec(bytes: &[u8]) -> Option<Event> {
     let ev: ExecEvent = read_pod(bytes)?;
     Some(Event::Exec {
-        pid: ev.header.pid,
+        pid: ev.header.tgid,
         uid: ev.header.uid,
         comm: cstr(&ev.header.comm),
         filename: cstr(&ev.filename),
@@ -41,7 +50,7 @@ fn decode_exec(bytes: &[u8]) -> Option<Event> {
 fn decode_connect4(bytes: &[u8]) -> Option<Event> {
     let ev: Connect4Event = read_pod(bytes)?;
     Some(Event::Connect {
-        pid: ev.header.pid,
+        pid: ev.header.tgid,
         uid: ev.header.uid,
         comm: cstr(&ev.header.comm),
         daddr: Ipv4Addr::from(u32::from_be(ev.daddr)).to_string(),
@@ -56,7 +65,7 @@ fn decode_connect4(bytes: &[u8]) -> Option<Event> {
 fn decode_connect6(bytes: &[u8]) -> Option<Event> {
     let ev: Connect6Event = read_pod(bytes)?;
     Some(Event::Connect {
-        pid: ev.header.pid,
+        pid: ev.header.tgid,
         uid: ev.header.uid,
         comm: cstr(&ev.header.comm),
         daddr: Ipv6Addr::from(ev.daddr).to_string(),
@@ -71,7 +80,7 @@ fn decode_connect6(bytes: &[u8]) -> Option<Event> {
 fn decode_open(bytes: &[u8]) -> Option<Event> {
     let ev: OpenEvent = read_pod(bytes)?;
     Some(Event::Open {
-        pid: ev.header.pid,
+        pid: ev.header.tgid,
         uid: ev.header.uid,
         comm: cstr(&ev.header.comm),
         filename: cstr(&ev.filename),

--- a/crates/sakimori/src/loader.rs
+++ b/crates/sakimori/src/loader.rs
@@ -427,6 +427,10 @@ mod tests {
     use sakimori_core::policy::{FilePolicy, ProcessPolicy};
 
     fn make_open_event_bytes(pid: u32, filename: &str) -> Vec<u8> {
+        make_open_event_bytes_pid_tgid(pid, pid, filename)
+    }
+
+    fn make_open_event_bytes_pid_tgid(pid: u32, tgid: u32, filename: &str) -> Vec<u8> {
         let mut path_buf = [0u8; PATH_LEN];
         let bytes = filename.as_bytes();
         path_buf[..bytes.len()].copy_from_slice(bytes);
@@ -435,7 +439,7 @@ mod tests {
                 kind: EVENT_KIND_OPEN,
                 verdict: VERDICT_ALLOW,
                 pid,
-                tgid: pid,
+                tgid,
                 uid: 0,
                 _pad: 0,
                 comm: [0u8; COMM_LEN],
@@ -488,5 +492,41 @@ mod tests {
 
         ingest(&mut stats, &raw, &fm, &em, None, 99999);
         assert_eq!(stats.observed, 1);
+    }
+
+    /// Regression for the v0.32.0 file-block CI failure. The eBPF
+    /// program splits `bpf_get_current_pid_tgid()` into `header.pid`
+    /// (kernel TID) and `header.tgid` (POSIX PID). Userspace decode
+    /// must read tgid, otherwise:
+    ///
+    /// - The supervisor's own tokio worker threads have TID ≠ tgid,
+    ///   so the supervisor-self filter wouldn't catch them
+    ///   (re-introducing the /proc-read feedback loop).
+    /// - cat opens /etc/shadow on a different thread of the same
+    ///   process; the audit log would show TID, not the PID a
+    ///   human or the test grep-script expects.
+    #[test]
+    fn ingest_treats_event_pid_as_posix_tgid_not_kernel_tid() {
+        // Synthetic event from a worker thread of the supervisor:
+        // TID 9999, tgid (POSIX PID) 4242. Filter must match.
+        let supervisor_pid = 4242;
+        let raw = make_open_event_bytes_pid_tgid(9999, supervisor_pid, "/proc/2109/cmdline");
+        let mut stats = Stats::default();
+        let fm = FileMatcher::from_policy(&FilePolicy::default());
+        let em = ExecMatcher::from_policy(&ProcessPolicy::default());
+
+        ingest(&mut stats, &raw, &fm, &em, None, supervisor_pid);
+        assert_eq!(
+            stats.observed, 0,
+            "event from supervisor's worker thread (TID != tgid) must be filtered by tgid match"
+        );
+
+        // And the inverse: a real supervised-tree event whose TID
+        // happens to collide with supervisor_pid (rare but possible
+        // PID-namespace edge case) should still be kept, because
+        // the filter looks at tgid.
+        let raw = make_open_event_bytes_pid_tgid(supervisor_pid, 5555, "/etc/passwd");
+        ingest(&mut stats, &raw, &fm, &em, None, supervisor_pid);
+        assert_eq!(stats.observed, 1, "tgid 5555 != supervisor 4242 → keep");
     }
 }


### PR DESCRIPTION
## Summary

The eBPF `make_header()` helper splits `bpf_get_current_pid_tgid()`
into the kernel's two senses:

```
header.pid  = (pid_tgid as u32)        // task->pid  = kernel TID
header.tgid = (pid_tgid >> 32) as u32  // task->tgid = POSIX PID
```

Userspace decode in `crates/sakimori/src/events.rs` was reading
`header.pid` — i.e. the kernel-internal per-thread TID — into the
public `Event::pid` field. That's not what \`getpid()\` /
`std::process::id()` returns and not what humans grepping the
audit log expect.

## Two real consequences seen in CI v0.32.0 file-block test

1. **Audit log shows "pid 8564"** for events emitted from the
   supervisor's own tokio worker thread (a TID), even though the
   supervisor's POSIX PID (tgid) was the same value any external
   `/proc/<pid>/...` lookup would resolve.

2. **The supervisor-self filter from #49** (`ev.pid() == supervisor_pid`)
   compared kernel TID against POSIX PID and consequently let
   worker-thread events slip through. The /proc-read feedback loop
   re-appeared, drowning the `cat → /etc/shadow` denied event in the
   sample buffer:

   ```
   observed=556 denied=0 lost=0
   cat_rc=137                                    # kernel SIGKILL fired
   Error: sakimori exit=0 despite denied open in block mode
   ```

   The kernel block worked correctly (cat got SIGKILL'd before it
   could read `/etc/shadow`), but the userspace exit-non-zero
   check never triggered because the deny was never counted in
   stats.denied.

## Fix

Read `header.tgid` in all four `decode_*` functions. One-line
change per call site, plus a doc comment at the top of `events.rs`
explaining the kernel TID vs POSIX PID distinction so the next
person doesn't re-do the same mistake.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 34 in sakimori (including a new
      regression test `ingest_treats_event_pid_as_posix_tgid_not_kernel_tid`
      that builds an event with TID ≠ tgid and confirms the
      supervisor-self filter matches by tgid). 129 in sakimori-core,
      161 in sakimori-proxy. All green.

The Linux file-block CI test that triggered this investigation
will exercise the fix end-to-end as part of this PR's check run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)