### PR TITLE
proxy: hostname egress allow-list (`--network-allow`)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,15 +197,20 @@ of value-per-implementation-cost.
    under a commented `# observed_exec` block. Reduces the "stare
    at the log and hand-craft the policy" friction that today
    blocks teams from flipping `mode: audit` → `mode: block`.
-8. **SNI-based egress in the proxy** — extend `coronarium proxy`
-   to honour a `network.allow` style hostname list at the CONNECT
-   layer (parse SNI from the TLS ClientHello, match against the
-   policy, return 403 on miss). Today the eBPF path enforces by
-   resolved IP, which loses against CDN rotation; doing it at the
-   proxy gives FQDN/wildcard semantics that match what
-   harden-runner users expect (`*.githubusercontent.com:443`
-   etc.). Doable on top of the existing hudsucker stack; depends
-   on `install-gate` already being on the user's shell.
+8. **SNI / hostname-based egress in the proxy** — ✅ implemented
+   in v0.33. New `--network-allow <pattern>` (repeatable) and
+   `--network-allow-file <path>` flags on `sakimori proxy start`
+   configure a default-deny hostname allow-list enforced at
+   `handle_request`. CONNECT requests pull the target from
+   `req.uri().authority()`; plain HTTP from the `Host:` header; a
+   missing Host with the policy active is treated as deny (no
+   silent slip-through). Pattern grammar in `host_allow.rs`:
+   `host.example.com` (exact, case-insensitive), `*.example.com`
+   (any subdomain, excludes the apex by design); embedded `*` is
+   a parse error. Off by default. Closes the eBPF-by-IP weakness
+   against CDN rotation — every `*.githubusercontent.com` IP that
+   happens to be live this minute resolves correctly because we
+   filter by the SNI/Host name the client actually asked for.
 9. **Workspace tamper detection** — ✅ implemented in v0.22 as
    standalone `coronarium workspace snapshot <dir>` +
    `coronarium workspace diff <baseline.json> <dir>`. Walks every

--- a/README.md
+++ b/README.md
@@ -268,6 +268,17 @@ Options:
                                fall back to the live API for
                                entries the mirror hasn't indexed.
   --osv-mirror-url <URL>       Override mirror URL (e.g. self-hosted).
+  --network-allow <HOST>       Hostname egress allow-list (repeatable).
+                               Patterns: `host.example.com` (exact) or
+                               `*.example.com` (any subdomain, excludes
+                               apex). When set, the proxy default-denies
+                               every CONNECT/HTTP whose target host
+                               doesn't match, returning 403. Off by
+                               default — without any flag, every host
+                               passes through.
+  --network-allow-file <PATH>  Read additional `--network-allow`
+                               patterns from a file (one per line;
+                               `#` comments / blank lines skipped).
   --config-dir <PATH>          Override CA / config directory.
                                Defaults to $XDG_CONFIG_HOME/sakimori
                                on Unix, %LOCALAPPDATA%\sakimori on
@@ -277,6 +288,21 @@ Options:
 **First-run side effect**: generates a self-signed root CA at the
 config dir and prints the OS-specific trust command. Subsequent runs
 reuse the existing CA.
+
+**Egress allow-list** closes the eBPF-by-IP gap: when you also run
+`sakimori run` with a network policy, the kernel layer enforces by
+resolved IP and loses against CDN rotation. The proxy's hostname
+filter sees the SNI / `Host:` value the client actually asked for,
+so an entry like `*.githubusercontent.com` matches every rotating
+CDN IP automatically — the same convention `step-security/harden-runner`
+users are used to:
+
+```bash
+sakimori proxy start \
+    --network-allow api.github.com \
+    --network-allow '*.githubusercontent.com' \
+    --network-allow registry.npmjs.org
+```
 
 ### `proxy install-ca` / `uninstall-ca`
 

