### PR TITLE
run: integrate workspace tamper detection via `--snapshot-workspace`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,10 +221,13 @@ of value-per-implementation-cost.
    `.gitignore`, since an attacker can write into it). Symlinks are
    recorded by target string, not followed. Files over 64 MiB
    default to size-only entries (configurable). Diff exits non-zero
-   on drift unless `--allow-drift`. Auto-integration into
-   `coronarium run` (snapshot before / diff after exec) is a
-   follow-up — kept standalone first so users can compose it with
-   any build, not just an eBPF-supervised one.
+   on drift unless `--allow-drift`. Also wired into `sakimori run`
+   via `--snapshot-workspace <DIR>` (v0.34): supervisor takes the
+   baseline before exec'ing the supervised command, takes a fresh
+   snapshot at exit, attaches the diff to the JSON log under
+   `workspace_drift`, surfaces it as a "Workspace drift" section in
+   the step summary, and (in `mode: block`) exits non-zero on any
+   drift the same way denied events do.
 10. **Floating-tag → SHA-pin static check** — ✅ implemented in v0.21
     as `coronarium actions audit <workflow.yml...>`. Walks every
     `uses:` in `jobs.<id>.steps[]` and `jobs.<id>.uses` (reusable

--- a/README.md
+++ b/README.md
@@ -579,9 +579,14 @@ Flags:
 | `--log` | — | `-` (stdout) | JSON audit log destination |
 | `--summary` | `GITHUB_STEP_SUMMARY` | — | markdown summary |
 | `--html` | — | — | self-contained HTML report (dark-mode aware, filterable) |
+| `--snapshot-workspace` | — | — | dir to hash before/after the run; drift goes into the JSON log + step summary, and (in block mode) makes the run fail |
+| `--snapshot-skip` | — | — | extra dir basenames to skip during the snapshot (repeatable) |
 
-Exit code: child's exit code, unless `mode=block` and at least one
-event was denied → exits `1`.
+Exit code: child's exit code, unless `mode=block` and **either**:
+- at least one event was denied, **or**
+- a `--snapshot-workspace` baseline was taken and the post-run diff is non-empty
+
+→ exits `1` either way.
 
 Policy format:
 

--- a/crates/sakimori-core/src/report.rs
+++ b/crates/sakimori-core/src/report.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::Result;
 
-use crate::{events::Event, html, policy::Policy, stats::Stats};
+use crate::{events::Event, html, policy::Policy, stats::Stats, tamper::Diff};
 
 /// How many rows we surface per breakdown table in the step summary.
 /// Picked to fit comfortably in a GitHub run page without scrolling
@@ -35,16 +35,30 @@ pub struct ReportArgs<'a> {
     pub mode: crate::policy::Mode,
     /// Policy passed through to the HTML "Effective policy" section.
     pub policy: &'a Policy,
+    /// Optional workspace tamper-detection diff. When `Some` and
+    /// non-empty, surfaces in the JSON log under `workspace_drift`
+    /// and in the step summary as a "Workspace drift" section. The
+    /// supervisor sets this only when the user passed
+    /// `--snapshot-workspace`.
+    pub workspace_drift: Option<&'a Diff>,
 }
 
 pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
     // --- JSON ---
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "observed": stats.observed,
         "denied": stats.denied,
         "lost": stats.lost,
         "samples": stats.samples,
     });
