### PR TITLE
action: add `run:` input to wrap the supervised command in one step

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,45 @@ of silently falling back.
 - run: cargo test   # only reached if the check passed
 ```
 
-### eBPF-supervised test run (Linux + Windows)
+### eBPF-supervised test run — one-step form (Linux + Windows)
+
+The simplest form: pass the command you want supervised via the
+`run:` input. The action installs sakimori AND wraps the command
+with `sakimori run` for you — no separate `sudo -E env "PATH=$PATH"
+"$SAKIMORI_BIN" run …` step required.
+
+```yaml
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest]
+runs-on: ${{ matrix.os }}
+steps:
+  - uses: actions/checkout@v4
+  - uses: bokuweb/sakimori@v0
+    with:
+      policy: .github/sakimori.yml
+      mode: audit
+      html: sakimori-report.html
+      run: |
+        corepack enable
+        cargo test
+        pnpm install --frozen-lockfile
+        pnpm test
+```
+
+On Linux the script runs under
+`sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run … -- bash -euxo pipefail -c '<run>'`;
+on Windows under `& $env:SAKIMORI_BIN … -- pwsh -NoProfile -Command "<run>"`.
+`--summary` defaults to `$GITHUB_STEP_SUMMARY` and `--log` defaults
+to the `log:` input (`sakimori.log.json`). Add `snapshot-workspace:
+<dir>` to also catch on-disk tampering.
+
+### eBPF-supervised test run — explicit form (Linux + Windows)
+
+If you need more control over the wrapper invocation, omit `run:`
+and write the `sakimori run` step yourself. The action exports
+`$SAKIMORI_BIN`, `$SAKIMORI_POLICY`, `$SAKIMORI_MODE`, and
+`$SAKIMORI_LOG` for you.
 
 ```yaml
 strategy:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,29 @@ inputs:
     description: "Where the subsequent `sakimori run` step should write its JSON audit log."
     required: false
     default: "sakimori.log.json"
+  run:
+    description: |
+      Optional shell script to supervise. If set, the action installs sakimori
+      AND runs the script under `sakimori run` automatically — no separate
+      step needed. On Linux the script is executed with
+      `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run … -- bash -euxo pipefail -c '<run>'`;
+      on Windows with `& $env:SAKIMORI_BIN run … -- pwsh -NoProfile -Command "<run>"`.
+      Leave empty (default) to keep the install-only behaviour and write the
+      `sakimori run` invocation yourself in a later step.
+    required: false
+    default: ""
+  html:
+    description: "Path to write the HTML report to (passed as `--html`). Only used when `run` is set."
+    required: false
+    default: "sakimori-report.html"
+  summary:
+    description: "Path the supervised run should append its step-summary markdown to (passed as `--summary`). Defaults to $GITHUB_STEP_SUMMARY. Only used when `run` is set."
+    required: false
+    default: ""
+  snapshot-workspace:
+    description: "If set, passed as `--snapshot-workspace <path>` to take a workspace tamper-detection baseline before and after the supervised command. Only used when `run` is set."
+    required: false
+    default: ""
 
 outputs:
   bin:
@@ -149,11 +172,88 @@ runs:
           echo "::notice::policy file '${SAKIMORI_POLICY}' not found — the next 'sakimori run' step should point --policy somewhere real."
         fi
         echo ""
-        echo "Sakimori (Linux) installed. Wrap the command you want to supervise like:"
-        echo "    - run: sudo -E \$SAKIMORI_BIN run --policy <path> --mode \$SAKIMORI_MODE --log \$SAKIMORI_LOG --summary \$GITHUB_STEP_SUMMARY -- <your command>"
+        if [[ -z "${INPUT_RUN}" ]]; then
+          echo "Sakimori (Linux) installed. Wrap the command you want to supervise like:"
+          echo "    - run: sudo -E \$SAKIMORI_BIN run --policy <path> --mode \$SAKIMORI_MODE --log \$SAKIMORI_LOG --summary \$GITHUB_STEP_SUMMARY -- <your command>"
+          echo ""
+          echo "Or, to let this action wrap the command for you, pass it via the 'run:' input."
+        fi
+      env:
+        INPUT_RUN: ${{ inputs.run }}
 
     - shell: pwsh
       if: runner.os == 'Windows'
+      env:
+        INPUT_RUN: ${{ inputs.run }}
       run: |