--- a/crates/sakimori-proxy/src/host_allow.rs
+++ b/crates/sakimori-proxy/src/host_allow.rs
@@ -1,0 +1,289 @@
+//! Hostname allow-list for the proxy's egress filter.
+//!
+//! Closes the gap that the eBPF supervisor leaves on its own — the
+//! kernel layer can only enforce by resolved IP, which loses against
+//! CDN rotation. Doing the check at the proxy's CONNECT layer gives
+//! us FQDN/wildcard semantics that match what `step-security/harden-runner`
+//! users expect (`api.github.com:443`, `*.githubusercontent.com:443`).
+//!
+//! Pattern grammar:
+//!
+//! - `host.example.com` — exact match (case-insensitive).
+//! - `*.example.com` — any direct or transitive subdomain
+//!   (`a.example.com`, `a.b.example.com`, …). Does **not** match the
+//!   bare apex `example.com`; add a separate entry for that. The
+//!   leading `*.` is the only wildcard form supported — embedded
+//!   `*` characters return a parse error rather than silently
+//!   matching nothing.
+//! - Port suffix on a query (`example.com:443`) is stripped before
+//!   matching; patterns describe hosts, not (host, port) pairs.
+//!   The proxy applies a separate per-port check elsewhere if
+//!   needed.
+//!
+//! Match semantics:
+//!
+//! - Empty list → no policy configured → caller treats every host
+//!   as allowed (current pre-policy behaviour).
+//! - Non-empty list → default-deny, allow only what's listed.
+//!   That's the point of the feature; an "allow plus default-allow"
+//!   list reduces to "no policy".
+
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Pattern {
+    /// Exact host (already lower-cased at parse).
+    Exact(String),
+    /// `*.<suffix>` — matches `*.suffix` where the host strictly ends
+    /// in `.suffix` (suffix stored without the leading dot).
+    SubdomainOf(String),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HostMatcher {
+    patterns: Vec<Pattern>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    Empty,
+    /// `*` appears anywhere other than as a leading `*.` prefix.
+    BadWildcard,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty hostname pattern"),
+            Self::BadWildcard => write!(
+                f,
+                "only a leading `*.` wildcard is supported (e.g. `*.example.com`)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl HostMatcher {
+    /// Build from an iterator of patterns. Returns the first parse
+    /// error encountered, with the offending input attached so the
+    /// CLI can point at the bad line. Order is preserved — useful
+    /// for any future "first match wins" semantics, though the
+    /// current implementation is order-independent.
+    pub fn from_patterns<I, S>(patterns: I) -> Result<Self, (String, ParseError)>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut out = Vec::new();
+        for raw in patterns {
+            let s = raw.as_ref().trim();
+            if s.is_empty() {
+                continue;
+            }
+            let parsed = parse_pattern(s).map_err(|e| (s.to_string(), e))?;
+            out.push(parsed);
+        }
+        Ok(Self { patterns: out })
+    }
+
+    /// `true` when no patterns were configured. The caller uses this
+    /// to short-circuit: an empty matcher means "feature disabled",
+    /// not "deny everything".
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Number of configured patterns. Only used for log formatting
+    /// — semantic decisions go through [`Self::is_empty`] or
+    /// [`Self::allows`].
+    pub fn len(&self) -> usize {
+        self.patterns.len()
+    }
+
+    /// Test a host. Strips a `:port` suffix if present so callers
+    /// can pass raw `Host:` headers / CONNECT URI authorities
+    /// without pre-processing. `host` is matched case-insensitively
+    /// against patterns (which were already lower-cased at parse).
+    pub fn allows(&self, host: &str) -> bool {
+        if self.patterns.is_empty() {
+            // No policy → caller handles via `is_empty()`. Returning
+            // `true` here keeps the predicate honest if someone
+            // skips the empty check by mistake.
+            return true;
+        }
+        let host = strip_port(host).to_ascii_lowercase();
+        self.patterns.iter().any(|p| match p {
+            Pattern::Exact(h) => *h == host,
+            Pattern::SubdomainOf(suffix) => {
+                // `host == suffix` is intentionally NOT a match; the
+                // wildcard `*.example.com` excludes the apex.
+                host.len() > suffix.len() + 1
+                    && host.ends_with(suffix)
+                    && host.as_bytes()[host.len() - suffix.len() - 1] == b'.'
+            }
+        })
+    }
+}
+
+fn parse_pattern(input: &str) -> Result<Pattern, ParseError> {
+    if input.is_empty() {
+        return Err(ParseError::Empty);
+    }
+    let lower = input.to_ascii_lowercase();
+    if let Some(rest) = lower.strip_prefix("*.") {
+        if rest.is_empty() || rest.contains('*') {
+            return Err(ParseError::BadWildcard);
+        }
+        Ok(Pattern::SubdomainOf(rest.to_string()))
+    } else if lower.contains('*') {
+        Err(ParseError::BadWildcard)
+    } else {
+        Ok(Pattern::Exact(lower))
+    }
+}
+
+fn strip_port(host: &str) -> &str {
+    // IPv6 literals come wrapped in brackets (`[::1]:8080`); strip
+    // those down to the inner address. Plain IPv4 / hostname use
+    // the last `:`. A bare IPv6 (no brackets, two or more colons)
+    // is unambiguous-as-host-only — port specifiers on bare v6
+    // literals aren't legal anyway, so we leave them alone rather
+    // than risk lopping off the trailing group.
+    let bytes = host.as_bytes();
+    if bytes.first() == Some(&b'[')
+        && let Some(end) = host.find(']')
+    {
+        return &host[1..end];
+    }
+    if host.bytes().filter(|b| *b == b':').count() >= 2 {
+        return host;
+    }
+    match host.rfind(':') {
+        Some(i) if !host[..i].is_empty() => &host[..i],
+        _ => host,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(pats: &[&str]) -> HostMatcher {
+        HostMatcher::from_patterns(pats.iter().copied()).unwrap()
+    }
+
+    #[test]
+    fn empty_matcher_short_circuits() {
+        let m = HostMatcher::default();
+        assert!(m.is_empty());
+        // The `allows` predicate should still return true for
+        // safety even though callers are expected to check
+        // `is_empty` first.
+        assert!(m.allows("anything.example.com"));
+    }
+
+    #[test]
+    fn exact_match_is_case_insensitive() {
+        let m = mk(&["api.github.com"]);
+        assert!(m.allows("api.github.com"));
+        assert!(m.allows("API.GitHub.com"));
+        assert!(!m.allows("evil.example.com"));
+    }
+
+    #[test]
+    fn port_is_stripped_before_match() {
+        let m = mk(&["api.github.com"]);
+        assert!(m.allows("api.github.com:443"));
+        assert!(m.allows("api.github.com:8080"));
+        assert!(!m.allows("evil.example.com:443"));
+    }
+
+    #[test]
+    fn ipv6_literal_with_port_is_handled() {
+        let m = mk(&["::1"]);
+        assert!(m.allows("[::1]:8080"));
+        // Bare IPv6 (no brackets, no port) — caller responsibility,
+        // we accept as-is.
+        assert!(m.allows("::1"));
+    }
+
+    #[test]
+    fn wildcard_matches_any_subdomain() {
+        let m = mk(&["*.githubusercontent.com"]);
+        assert!(m.allows("avatars.githubusercontent.com"));
+        assert!(m.allows("camo.githubusercontent.com"));
+        assert!(m.allows("a.b.c.githubusercontent.com"));
+    }
+
+    #[test]
+    fn wildcard_does_not_match_apex() {
+        // `*.example.com` should NOT match the bare `example.com`.
+        // If the user wants both, they list both.
+        let m = mk(&["*.example.com"]);
+        assert!(!m.allows("example.com"));
+        assert!(m.allows("a.example.com"));
+    }
+
+    #[test]
+    fn wildcard_does_not_match_unrelated_suffix_collision() {
+        // `*.example.com` must not match `notexample.com` or
+        // `example.com.attacker.com` (both would be true if we just
+        // did `ends_with`).
+        let m = mk(&["*.example.com"]);
+        assert!(!m.allows("notexample.com"));
+        assert!(!m.allows("example.com.attacker.com"));
+    }
+
+    #[test]
+    fn multiple_patterns_or_together() {
+        let m = mk(&["api.github.com", "*.githubusercontent.com"]);
+        assert!(m.allows("api.github.com"));
+        assert!(m.allows("avatars.githubusercontent.com"));
+        assert!(!m.allows("registry.npmjs.org"));
+    }
+
+    #[test]
+    fn empty_lines_in_input_are_skipped() {
+        let m = HostMatcher::from_patterns(["api.github.com", "", "  "]).unwrap();
+        assert_eq!(m.patterns.len(), 1);
+    }
+
+    #[test]
+    fn embedded_wildcard_is_rejected() {
+        let err = HostMatcher::from_patterns(["api.*.github.com"]).unwrap_err();
+        assert_eq!(err.0, "api.*.github.com");
+        assert_eq!(err.1, ParseError::BadWildcard);
+
+        let err = HostMatcher::from_patterns(["foo*.bar"]).unwrap_err();
+        assert_eq!(err.1, ParseError::BadWildcard);
+
+        // Bare `*` and `*.` (no suffix) also rejected.
+        assert_eq!(
+            HostMatcher::from_patterns(["*"]).unwrap_err().1,
+            ParseError::BadWildcard
+        );
+        assert_eq!(
+            HostMatcher::from_patterns(["*."]).unwrap_err().1,
+            ParseError::BadWildcard
+        );
+    }
+
+    #[test]
+    fn parse_lowercases_the_pattern_so_match_doesnt_have_to() {
+        let m = mk(&["API.GITHUB.com"]);
+        // Internally stored lower-case.
+        assert!(matches!(&m.patterns[0], Pattern::Exact(s) if s == "api.github.com"));
+        assert!(m.allows("api.github.com"));
+    }
+
+    #[test]
+    fn strip_port_handles_no_port_no_brackets() {
+        assert_eq!(strip_port("example.com"), "example.com");
+        assert_eq!(strip_port("example.com:443"), "example.com");
+        assert_eq!(strip_port(":443"), ":443"); // empty host, leave alone
+        assert_eq!(strip_port("[::1]:8080"), "::1");
+        assert_eq!(strip_port("[2001:db8::1]:443"), "2001:db8::1");
+    }
+}

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod ca;
 pub mod daemon;
 pub mod decision;
+pub mod host_allow;
 pub mod install;
 pub mod nuget_flatcontainer_client;
 pub mod osv;

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -70,6 +70,12 @@ pub struct ProxyConfig {
     pub user_agent: String,
     /// Override to inject a fake oracle in tests.
     pub oracle: Option<Box<dyn AgeOracle>>,
+    /// Optional egress allow-list. When `Some` and non-empty, the
+    /// proxy default-denies every host not on the list (including
+    /// CONNECT requests for non-MITM'd hosts). When `None`, egress
+    /// is unrestricted — current behaviour. See
+    /// [`crate::host_allow::HostMatcher`] for pattern grammar.
+    pub network_allow: Option<crate::host_allow::HostMatcher>,
 }
 
 impl ProxyConfig {
@@ -88,6 +94,7 @@ impl ProxyConfig {
             ca_files: CaFiles::at_default_location()?,
             user_agent: format!("sakimori-proxy/{}", env!("CARGO_PKG_VERSION")),
             oracle: None,
+            network_allow: None,
         })
     }
 }
