### PR TITLE
docs(readme): add CI / release / license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # sakimori
 
+[![CI](https://github.com/bokuweb/sakimori/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bokuweb/sakimori/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/bokuweb/sakimori?sort=semver)](https://github.com/bokuweb/sakimori/releases/latest)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 **Cross-platform supply-chain guard for every package manager on your
 machine.** Silently blocks too-young versions, known-malicious packages
 and unsigned publishes — across **npm, cargo, pypi, nuget** — without


### PR DESCRIPTION
## Summary

Three badges added right under the title:

- CI status (main branch) — links to the workflow runs page
- Latest release version — links to /releases/latest
- License (MIT) — links to LICENSE

No content changes elsewhere; one diff hunk in `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)