+    // Only emit `workspace_drift` when the user actually opted into
+    // a snapshot AND something changed — empty diffs would just
+    // bloat every audit log with noise.
+    if let Some(drift) = args.workspace_drift
+        && !drift.is_clean()
+    {
+        payload["workspace_drift"] = serde_json::to_value(drift)?;
+    }
     let serialized = serde_json::to_string_pretty(&payload)?;
 
     if args.log == "-" {
@@ -69,7 +83,7 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
     // --- $GITHUB_STEP_SUMMARY markdown ---
     if let Some(path) = args.summary {
         let mut f = OpenOptions::new().create(true).append(true).open(path)?;
-        let body = render_step_summary(args.command, stats);
+        let body = render_step_summary(args.command, stats, args.workspace_drift);
         writeln!(f, "{body}")?;
     }
 
@@ -96,7 +110,7 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
 /// caps live in `stats::PER_KIND_CAP` — the tables can undercount
 /// if a single kind floods, but `stats.observed` / `stats.denied`
 /// totals are exact and shown above.
-pub fn render_step_summary(command: &str, stats: &Stats) -> String {
+pub fn render_step_summary(command: &str, stats: &Stats, drift: Option<&Diff>) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "## sakimori\n");
     let _ = writeln!(out, "Command: `{}`\n", escape_pipe(command));
@@ -105,6 +119,9 @@ pub fn render_step_summary(command: &str, stats: &Stats) -> String {
     let _ = writeln!(out, "| observed | **{}** |", stats.observed);
     let _ = writeln!(out, "| denied   | **{}** |", stats.denied);
     let _ = writeln!(out, "| lost     | {} |", stats.lost);
+    if let Some(d) = drift {
+        let _ = writeln!(out, "| drift    | **{}** |", d.total());
+    }
     if stats.lost > 0 {
         let _ = writeln!(
             out,
@@ -139,7 +156,86 @@ pub fn render_step_summary(command: &str, stats: &Stats) -> String {
         "source",
         source_breakdown(&stats.samples),
     );
+    if let Some(d) = drift {
+        push_drift_section(&mut out, d);
+    }
     out
+}
+
+/// How many drift rows to surface per category (added / modified /
+/// removed) before the table gets a "… N more" footnote.
+const DRIFT_TOP_N: usize = 25;
+
+fn push_drift_section(out: &mut String, drift: &Diff) {
+    if drift.is_clean() {
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "\n### Workspace drift — files changed by the supervised step\n",
+    );
+    let _ = writeln!(out, "| | | path | note |\n|:-:|---|---|---|",);
+    for p in drift.added.iter().take(DRIFT_TOP_N) {
+        let _ = writeln!(
+            out,
+            "| ➕ | added    | `{}` |  |",
+            escape_pipe(&p.display().to_string())
+        );
+    }
+    for m in drift.modified.iter().take(DRIFT_TOP_N) {
+        let _ = writeln!(
+            out,
+            "| 🔧 | modified | `{}` | {} |",
+            escape_pipe(&m.path.display().to_string()),
+            modification_note(m),
+        );
+    }
+    for p in drift.removed.iter().take(DRIFT_TOP_N) {
+        let _ = writeln!(
+            out,
+            "| ➖ | removed  | `{}` |  |",
+            escape_pipe(&p.display().to_string())
+        );
+    }
+    let total = drift.total();
+    let shown = drift.added.len().min(DRIFT_TOP_N)
+        + drift.modified.len().min(DRIFT_TOP_N)
+        + drift.removed.len().min(DRIFT_TOP_N);
+    if total > shown {
+        let _ = writeln!(
+            out,
+            "\n_… {} more rows omitted; full diff is in `workspace_drift` of the JSON log._",
+            total - shown,
+        );
+    }
+}
+
+fn modification_note(m: &crate::tamper::ModifiedEntry) -> String {
+    use crate::tamper::Entry;
+    match (&m.before, &m.after) {
+        (
+            Entry::File {
+                size: a,
+                sha256: ha,
+            },
+            Entry::File {
+                size: b,
+                sha256: hb,
+            },
+        ) => {
+            if a != b {
+                format!("{} → {} bytes", a, b)
+            } else if ha != hb {
+                "contents changed".to_string()
+            } else {
+                "metadata changed".to_string()
+            }
+        }
+        (Entry::Symlink { target: a }, Entry::Symlink { target: b }) => {
+            format!("link target {} → {}", a, b)
+        }
+        _ => "type changed".to_string(),
+    }
 }
 
 /// One row in a breakdown table: label, total occurrences, and how
@@ -344,7 +440,7 @@ mod tests {
         stats.ingest(ev_open("/etc/hosts", false));
         stats.ingest(ev_exec("/bin/sh", false));
 
-        let s = render_step_summary("npm install", &stats);
+        let s = render_step_summary("npm install", &stats, None);
         // Header + command line.
         assert!(s.contains("## sakimori"));
         assert!(s.contains("`npm install`"));
@@ -370,7 +466,7 @@ mod tests {
         }
         stats.ingest(ev_connect(Some("evil.example"), "9.9.9.9", 443, true));
 
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         let evil_pos = s.find("evil.example").expect("evil row present");
         let good_pos = s.find("good.example").expect("good row present");
         assert!(
@@ -387,7 +483,7 @@ mod tests {
         // headers in the summary).
         let mut stats = Stats::default();
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         assert!(s.contains("### Files"));
         assert!(!s.contains("### Network"));
         assert!(!s.contains("### Processes"));
@@ -396,7 +492,7 @@ mod tests {
     #[test]
     fn pipe_in_command_is_escaped_so_table_doesnt_break() {
         let stats = Stats::default();
-        let s = render_step_summary("bash -c 'foo | bar'", &stats);
+        let s = render_step_summary("bash -c 'foo | bar'", &stats, None);
         assert!(s.contains(r"bash -c 'foo \| bar'"));
     }
 
@@ -406,7 +502,7 @@ mod tests {
         for i in 0..(SUMMARY_TOP_N + 5) {
             stats.ingest(ev_open(&format!("/tmp/file-{i}"), false));
         }
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         assert!(s.contains("more rows omitted"));
     }
 
@@ -417,7 +513,7 @@ mod tests {
             ..Stats::default()
         };
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         assert!(s.contains("⚠️"));
         assert!(s.contains("7 events were dropped"));
     }
@@ -429,7 +525,7 @@ mod tests {
         // No source attribution anywhere → table suppressed.
         let mut stats = Stats::default();
         stats.ingest(ev_connect(Some("a.example"), "1.1.1.1", 443, false));
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         assert!(
             !s.contains("### Sources"),
             "with zero attribution the section must be hidden, got:\n{s}"
@@ -463,10 +559,90 @@ mod tests {
         stats.ingest(e2);
         stats.ingest(e3);
 
-        let s = render_step_summary("cmd", &stats);
+        let s = render_step_summary("cmd", &stats, None);
         assert!(s.contains("### Sources"), "section header missing");
         assert!(s.contains("`npm`"));
         assert!(s.contains("`pip`"));
         assert!(s.contains("(unattributed)"));
+    }
+
+    #[test]
+    fn drift_section_renders_added_modified_removed() {
+        use crate::tamper::{Diff, Entry, ModifiedEntry};
+        use std::path::PathBuf;
+
+        let drift = Diff {
+            added: vec![PathBuf::from("src/new.rs")],
+            modified: vec![ModifiedEntry {
+                path: PathBuf::from("src/lib.rs"),
+                before: Entry::File {
+                    size: 100,
+                    sha256: Some("a".repeat(64)),
+                },
+                after: Entry::File {
+                    size: 100,
+                    sha256: Some("b".repeat(64)),
+                },
+            }],
+            removed: vec![PathBuf::from("src/old.rs")],
+        };
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, Some(&drift));
+
+        assert!(s.contains("| drift    | **3** |"), "drift count missing");
+        assert!(s.contains("### Workspace drift"), "drift section missing");
+        assert!(s.contains("`src/new.rs`"));
+        assert!(s.contains("`src/lib.rs`"));
+        assert!(s.contains("`src/old.rs`"));
+        // Modification note for same-size, different-hash file.
+        assert!(s.contains("contents changed"), "expected note: {s}");
+    }
+
+    #[test]
+    fn drift_section_suppressed_when_clean() {
+        use crate::tamper::Diff;
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, Some(&Diff::default()));
+        assert!(!s.contains("### Workspace drift"));
+        // Clean diff still gets a "drift | 0" row so the user knows
+        // the snapshot ran.
+        assert!(s.contains("| drift    | **0** |"));
+    }
+
+    #[test]
+    fn drift_section_truncates_with_remainder_note() {
+        use crate::tamper::Diff;
+        use std::path::PathBuf;
+
+        let drift = Diff {
+            added: (0..(DRIFT_TOP_N + 5))
+                .map(|i| PathBuf::from(format!("a-{i}")))
+                .collect(),
+            modified: vec![],
+            removed: vec![],
+        };
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, Some(&drift));
+        assert!(s.contains("more rows omitted"), "{s}");
+    }
+
+    #[test]
+    fn modification_note_size_change_overrides_hash_check() {
+        use crate::tamper::{Entry, ModifiedEntry};
+        use std::path::PathBuf;
+
+        let m = ModifiedEntry {
+            path: PathBuf::from("p"),
+            before: Entry::File {
+                size: 100,
+                sha256: Some("a".into()),
+            },
+            after: Entry::File {
+                size: 200,
+                sha256: Some("b".into()),
+            },
+        };
+        let note = modification_note(&m);
+        assert!(note.contains("100 → 200"), "{note}");
     }
 }

--- a/crates/sakimori-win/src/win.rs
+++ b/crates/sakimori-win/src/win.rs
@@ -262,6 +262,10 @@ pub fn run() -> Result<()> {
         command: command_str.as_str(),
         mode,
         policy: &policy,
+        // Workspace tamper detection isn't wired into the Windows
+        // ETW supervisor yet — Linux supervisor opted in via
+        // `--snapshot-workspace`. Adding it here is a follow-up.
+        workspace_drift: None,
     };
     sakimori_core::report::write(&report_args, &final_stats)?;
 

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -599,6 +599,24 @@ pub struct RunArgs {
     #[arg(long, default_value_t = 15, value_name = "SECS")]
     pub dns_refresh_interval: u64,
 
+    /// Snapshot the contents of this directory before exec'ing the
+    /// supervised command, take a fresh snapshot afterwards, and
+    /// surface any files added / modified / removed by the build
+    /// in the JSON log (under `workspace_drift`) and the step
+    /// summary. Off by default — same skip list as
+    /// `sakimori workspace snapshot` (`.git`, `node_modules`,
+    /// `target`, …). In `mode: block`, any drift causes a non-zero
+    /// exit (the same way denied events do); in `mode: audit` the
+    /// drift is reported but doesn't change exit code.
+    #[arg(long, value_name = "DIR")]
+    pub snapshot_workspace: Option<PathBuf>,
+
+    /// Extra directory basenames to skip during the workspace
+    /// snapshot, on top of the built-in build-artefact list.
+    /// Repeatable. Only meaningful with `--snapshot-workspace`.
+    #[arg(long = "snapshot-skip", value_name = "NAME")]
+    pub snapshot_skip: Vec<String>,
+
     /// Command + args to execute under supervision.
     #[arg(trailing_var_arg = true, required = true)]
     pub command: Vec<String>,
@@ -1046,6 +1064,29 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         args.command
     );
 
+    // Workspace tamper baseline. Taken BEFORE the eBPF supervisor
+    // starts so we don't accidentally hash any files the supervisor
+    // itself writes (cgroup state etc.). Off-path failure is a hard
+    // error — if the user explicitly asked for tamper detection, a
+    // missing snapshot would silently make every later diff "clean".
+    let baseline = match &args.snapshot_workspace {
+        Some(dir) => {
+            let opts = sakimori_core::tamper::Options {
+                skip_extra: args.snapshot_skip.clone(),
+                ..Default::default()
+            };
+            let snap = sakimori_core::tamper::Snapshot::take(dir, &opts)
+                .with_context(|| format!("snapshotting workspace {} before run", dir.display()))?;
+            log::info!(
+                "workspace baseline: {} files under {}",
+                snap.files.len(),
+                dir.display()
+            );
+            Some(snap)
+        }
+        None => None,
+    };
+
     let supervised = loader::Supervisor::start(
         policy.clone(),
         mode,
@@ -1054,6 +1095,28 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
     .await?;
     let exit = supervised.run_child(&args.command).await?;
     let mut stats = supervised.shutdown().await?;
+
+    // After-snapshot + diff. Errors here are non-fatal: the audit
+    // log + summary still go out, just without `workspace_drift`.
+    let drift = if let Some(baseline) = baseline.as_ref() {
+        let dir = args
+            .snapshot_workspace
+            .as_ref()
+            .expect("baseline implies dir");
+        let opts = sakimori_core::tamper::Options {
+            skip_extra: args.snapshot_skip.clone(),
+            ..Default::default()
+        };
+        match sakimori_core::tamper::Snapshot::take(dir, &opts) {
+            Ok(after) => Some(sakimori_core::tamper::diff(baseline, &after)),
+            Err(e) => {
+                log::warn!("post-run workspace snapshot failed: {e:#} — skipping drift section");
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     // Best-effort PTR enrichment so the HTML report shows hostnames
     // next to raw IPs. Failures are silent — the report is still
@@ -1069,8 +1132,11 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         command: command_str.as_str(),
         mode,
         policy: &policy,
+        workspace_drift: drift.as_ref().filter(|d| !d.is_clean()),
     };
     sakimori_core::report::write(&report_args, &stats)?;
+
+    let drift_violation = drift.as_ref().map(|d| !d.is_clean()).unwrap_or(false);
 
     if stats.denied > 0 && matches!(mode, policy::Mode::Block) {
         // GitHub Actions error annotation — renders as a red banner on the
@@ -1078,6 +1144,13 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         eprintln!(
             "::error title=sakimori::policy violation: {} events denied in block mode",
             stats.denied
+        );
+        std::process::exit(1);
+    }
+    if drift_violation && matches!(mode, policy::Mode::Block) {
+        let n = drift.as_ref().map(|d| d.total()).unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::workspace tamper detected: {n} files added/modified/removed during the supervised step"
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

Closes the deferred follow-up from #48 (workspace tamper detection).

Standalone `sakimori workspace snapshot|diff` was always usable, but
you had to wrap your CI step manually:

```bash
sakimori workspace snapshot \$WORKSPACE -o /tmp/before.json
sakimori run -p policy.yml -- cargo test
sakimori workspace diff /tmp/before.json \$WORKSPACE
```

That's now a single `sakimori run --snapshot-workspace \$WORKSPACE`:

- **baseline snapshot** taken before the eBPF supervisor starts (so
  we don't accidentally hash files the supervisor itself writes);
  baseline failure is **fatal** — silent drift would defeat the
  whole point.
- **post-run snapshot** taken after the supervised command exits;
  failure here is a warn (the audit log still goes out).
- **diff attached** to `ReportArgs.workspace_drift`, surfaced as:
  - `workspace_drift: { added, modified, removed }` block in the
    JSON log (only when non-empty — clean runs don't bloat the log)
  - a "Workspace drift" section in the step summary with per-file
    rows (truncated at 25 per category with a remainder note)
  - a `| drift | N |` row in the totals table
- **in `mode: block`**, any drift makes the run exit non-zero with
  a GitHub Actions error annotation, the same way denied events do.
- `--snapshot-skip <NAME>` extends the built-in skip list (`.git`,
  `node_modules`, `target`, …) for repo-specific build artefacts.

## Off-by-default

Without `--snapshot-workspace`, the supervisor behaves exactly as
before — no snapshot taken, no `workspace_drift` field in the log.

Windows ETW supervisor leaves `workspace_drift: None` for now; the
schema accommodates it without a bump when added later.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 4 new tests in `report::tests` for
      drift section rendering (added/modified/removed,
      modification-note variants for size-vs-hash changes, clean =
      no section, top-N truncation). 133 in sakimori-core, all green.
- [x] `sakimori run --help` shows the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)