### PR TITLE
action: `bokuweb/sakimori/job/stop@v0` — 1-line mid-job flush

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,15 @@ of value-per-implementation-cost.
       `job-scoped-smoke` CI job to test the action against a
       locally-built binary, also useful for air-gapped mirrors.
 
+      Sub-action `bokuweb/sakimori/job/stop@v0` (composite, one
+      step) is a 1-line shortcut for the "flush the daemon early
+      before `actions/upload-artifact` inside the same job"
+      pattern. Replaces the previous 4-line `sudo -n -E
+      $SAKIMORI_BIN daemon stop --pid-file $SAKIMORI_JOB_PIDFILE`
+      snippet so consumer workflows don't have to know about
+      pid-files or sudo. Idempotent + Linux-only-no-op so it can
+      be dropped into cross-OS matrices unchanged.
+
       **Out of scope for this iteration**: container jobs
       (`jobs.<id>.container:`) — the host-side cgroup attach can't
       reach steps that run inside the container. `pre.js` detects

--- a/README.md
+++ b/README.md
@@ -769,11 +769,33 @@ Limitations: Linux runners only (Windows needs a different kernel
 hook), and **container jobs** (`jobs.<id>.container:`) are unsupported
 because the host-side cgroup attach can't reach steps that run inside
 the container. Matrix shards and reusable-workflow callers are each
-their own job and need their own `bokuweb/sakimori/job@v0`. Note also
-that the audit log is only written at post-time, so `actions/upload-
-artifact` *inside the same job* can't see it — upload it from a
-downstream job, or use the `bokuweb/sakimori@v0` one-step form below
-if you need the artifact mid-job.
+their own job and need their own `bokuweb/sakimori/job@v0`.
+
+**Uploading the audit log from the same job**: the daemon writes
+its JSON / HTML / step-summary at end-of-job (the post-hook), which
+is too late for an `actions/upload-artifact` step inside the same
+job. Drop in `bokuweb/sakimori/job/stop@v0` right before the
+upload to flush the daemon early:
+
+```yaml
+- uses: bokuweb/sakimori/job@v0
+  with: { policy: .github/sakimori.yml, mode: block }
+
+- uses: actions/checkout@v4
+- run: pnpm test
+
+- uses: bokuweb/sakimori/job/stop@v0       # flush + stop
+- uses: actions/upload-artifact@v4
+  with:
+    name: sakimori-report
+    path: |
+      sakimori.log.json
+      sakimori-report.html
+```
+
+It's idempotent — the daemon's own post-hook turns into a no-op on
+the missing pid-file. On non-Linux matrix entries the sub-action
+no-ops silently, so it's safe to drop into a cross-OS workflow.
 
 **Tamper detection**: pass `snapshot-workspace: <DIR>` to also catch
 on-disk tampering. The daemon can't take the baseline itself (it

--- a/job/stop/action.yml
+++ b/job/stop/action.yml
@@ -1,0 +1,47 @@
+name: "sakimori-job-stop"
+description: |
+  Stop the sakimori daemon spawned by `bokuweb/sakimori/job@v0`,
+  flushing its JSON audit log + HTML report + step summary to
+  disk. Use this when you want to upload those files via
+  `actions/upload-artifact` from inside the same job — the
+  daemon's own post-hook writes them at end-of-job, which is too
+  late for an in-job upload.
+
+  Idempotent: a missing pid-file (because the daemon already
+  stopped, or never started on this matrix entry) is a no-op.
+
+  Linux only — matches `bokuweb/sakimori/job@v0`. Other runners
+  silently no-op so this is safe to drop into a cross-OS workflow.
+
+author: "bokuweb"
+branding:
+  icon: "shield"
+  color: "red"
+
+runs:
+  using: composite
+  steps:
+    - if: runner.os == 'Linux'
+      shell: bash
+      env:
+        # Pulled from $GITHUB_ENV by the matching `job@v0` main step.
+        # We re-read them here rather than accept them as `with:`
+        # inputs so the consumer doesn't have to know they exist.
+        BIN: ${{ env.SAKIMORI_BIN }}
+        PIDFILE: ${{ env.SAKIMORI_JOB_PIDFILE }}
+      run: |
+        set -euo pipefail
+        if [ -z "${BIN:-}" ] || [ -z "${PIDFILE:-}" ]; then
+          echo "sakimori-job-stop: SAKIMORI_BIN / SAKIMORI_JOB_PIDFILE unset — " \
+               "either bokuweb/sakimori/job@v0 wasn't used in this job or " \
+               "its pre-step failed. Nothing to flush."
+          exit 0
+        fi
+        if [ ! -f "$PIDFILE" ]; then
+          echo "sakimori-job-stop: pid-file $PIDFILE missing — daemon already stopped."
+          exit 0
+        fi
+        # `sudo -n -E` mirrors the main action's pre.js, which spawns
+        # the daemon as root via the same invocation. We pass -E to
+        # preserve env so the binary can read GITHUB_STEP_SUMMARY etc.
+        sudo -n -E "$BIN" daemon stop --pid-file "$PIDFILE"


### PR DESCRIPTION
## Why

The "flush before `actions/upload-artifact` in the same job" pattern is a 4-line snippet that leaks implementation detail:

```yaml
- if: always() && runner.os == 'Linux'
  name: Flush sakimori daemon
  run: |
    sudo -n -E "$SAKIMORI_BIN" daemon stop \
      --pid-file "$SAKIMORI_JOB_PIDFILE"
- uses: actions/upload-artifact@v4
  ...
```

Consumers shouldn't need to know about sudo, the binary path, or the pid-file env var. This was the friction that made reg-viz/reg-cli#652 and reg-viz/reg-actions#211 look uglier than they should.

## What

A composite sub-action at `job/stop/action.yml`:

```yaml
- uses: bokuweb/sakimori/job/stop@v0
- uses: actions/upload-artifact@v4
  ...
```

That's it. The sub-action:

- **Idempotent.** Missing pid-file → no-op. The main `job@v0` post-hook also no-ops on the same missing pid-file, so ordering is safe either way.
- **Cross-OS-safe.** On macOS / Windows entries (where the main `job@v0` is already a silent no-op) this sub-action also no-ops via `if: runner.os == 'Linux'`. Drop it into a tri-platform matrix without conditionals.
- **Reads env, no inputs.** `SAKIMORI_BIN` and `SAKIMORI_JOB_PIDFILE` were already exported to `$GITHUB_ENV` by the main action's pre.js.

README + CLAUDE.md updated. Once this merges + v0.34.4 ships + the `v0` floating tag repoints, consumers can use it immediately.

## Test plan

- [x] `ruby -ryaml -c job/stop/action.yml` parses
- [x] action.yml shape matches `comment/action.yml` (the other composite sub-action) so GitHub Actions resolves it the same way
- Followups (after release):
  - Open reg-viz/reg-cli + reg-viz/reg-actions PRs replacing the 4-line snippet with the sub-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)