### PR TITLE
daemon: workspace tamper integration + doctor pid-file check

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,30 @@ artifact` *inside the same job* can't see it — upload it from a
 downstream job, or use the `bokuweb/sakimori@v0` one-step form below
 if you need the artifact mid-job.
 
+**Tamper detection**: pass `snapshot-workspace: <DIR>` to also catch
+on-disk tampering. The daemon can't take the baseline itself (it
+starts before checkout), so add a tiny step right after checkout that
+records the baseline — the action exports the paths for you:
+
+```yaml
+- uses: bokuweb/sakimori/job@v0
+  with:
+    policy: .github/sakimori.yml
+    mode: block
+    snapshot-workspace: .
+
+- uses: actions/checkout@v4
+- run: sudo -E "$SAKIMORI_BIN" workspace snapshot
+       "$SAKIMORI_WORKSPACE_DIR" -o "$SAKIMORI_BASELINE_PATH"
+- run: pnpm install --frozen-lockfile
+- run: pnpm build
+```
+
+The daemon re-snapshots `$SAKIMORI_WORKSPACE_DIR` at post-time, diffs
+against the baseline, and surfaces drift in the JSON log + step
+summary. Forgetting the snapshot step is non-fatal (the daemon logs a
+warning and the drift section is omitted).
+
 ### eBPF-supervised test run — one-step form (Linux + Windows)
 
 The simplest form: pass the command you want supervised via the

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -214,6 +214,33 @@ pub struct DaemonStartArgs {
     /// doing (e.g. "ci: build + test").
     #[arg(long, default_value = "sakimori daemon (job-scoped)")]
     pub command_label: String,
+
+    /// Path to a workspace snapshot file (produced by
+    /// `sakimori workspace snapshot <dir>`). When set, the daemon
+    /// re-snapshots `--workspace-dir` at shutdown and surfaces the
+    /// diff under `workspace_drift` in the report. Must be set
+    /// together with `--workspace-dir`.
+    ///
+    /// Unlike `sakimori run --snapshot-workspace`, the daemon does
+    /// NOT take the baseline itself — daemon mode starts before
+    /// checkout (so the workspace would be empty at start time).
+    /// Take the baseline yourself after checkout, in a separate
+    /// step.
+    #[arg(long, value_name = "FILE")]
+    pub workspace_baseline: Option<PathBuf>,
+
+    /// Directory to re-snapshot + diff against `--workspace-baseline`
+    /// at shutdown. Must match the directory the baseline was taken
+    /// from.
+    #[arg(long, value_name = "DIR")]
+    pub workspace_dir: Option<PathBuf>,
+
+    /// Extra directory basenames to skip during the post-shutdown
+    /// snapshot — must match what was passed to
+    /// `sakimori workspace snapshot` when the baseline was taken,
+    /// otherwise added/removed entries will fire spuriously.
+    #[arg(long = "workspace-skip", value_name = "NAME")]
+    pub workspace_skip: Vec<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -455,6 +482,11 @@ pub struct DoctorArgs {
     /// would target for the detected shell.
     #[arg(long)]
     pub rc: Option<PathBuf>,
+    /// Path to a `sakimori daemon start --pid-file` file. When given,
+    /// doctor reads the pid and reports whether the daemon process is
+    /// alive. Skipped when omitted.
+    #[arg(long, value_name = "FILE")]
+    pub daemon_pidfile: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -917,6 +949,9 @@ async fn run_daemon_start(args: DaemonStartArgs) -> Result<()> {
         allow_root_cgroup: args.allow_root_cgroup,
         dns_refresh: Duration::from_secs(args.dns_refresh_interval),
         command_label: args.command_label,
+        workspace_baseline: args.workspace_baseline,
+        workspace_dir: args.workspace_dir,
+        workspace_skip: args.workspace_skip,
     })
     .await
 }
@@ -1419,6 +1454,7 @@ fn run_doctor(args: DoctorArgs) -> Result<()> {
         expected_https_proxy,
         rc_path,
         daemon_unit_path,
+        daemon_pidfile: args.daemon_pidfile,
     };
     let results = crate::doctor::run_checks(&inputs);
     print!("{}", crate::doctor::render_report(&results));

--- a/crates/sakimori/src/daemon.rs
+++ b/crates/sakimori/src/daemon.rs
@@ -50,6 +50,29 @@ pub struct DaemonStartArgs {
     /// Daemon mode doesn't exec anything itself; this is a free-form
     /// description of what the surrounding job is doing.
     pub command_label: String,
+    /// Path to a pre-taken workspace snapshot (as produced by
+    /// `sakimori workspace snapshot`). When set, the daemon takes a
+    /// fresh snapshot of [`workspace_dir`](Self::workspace_dir) at
+    /// shutdown and surfaces the diff in the report under
+    /// `workspace_drift`. Required to be set alongside
+    /// `workspace_dir`; either both or neither.
+    ///
+    /// Unlike `sakimori run --snapshot-workspace`, the baseline is
+    /// *not* taken by the daemon — the daemon's whole point is to
+    /// start observing before checkout happens, so the workspace
+    /// is empty at start time. Callers (typically the JS action
+    /// wrapper or a CI step) take the baseline themselves after
+    /// checkout and hand the file path here.
+    pub workspace_baseline: Option<PathBuf>,
+    /// Directory the daemon re-snapshots at shutdown to compute the
+    /// drift diff. Must match whatever directory produced
+    /// `workspace_baseline`.
+    pub workspace_dir: Option<PathBuf>,
+    /// Extra directory basenames to skip during the workspace
+    /// snapshot, on top of the built-in build-artefact list. Must
+    /// match what was passed to `sakimori workspace snapshot`
+    /// when the baseline was taken.
+    pub workspace_skip: Vec<String>,
 }
 
 /// Parameters for `sakimori daemon stop`.
@@ -76,6 +99,23 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
     // output paths would collide and we'd have no clean way to stop
     // them individually. Loud-fail.
     check_pidfile_unused(&args.pid_file)?;
+
+    // Validate workspace-tamper args eagerly: either both or neither.
+    // Note we *don't* require the baseline file to exist yet — the
+    // expected wrapper flow is "daemon start before checkout, take
+    // baseline after checkout, diff at shutdown". So the baseline
+    // file is allowed to be absent here; it's read at shutdown, and
+    // `compute_workspace_drift` fails soft (warn + drop drift section)
+    // if it still isn't there. That keeps audit logs flowing even
+    // when the user forgets the snapshot step.
+    if args.workspace_baseline.is_some() != args.workspace_dir.is_some() {
+        anyhow::bail!(
+            "--workspace-baseline and --workspace-dir must be set together \
+             (either both or neither). The baseline is read at shutdown from \
+             --workspace-baseline and diffed against a fresh snapshot of \
+             --workspace-dir."
+        );
+    }
 
     let cgroup = Cgroup::observe_existing(args.observe_cgroup_of, args.allow_root_cgroup)
         .context("attaching to existing cgroup")?;
@@ -104,6 +144,15 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
     let mut stats = supervisor.shutdown().await?;
     crate::resolve_hostnames::resolve(&mut stats).await;
 
+    // Workspace tamper diff. Non-fatal: log + summary still go out
+    // without `workspace_drift` if the snapshot or read fails — same
+    // policy as `sakimori run`.
+    let drift = compute_workspace_drift(
+        args.workspace_baseline.as_deref(),
+        args.workspace_dir.as_deref(),
+        &args.workspace_skip,
+    );
+
     let report = ReportArgs {
         log: &args.log,
         summary: args.summary.as_deref(),
@@ -111,9 +160,11 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         command: args.command_label.as_str(),
         mode,
         policy: &policy,
-        workspace_drift: None,
+        workspace_drift: drift.as_ref().filter(|d| !d.is_clean()),
     };
     sakimori_core::report::write(&report, &stats)?;
+
+    let drift_violation = drift.as_ref().map(|d| !d.is_clean()).unwrap_or(false);
 
     // Block-mode parity with `sakimori run`: any denied event flips the
     // exit code so the surrounding job fails.
@@ -124,7 +175,63 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         );
         std::process::exit(1);
     }
+    if drift_violation && matches!(mode, Mode::Block) {
+        let n = drift.as_ref().map(|d| d.total()).unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::workspace tamper detected: {n} files added/modified/removed during the supervised job"
+        );
+        std::process::exit(1);
+    }
     Ok(())
+}
+
+/// Take a fresh snapshot of `dir`, diff against the baseline file. Returns
+/// `None` (and logs) on any error so a bad-config / bad-fs situation doesn't
+/// silently drop the entire audit log.
+fn compute_workspace_drift(
+    baseline_path: Option<&Path>,
+    workspace_dir: Option<&Path>,
+    skip_extra: &[String],
+) -> Option<sakimori_core::tamper::Diff> {
+    let (baseline_path, workspace_dir) = match (baseline_path, workspace_dir) {
+        (Some(b), Some(d)) => (b, d),
+        _ => return None,
+    };
+    let baseline_json = match std::fs::read_to_string(baseline_path) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!(
+                "workspace tamper: reading baseline {} failed: {e}",
+                baseline_path.display()
+            );
+            return None;
+        }
+    };
+    let baseline = match sakimori_core::tamper::Snapshot::from_json(&baseline_json) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!(
+                "workspace tamper: parsing baseline {} failed: {e}",
+                baseline_path.display()
+            );
+            return None;
+        }
+    };
+    let opts = sakimori_core::tamper::Options {
+        skip_extra: skip_extra.to_vec(),
+        ..Default::default()
+    };
+    let current = match sakimori_core::tamper::Snapshot::take(workspace_dir, &opts) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!(
+                "workspace tamper: snapshotting {} failed: {e}",
+                workspace_dir.display()
+            );
+            return None;
+        }
+    };
+    Some(sakimori_core::tamper::diff(&baseline, &current))
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -371,5 +478,53 @@ mod tests {
         let p = base.join(unique);
         std::fs::create_dir_all(&p).unwrap();
         p
+    }
+
+    #[test]
+    fn workspace_drift_returns_none_when_args_unset() {
+        // Both unset: feature is off, return None (no warning).
+        let r = compute_workspace_drift(None, None, &[]);
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn workspace_drift_returns_none_when_baseline_missing() {
+        let tmp = tempdir();
+        let missing = tmp.join("nope.json");
+        let r = compute_workspace_drift(Some(&missing), Some(&tmp), &[]);
+        assert!(r.is_none(), "missing baseline must fail soft, not panic");
+    }
+
+    #[test]
+    fn workspace_drift_returns_none_when_baseline_malformed() {
+        let tmp = tempdir();
+        let bogus = tmp.join("bogus.json");
+        std::fs::write(&bogus, "not json").unwrap();
+        let r = compute_workspace_drift(Some(&bogus), Some(&tmp), &[]);
+        assert!(r.is_none(), "unparseable baseline must fail soft");
+    }
+
+    #[test]
+    fn workspace_drift_detects_added_file_against_real_baseline() {
+        // End-to-end: take a real snapshot via the public API, write
+        // a new file, compute drift, assert the new file shows up.
+        let tmp = tempdir();
+        std::fs::write(tmp.join("a"), b"hello").unwrap();
+        let opts = sakimori_core::tamper::Options::default();
+        let baseline = sakimori_core::tamper::Snapshot::take(&tmp, &opts).unwrap();
+        let baseline_path = tmp.join("baseline.json");
+        std::fs::write(&baseline_path, baseline.to_json_pretty().unwrap()).unwrap();
+
+        // Add a file post-baseline.
+        std::fs::write(tmp.join("b"), b"new").unwrap();
+
+        let diff = compute_workspace_drift(Some(&baseline_path), Some(&tmp), &[])
+            .expect("drift should be Some when both args valid");
+        assert!(!diff.is_clean(), "must detect drift");
+        assert!(
+            diff.added.iter().any(|p| p.ends_with("b")),
+            "added: {:?}",
+            diff.added
+        );
     }
 }

--- a/crates/sakimori/src/doctor.rs
+++ b/crates/sakimori/src/doctor.rs
@@ -122,6 +122,12 @@ pub struct DoctorInputs {
     /// Path to the daemon unit (launchd plist / systemd unit).
     /// `None` means "skip this check".
     pub daemon_unit_path: Option<PathBuf>,
+    /// Path to a `sakimori daemon start --pid-file` file. When set,
+    /// doctor reads the pid and reports whether the daemon process
+    /// is still alive — useful for catching "the daemon died mid-job
+    /// and nothing told me" situations on long-running runners.
+    /// `None` means "skip this check".
+    pub daemon_pidfile: Option<PathBuf>,
 }
 
 /// Run every check with the given inputs. Pure-ish — does read the
@@ -141,7 +147,78 @@ pub fn run_checks(inp: &DoctorInputs) -> Vec<CheckResult> {
     if let Some(d) = &inp.daemon_unit_path {
         out.push(check_daemon_unit(d));
     }
+    if let Some(p) = &inp.daemon_pidfile {
+        out.push(check_daemon_pidfile(p));
+    }
     out
+}
+
+fn check_daemon_pidfile(path: &Path) -> CheckResult {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return CheckResult::warn(
+                "sakimori daemon",
+                format!("no pid-file at {}", path.display()),
+                "start it from the action's pre-step or `sakimori daemon start`",
+            );
+        }
+        Err(e) => {
+            return CheckResult::fail(
+                "sakimori daemon",
+                format!("reading {}: {e}", path.display()),
+                "check filesystem permissions",
+            );
+        }
+    };
+    let pid: u32 = match contents.trim().parse() {
+        Ok(p) => p,
+        Err(_) => {
+            return CheckResult::fail(
+                "sakimori daemon",
+                format!("pid-file {} is malformed: {:?}", path.display(), contents),
+                "remove the file and restart the daemon",
+            );
+        }
+    };
+    if daemon_pid_is_alive(pid) {
+        CheckResult::ok(
+            "sakimori daemon",
+            format!("pid {pid} alive ({})", path.display()),
+        )
+    } else {
+        CheckResult::fail(
+            "sakimori daemon",
+            format!(
+                "pid {pid} from {} is no longer alive — daemon crashed or was killed",
+                path.display()
+            ),
+            "inspect the daemon's stderr log (next to the pid-file) and restart",
+        )
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_is_alive(pid: u32) -> bool {
+    // Mirrors `daemon::pid_is_alive` — kept as a private dup to avoid
+    // exposing that function publicly. See its comment for the i32-wrap
+    // / EPERM rationale.
+    if pid == 0 || pid > i32::MAX as u32 {
+        return false;
+    }
+    let r = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if r == 0 {
+        return true;
+    }
+    let errno = unsafe { *libc::__errno_location() };
+    errno == libc::EPERM
+}
+
+#[cfg(not(target_os = "linux"))]
+fn daemon_pid_is_alive(_pid: u32) -> bool {
+    // No daemon on non-Linux yet; report dead so the doctor check fires
+    // a clear "daemon not running" message instead of a misleading OK.
+    false
 }
 
 fn check_ca_file(path: &Path) -> CheckResult {
@@ -370,5 +447,59 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
         let r = check_proxy_listening(addr);
         assert_eq!(r.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn daemon_pidfile_missing_is_warn_not_fail() {
+        // Daemon is intentionally ephemeral (only running during a job),
+        // so absence is informational, not an error.
+        let d = std::env::temp_dir().join(format!(
+            "sakimori-doctor-test-{}-pid-missing",
+            std::process::id()
+        ));
+        let r = check_daemon_pidfile(&d);
+        assert_eq!(r.status, CheckStatus::Warn);
+    }
+
+    #[test]
+    fn daemon_pidfile_malformed_is_fail() {
+        let d = std::env::temp_dir().join(format!(
+            "sakimori-doctor-test-{}-pid-bad",
+            std::process::id()
+        ));
+        std::fs::write(&d, "not-a-pid\n").unwrap();
+        let r = check_daemon_pidfile(&d);
+        assert_eq!(r.status, CheckStatus::Fail);
+        std::fs::remove_file(&d).ok();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn daemon_pidfile_with_live_pid_is_ok() {
+        // Our own pid is alive — the check should report OK.
+        let d = std::env::temp_dir().join(format!(
+            "sakimori-doctor-test-{}-pid-live",
+            std::process::id()
+        ));
+        std::fs::write(&d, format!("{}\n", std::process::id())).unwrap();
+        let r = check_daemon_pidfile(&d);
+        assert_eq!(r.status, CheckStatus::Ok);
+        std::fs::remove_file(&d).ok();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn daemon_pidfile_with_dead_pid_is_fail() {
+        // Same sentinel as daemon::tests::check_pidfile_unused_ignores_stale_pid
+        // — comfortably above Linux pid_max but inside positive i32.
+        const STALE: u32 = 2_000_000_000;
+        let d = std::env::temp_dir().join(format!(
+            "sakimori-doctor-test-{}-pid-stale",
+            std::process::id()
+        ));
+        std::fs::write(&d, format!("{STALE}\n")).unwrap();
+        let r = check_daemon_pidfile(&d);
+        assert_eq!(r.status, CheckStatus::Fail);
+        std::fs::remove_file(&d).ok();
     }
 }

--- a/job/action.yml
+++ b/job/action.yml
@@ -44,6 +44,34 @@ inputs:
       single-tenant runner where that's actually what you want.
     required: false
     default: "false"
+  snapshot-workspace:
+    description: |
+      Directory to diff for tamper detection. When set, the daemon is
+      started with `--workspace-dir <DIR> --workspace-baseline <BASELINE>`,
+      and the action exports two env vars for use in a post-checkout
+      step:
+        - SAKIMORI_WORKSPACE_DIR   — resolved absolute directory
+        - SAKIMORI_BASELINE_PATH   — where to write the baseline JSON
+      Add a step right after `actions/checkout` that takes the
+      baseline:
+        - run: sudo -E "$SAKIMORI_BIN" workspace snapshot
+                 "$SAKIMORI_WORKSPACE_DIR" -o "$SAKIMORI_BASELINE_PATH"
+      The daemon reads the file at SIGTERM time and surfaces drift in
+      the JSON log + step summary. Forgetting the snapshot step is
+      non-fatal — the daemon logs a warning and the report omits the
+      drift section.
+    required: false
+    default: ""
+  snapshot-skip:
+    description: |
+      Newline-separated extra directory basenames to skip during the
+      tamper snapshot, on top of the built-in build-artefact list
+      (`.git`, `node_modules`, `target`, `dist`, …). Must match
+      whatever the post-checkout `sakimori workspace snapshot` step
+      passes for `--skip`, otherwise added/removed entries fire
+      spuriously.
+    required: false
+    default: ""
 
 outputs:
   bin:

--- a/job/pre.js
+++ b/job/pre.js
@@ -169,6 +169,21 @@ function startDaemon() {
     : process.env.GITHUB_STEP_SUMMARY || "";
   const allowRoot = input("allow-root-cgroup") === "true";
 
+  // Tamper detection wiring. Baseline file is read at SIGTERM time so
+  // it's fine that it doesn't exist yet at start (the user takes it
+  // after checkout in a separate step). See action.yml for the
+  // recipe. snapshot-skip is newline-separated since YAML `with:`
+  // doesn't have a clean way to pass a list of strings.
+  const snapshotDirIn = input("snapshot-workspace");
+  const snapshotDir = snapshotDirIn ? resolveOutput(snapshotDirIn) : "";
+  const baselinePath = snapshotDir
+    ? path.join(runnerTemp, "sakimori-workspace-baseline.json")
+    : "";
+  const snapshotSkip = (input("snapshot-skip") || "")
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
   // process.ppid is the GitHub Actions runner worker that spawned `node
   // pre.js`. It's the common ancestor cgroup we need to attach to: every
   // subsequent step the worker spawns inherits its cgroup, so attaching