-        Write-Host "Sakimori (Windows) installed. Wrap the command you want to supervise like:"
-        Write-Host "    - run: & `"$env:SAKIMORI_BIN`" --policy <path> --mode $env:SAKIMORI_MODE --log $env:SAKIMORI_LOG --summary $env:GITHUB_STEP_SUMMARY -- <your command>"
+        if ([string]::IsNullOrEmpty($env:INPUT_RUN)) {
+          Write-Host "Sakimori (Windows) installed. Wrap the command you want to supervise like:"
+          Write-Host "    - run: & `"$env:SAKIMORI_BIN`" --policy <path> --mode $env:SAKIMORI_MODE --log $env:SAKIMORI_LOG --summary $env:GITHUB_STEP_SUMMARY -- <your command>"
+          Write-Host ""
+          Write-Host "Or, to let this action wrap the command for you, pass it via the 'run:' input."
+        }
+
+    # --------------- Optional supervised-run (Linux) ---------------
+    # Only fires when the caller set `with: run: |\n  …`. Mirrors the
+    # canonical `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run …` snippet
+    # from the README so callers don't have to copy it by hand.
+    - name: sakimori run (Linux)
+      if: runner.os == 'Linux' && inputs.run != ''
+      shell: bash
+      env:
+        INPUT_RUN: ${{ inputs.run }}
+        INPUT_HTML: ${{ inputs.html }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
+        INPUT_SNAPSHOT_WORKSPACE: ${{ inputs.snapshot-workspace }}
+      run: |
+        set -euo pipefail
+        args=(
+          run
+          --policy "${SAKIMORI_POLICY}"
+          --mode   "${SAKIMORI_MODE}"
+          --log    "${SAKIMORI_LOG}"
+        )
+        if [[ -n "${INPUT_HTML}" ]]; then
+          args+=(--html "${INPUT_HTML}")
+        fi
+        summary_path="${INPUT_SUMMARY:-${GITHUB_STEP_SUMMARY:-}}"
+        if [[ -n "${summary_path}" ]]; then
+          args+=(--summary "${summary_path}")
+        fi
+        if [[ -n "${INPUT_SNAPSHOT_WORKSPACE}" ]]; then
+          args+=(--snapshot-workspace "${INPUT_SNAPSHOT_WORKSPACE}")
+        fi
+        # `sudo -E` preserves env *except* PATH (sudo always resets it
+        # to secure_path). Re-inject the runner user's PATH so the
+        # supervised child can find pnpm / cargo / rustup-installed
+        # toolchains.
+        sudo -E env "PATH=$PATH" "${SAKIMORI_BIN}" "${args[@]}" \
+          -- bash -euxo pipefail -c "${INPUT_RUN}"
+
+    # --------------- Optional supervised-run (Windows) ---------------
+    - name: sakimori run (Windows)
+      if: runner.os == 'Windows' && inputs.run != ''
+      shell: pwsh
+      env:
+        INPUT_RUN: ${{ inputs.run }}
+        INPUT_HTML: ${{ inputs.html }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
+        INPUT_SNAPSHOT_WORKSPACE: ${{ inputs.snapshot-workspace }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        $cliArgs = @(
+          "--policy", $env:SAKIMORI_POLICY,
+          "--log",    $env:SAKIMORI_LOG
+        )
+        if (-not [string]::IsNullOrEmpty($env:INPUT_HTML)) {
+          $cliArgs += @("--html", $env:INPUT_HTML)
+        }
+        $summaryPath = if ([string]::IsNullOrEmpty($env:INPUT_SUMMARY)) { $env:GITHUB_STEP_SUMMARY } else { $env:INPUT_SUMMARY }
+        if (-not [string]::IsNullOrEmpty($summaryPath)) {
+          $cliArgs += @("--summary", $summaryPath)
+        }
+        if (-not [string]::IsNullOrEmpty($env:INPUT_SNAPSHOT_WORKSPACE)) {
+          $cliArgs += @("--snapshot-workspace", $env:INPUT_SNAPSHOT_WORKSPACE)
+        }
+        & $env:SAKIMORI_BIN @cliArgs -- pwsh -NoProfile -Command $env:INPUT_RUN
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Summary
- Add an optional `run:` input to the composite action. When set, the action installs sakimori **and** executes the script under `sakimori run` — callers no longer need a separate step that hand-rolls `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run … --`.
- Add `html`, `summary`, and `snapshot-workspace` inputs for the most common flags. `summary` defaults to `$GITHUB_STEP_SUMMARY`; `log` reuses the existing input.
- Behaviour is unchanged when `run:` is empty — the action stays install-only and prints the usual reminder line.

Before:
```yaml
- uses: bokuweb/sakimori@v0
  with:
    policy: .github/sakimori.yml
    mode: block
- run: |
    sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run \
      --policy  "$SAKIMORI_POLICY" \
      --mode    "$SAKIMORI_MODE" \
      --log     "$SAKIMORI_LOG" \
      --html    sakimori-report.html \
      --summary "$GITHUB_STEP_SUMMARY" \
      -- bash -euxo pipefail -c '
        corepack enable
        cargo test
        pnpm install --frozen-lockfile
        pnpm test
      '
```

After:
```yaml
- uses: bokuweb/sakimori@v0
  with:
    policy: .github/sakimori.yml
    mode: block
    html: sakimori-report.html
    run: |
      corepack enable
      cargo test
      pnpm install --frozen-lockfile
      pnpm test
```

On Linux the script runs under `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run … -- bash -euxo pipefail -c '<run>'`; on Windows under `& $env:SAKIMORI_BIN … -- pwsh -NoProfile -Command "<run>"`.

## Test plan
- [ ] CI green on this PR (composite action is exercised by `consumer-smoke.yml` after publish — manual smoke before merge: dispatch a workflow that uses `with: run: |` against the branch).
- [ ] `consumer-smoke` continues to pass with the existing explicit form (no `run:` input set).
- [ ] README examples render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)