@@ -178,6 +185,14 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         typosquat,
     });
 
+    if let Some(matcher) = cfg.network_allow.as_ref()
+        && !matcher.is_empty()
+    {
+        log::info!(
+            "egress allow-list active: {} pattern(s) — non-matching CONNECT/HTTP returns 403",
+            matcher.len(),
+        );
+    }
     let handler = SakimoriHandler {
         parsers: Arc::new(default_parsers()),
         decider,
@@ -186,6 +201,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         require_provenance: cfg.require_provenance,
         nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
+        network_allow: cfg.network_allow.map(Arc::new),
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -215,6 +231,47 @@ fn should_intercept(host: &str, parsers: &[Box<dyn RegistryParser>]) -> bool {
     parsers.iter().any(|p| host.eq_ignore_ascii_case(p.host()))
 }
 
+/// Decide whether an incoming request should be denied by the
+/// hostname allow-list. Returns `None` to allow (or when the
+/// matcher is empty / disabled), `Some(reason)` to deny.
+///
+/// CONNECT requests carry the target host in `req.uri().authority()`;
+/// plain HTTP requests in the `Host:` header. Picking the right one
+/// matters because hudsucker invokes `handle_request` for the
+/// CONNECT itself — a denied CONNECT must short-circuit before the
+/// upstream tunnel opens.
+///
+/// Extracted so the deny decision can be unit-tested without
+/// constructing hudsucker's `HttpContext`.
+fn egress_deny_reason(
+    matcher: &crate::host_allow::HostMatcher,
+    method: &http::Method,
+    uri: &http::Uri,
+    headers: &http::HeaderMap,
+) -> Option<String> {
+    if matcher.is_empty() {
+        return None;
+    }
+    let target = if method == http::Method::CONNECT {
+        uri.authority()
+            .map(|a| a.as_str().to_string())
+            .unwrap_or_default()
+    } else {
+        headers
+            .get(http::header::HOST)
+            .and_then(|h| h.to_str().ok())
+            .map(str::to_string)
+            .unwrap_or_default()
+    };
+    if matcher.allows(&target) {
+        None
+    } else {
+        Some(format!(
+            "egress denied: host `{target}` not on the allow-list"
+        ))
+    }
+}
+
 #[derive(Clone)]
 struct SakimoriHandler {
     parsers: Arc<Vec<Box<dyn RegistryParser>>>,
@@ -238,6 +295,11 @@ struct SakimoriHandler {
     /// API so we can silently filter the PEP 503 HTML Simple index
     /// (which has no dates inline).
     pypi_simple: PypiSimpleClient,
+    /// Hostname allow-list. `None` (or empty) → unrestricted egress.
+    /// `Some(non-empty)` → default-deny: any CONNECT or plain-HTTP
+    /// request whose target host doesn't match returns 403 before
+    /// hudsucker tunnels or MITMs anything.
+    network_allow: Option<Arc<crate::host_allow::HostMatcher>>,
 }
 
 impl HttpHandler for SakimoriHandler {
@@ -246,6 +308,17 @@ impl HttpHandler for SakimoriHandler {
         _ctx: &HttpContext,
         req: Request<Body>,
     ) -> RequestOrResponse {
+        // Hostname egress allow-list — runs before everything else.
+        if let Some(matcher) = self.network_allow.as_deref()
+            && let Some(reason) =
+                egress_deny_reason(matcher, req.method(), req.uri(), req.headers())
+        {
+            log::warn!("egress deny: {} {}", req.method(), reason);
+            self.last_host = None;
+            self.last_path = None;
+            return RequestOrResponse::Response(deny_response(&reason));
+        }
+
         // Host header is required; without it we can't route.
         let host = req
             .headers()
@@ -823,5 +896,83 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("minimum-release-age")
         );
+    }
+
+    fn matcher(pats: &[&str]) -> crate::host_allow::HostMatcher {
+        crate::host_allow::HostMatcher::from_patterns(pats.iter().copied()).unwrap()
+    }
+
+    #[test]
+    fn egress_deny_reason_passes_when_matcher_empty() {
+        let m = crate::host_allow::HostMatcher::default();
+        let mut h = http::HeaderMap::new();
+        h.insert(http::header::HOST, "anywhere.example".parse().unwrap());
+        let r = egress_deny_reason(&m, &http::Method::GET, &"/".parse().unwrap(), &h);
+        assert!(r.is_none(), "empty matcher = feature off, must allow");
+    }
+
+    #[test]
+    fn egress_deny_reason_uses_uri_authority_for_connect() {
+        // CONNECT requests put the target in the URI's authority,
+        // not in the Host header. Filtering on Host would let
+        // every CONNECT through.
+        let m = matcher(&["api.github.com"]);
+        let h = http::HeaderMap::new();
+        // Allowed CONNECT.
+        let allowed = egress_deny_reason(
+            &m,
+            &http::Method::CONNECT,
+            &"api.github.com:443".parse().unwrap(),
+            &h,
+        );
+        assert!(allowed.is_none());
+        // Denied CONNECT.
+        let denied = egress_deny_reason(
+            &m,
+            &http::Method::CONNECT,
+            &"evil.example:443".parse().unwrap(),
+            &h,
+        );
+        let reason = denied.expect("expected deny");
+        assert!(reason.contains("evil.example:443"), "{reason}");
+    }
+
+    #[test]
+    fn egress_deny_reason_uses_host_header_for_plain_http() {
+        let m = matcher(&["api.github.com"]);
+        let mut h = http::HeaderMap::new();
+        h.insert(http::header::HOST, "evil.example".parse().unwrap());
+        let denied = egress_deny_reason(&m, &http::Method::GET, &"/".parse().unwrap(), &h);
+        assert!(denied.is_some());
+
+        h.insert(http::header::HOST, "api.github.com".parse().unwrap());
+        let allowed = egress_deny_reason(&m, &http::Method::GET, &"/".parse().unwrap(), &h);
+        assert!(allowed.is_none());
+    }
+
+    #[test]
+    fn egress_deny_reason_treats_missing_host_as_deny() {
+        // Missing/blank Host with a non-empty allow-list must NOT
+        // silently slip through. Empty target falls through to
+        // `matcher.allows("")` which is false → deny.
+        let m = matcher(&["api.github.com"]);
+        let h = http::HeaderMap::new();
+        let denied = egress_deny_reason(&m, &http::Method::GET, &"/".parse().unwrap(), &h);
+        assert!(
+            denied.is_some(),
+            "missing Host with allow-list active must deny"
+        );
+    }
+
+    #[test]
+    fn egress_deny_reason_honours_wildcard_subdomain() {
+        let m = matcher(&["*.githubusercontent.com"]);
+        let allowed = egress_deny_reason(
+            &m,
+            &http::Method::CONNECT,
+            &"avatars.githubusercontent.com:443".parse().unwrap(),
+            &http::HeaderMap::new(),
+        );
+        assert!(allowed.is_none());
     }
 }

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -18,6 +18,33 @@ fn ca_files_for(dir: Option<PathBuf>) -> anyhow::Result<sakimori_proxy::ca::CaFi
     })
 }
 