@@ -207,6 +222,17 @@ function startDaemon() {
   if (allowRoot) {
     daemonArgs.push("--allow-root-cgroup");
   }
+  if (snapshotDir) {
+    daemonArgs.push(
+      "--workspace-baseline",
+      baselinePath,
+      "--workspace-dir",
+      snapshotDir,
+    );
+    for (const skip of snapshotSkip) {
+      daemonArgs.push("--workspace-skip", skip);
+    }
+  }
 
   // Fresh log files each run — append would mix stale daemon output
   // from a previous job that ran on this same runner image (rare on
@@ -241,6 +267,17 @@ function startDaemon() {
       // daemon flagged denied events in block mode.
       setEnv("SAKIMORI_JOB_LOG", log);
       setEnv("SAKIMORI_JOB_MODE", mode || "audit");
+      // Tamper-detection wiring: expose the resolved paths so the
+      // user's post-checkout snapshot step can find them.
+      if (snapshotDir) {
+        setEnv("SAKIMORI_WORKSPACE_DIR", snapshotDir);
+        setEnv("SAKIMORI_BASELINE_PATH", baselinePath);
+        notice(
+          `tamper detection armed — take the baseline with: ` +
+            `sudo -E "$SAKIMORI_BIN" workspace snapshot ` +
+            `"$SAKIMORI_WORKSPACE_DIR" -o "$SAKIMORI_BASELINE_PATH"`,
+        );
+      }
       setOutput("bin", binPath);
       setOutput("log", log);
       setOutput("pidfile", pidFile);


### PR DESCRIPTION
## Summary

Two follow-ups to PR #58 (the job-scoped supervised mode).

### 1. Workspace tamper detection in daemon mode

`sakimori run --snapshot-workspace` has had tamper detection for a
while, but the daemon variant (`bokuweb/sakimori/job@v0`) couldn't
use it because pre.js runs *before* checkout — the workspace is
empty at daemon-start time, so a daemon-taken baseline would be
useless. Split the lifecycle:

- `sakimori daemon start --workspace-baseline <FILE> --workspace-dir <DIR>`
  stores the path; baseline read is deferred to SIGTERM.
- After SIGTERM, daemon takes a fresh snapshot, diffs against the
  baseline file, and includes the result in the same
  `workspace_drift` JSON / step-summary section `sakimori run`
  uses.
- Block mode exits non-zero on any drift, matching the run-mode
  policy.
- Forgetting to take the baseline is non-fatal — daemon logs a
  warning, drift section is omitted, audit log still flows.

`bokuweb/sakimori/job@v0` surfaces this via `snapshot-workspace:
<DIR>` + `snapshot-skip:` inputs. pre.js exports
`SAKIMORI_WORKSPACE_DIR` / `SAKIMORI_BASELINE_PATH` so the
post-checkout step can take the baseline with a one-liner. README
shows the recipe.

### 2. `sakimori doctor --daemon-pidfile <FILE>`

Opt-in health check: reads the pid, verifies the daemon process is
alive (i32-wrap-safe `kill(pid, 0)` — same logic as the daemon
module's own pid_is_alive). Useful on self-hosted runners where a
daemon could crash mid-job and the runner would happily continue.
Skipped when the flag is omitted, so existing `sakimori doctor`
users see no change.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 8 new unit tests pass (4 daemon
      tamper: soft-fail when args/file missing/malformed + a real
      take-snapshot/add-file/diff cycle; 4 doctor: missing /
      malformed / live / dead pidfile)
- [x] `node --check job/pre.js` clean (existing CI smoke covers the
      daemon binary; wrapper-level e2e remains a post-release
      consumer-smoke task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)