+/// Build the proxy's egress allow-list from `--network-allow` flags
+/// plus an optional file. Returns `None` (= "feature off") when no
+/// patterns came from either source — `Some(empty)` would also work
+/// but `None` lets the proxy skip the per-request check entirely.
+fn build_network_allow(
+    flags: &[String],
+    file: &Option<PathBuf>,
+) -> Result<Option<sakimori_proxy::host_allow::HostMatcher>> {
+    let mut all: Vec<String> = flags.to_vec();
+    if let Some(path) = file {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading --network-allow-file {}", path.display()))?;
+        for line in text.lines() {
+            let trimmed = line.split('#').next().unwrap_or("").trim();
+            if !trimmed.is_empty() {
+                all.push(trimmed.to_string());
+            }
+        }
+    }
+    if all.is_empty() {
+        return Ok(None);
+    }
+    let matcher = sakimori_proxy::host_allow::HostMatcher::from_patterns(all)
+        .map_err(|(pat, e)| anyhow::anyhow!("--network-allow `{pat}`: {e}"))?;
+    Ok(Some(matcher))
+}
+
 /// Parse a simple `<N><unit>` duration (e.g. `7d`, `12h`, `30m`, `3600s`).
 /// Bare numbers default to days. Used by proxy/watch-style CLI flags
 /// where pulling in humantime feels overkill.
@@ -415,6 +442,22 @@ pub struct ProxyStartArgs {
     /// Override the typosquat mirror URL.
     #[arg(long)]
     pub typosquat_mirror_url: Option<String>,
+    /// Hostname egress allow-list. Repeatable. When set, the proxy
+    /// default-denies every CONNECT / HTTP request whose target
+    /// host doesn't match an entry, returning 403. Patterns:
+    ///
+    /// - `host.example.com` — exact (case-insensitive)
+    /// - `*.example.com` — any subdomain (does NOT match the apex)
+    ///
+    /// Embedded `*` is a parse error. Off by default; without any
+    /// `--network-allow` flag the proxy passes every host through.
+    #[arg(long = "network-allow", value_name = "HOST")]
+    pub network_allow: Vec<String>,
+    /// Read additional `--network-allow` patterns from a file (one
+    /// per line; `#` comments and blank lines are skipped). Layered
+    /// on top of any `--network-allow` flags.
+    #[arg(long)]
+    pub network_allow_file: Option<PathBuf>,
     /// Override the CA/config directory. Defaults to
     /// `$XDG_CONFIG_HOME/sakimori` (or `~/.config/sakimori`).
     #[arg(long)]
@@ -647,6 +690,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => {
             let min_age = parse_simple_duration(&args.min_age)?;
             let ca_files = ca_files_for(args.config_dir)?;
+            let network_allow = build_network_allow(&args.network_allow, &args.network_allow_file)?;
             let cfg = sakimori_proxy::ProxyConfig {
                 listen: args.listen,
                 min_age,
@@ -661,6 +705,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 ca_files,
                 user_agent: format!("sakimori-proxy/{}", env!("CARGO_PKG_VERSION")),
                 oracle: None,
+                network_allow,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())


### PR DESCRIPTION
## Summary

Closes harden-runner parity gap #8. New `--network-allow <HOST>`
(repeatable) and `--network-allow-file <PATH>` flags on
`sakimori proxy start` configure a default-deny hostname allow-list
enforced at the proxy's `handle_request`, before MITM/tunnel
routing happens.

The check pulls the target host from:

- **CONNECT** — `req.uri().authority()` (`example.com:443`)
- **Plain HTTP** — `Host:` header
- **Missing Host with policy active** — treated as deny; no silent
  slip-through.

Pattern grammar in the new `host_allow` module:

| pattern | matches |
|---|---|
| `host.example.com` | exact, case-insensitive |
| `*.example.com` | any subdomain (does NOT match the apex by design; list both if you want both) |

Embedded `*` returns a parse error rather than silently matching
nothing. IPv6 literals (bracketed `[::1]:8080` and bare `::1`)
are both handled in `strip_port`.

## Why hostnames

The eBPF supervisor's `network.allow` enforces by **resolved IP**,
which loses against CDN rotation — `*.githubusercontent.com` is
served from a pool that rotates every few minutes, and an
already-resolved IP map drifts out of sync. Doing the check at the
proxy layer sees the SNI/Host name the client actually asked for,
so a single `*.githubusercontent.com` entry covers every live IP
automatically. Same convention `step-security/harden-runner` users
expect.

## Off-by-default

Without `--network-allow*` flags the proxy passes every host
through (current behaviour). When set, a startup log line names
the policy explicitly so the operator knows it's active:

```
sakimori-proxy: egress allow-list active: 3 pattern(s) — non-matching CONNECT/HTTP returns 403
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 17 new unit tests:
      - 12 in `host_allow::tests` (pattern parse, exact / wildcard /
        apex-exclusion / port stripping / IPv6 bracket form / case
        normalisation / embedded-`*` rejection)
      - 5 in `proxy::tests::egress_*` (CONNECT vs plain HTTP, missing
        Host = deny, wildcard subdomain, empty matcher = pass-through)
- [x] `sakimori proxy start --help` shows the new flags with
      grammar documented inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)