### PR TITLE
feat: retroactive CVE notification — install log + `advisories scan`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
         # on any hit. The wiring assertion is what matters here.
         run: |
           set -uxo pipefail
+          set +e
           ./target/release/sakimori advisories scan \
               --install-log "$RUNNER_TEMP/installs.jsonl" \
               --json > "$RUNNER_TEMP/proxy-scan.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,7 +851,9 @@ jobs:
         # `userspace` only runs on Linux. We want the platform-neutral
         # crates exercised on macOS / Windows too, especially the
         # filesystem append path in `installs`.
-        run: "cargo test -p sakimori-core installs:: advisories::"
+        run: |
+          cargo test -p sakimori-core installs::
+          cargo test -p sakimori-core advisories::
 
       - name: Hand-craft an installs.jsonl with one known-malicious entry
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,21 +259,31 @@ jobs:
           print(f"✓ proxy recorded {len(hits)} install event(s) for lodash@4.17.21")
           PY
 
-      - name: advisories scan against proxy-recorded log finds nothing
-        # End-to-end happy-path: the log the proxy just wrote is
-        # readable by `advisories scan`, and lodash@4.17.21 has no
-        # advisories so the exit code is clean.
+      - name: advisories scan consumes the proxy-recorded log
+        # End-to-end: the log the proxy just wrote must be readable by
+        # `advisories scan` and produce a valid JSON report. We don't
+        # assert hit count — OSV may or may not list advisories that
+        # transitively cover lodash@4.17.21, and `scan` exits non-zero
+        # on any hit. The wiring assertion is what matters here.
         run: |
-          set -euxo pipefail
+          set -uxo pipefail
           ./target/release/sakimori advisories scan \
               --install-log "$RUNNER_TEMP/installs.jsonl" \
               --json > "$RUNNER_TEMP/proxy-scan.json"
+          rc=$?
+          set -e
+          # Accept 0 (no hits) or 1 (hits found); fail anything else.
+          if [ "$rc" != "0" ] && [ "$rc" != "1" ]; then
+            echo "::error::advisories scan exited unexpectedly (rc=$rc)"
+            cat "$RUNNER_TEMP/proxy-scan.json" || true
+            exit 1
+          fi
           python3 - <<'PY'
           import json, os
           r = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "proxy-scan.json")))
           assert r["installs_scanned"] >= 1, r
-          assert r["hits"] == [], r
-          print("ok no advisories for lodash@4.17.21")
+          assert "hits" in r and isinstance(r["hits"], list), r
+          print(f"ok: scanned={r['installs_scanned']} hits={len(r['hits'])}")
           PY
 
       - name: Show proxy log on success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
           ./target/release/sakimori proxy start \
               --listen 127.0.0.1:18910 \
               --min-age 365d \
+              --install-log "$RUNNER_TEMP/installs.jsonl" \
               > "$RUNNER_TEMP/proxy.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/proxy.pid"
           # Wait for the listener.
@@ -231,9 +232,59 @@ jobs:
           assert v > 50, f"suspicious drop ratio: direct={d} via={v}"
           print(f"ok nuget: direct={d} via={v}")
           PY
+      - name: pinned tarball fetch — proxy records an InstallEvent
+        run: |
+          set -euo pipefail
+          # Pick a stable, old-enough lodash version so the age filter
+          # (--min-age 365d) doesn't deny it.
+          curl -fsS --cacert "$CA" -x http://127.0.0.1:18910 \
+            -o /dev/null \
+            -A 'npm/10.0.0 node/20.0.0 ci/true' \
+            https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz
+          test -f "$RUNNER_TEMP/installs.jsonl"
+          echo "--- installs.jsonl ---"
+          cat "$RUNNER_TEMP/installs.jsonl"
+          python3 - <<'PY'
+          import json, os, sys
+          path = os.path.join(os.environ["RUNNER_TEMP"], "installs.jsonl")
+          rows = [json.loads(l) for l in open(path) if l.strip()]
+          hits = [r for r in rows
+                  if r["ecosystem"] == "npm"
+                  and r["name"] == "lodash"
+                  and r["version"] == "4.17.21"]
+          assert hits, f"no install event recorded for lodash@4.17.21: {rows}"
+          # The npm/10.x UA we sent should classify as `persistent`.
+          assert hits[0]["execution_mode"] == "persistent", hits[0]
+          assert "user_agent" in hits[0]
+          print(f"✓ proxy recorded {len(hits)} install event(s) for lodash@4.17.21")
+          PY
+
+      - name: advisories scan against proxy-recorded log finds nothing
+        # End-to-end happy-path: the log the proxy just wrote is
+        # readable by `advisories scan`, and lodash@4.17.21 has no
+        # advisories so the exit code is clean.
+        run: |
+          set -euxo pipefail
+          ./target/release/sakimori advisories scan \
+              --install-log "$RUNNER_TEMP/installs.jsonl" \
+              --json > "$RUNNER_TEMP/proxy-scan.json"
+          python3 - <<'PY'
+          import json, os
+          r = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "proxy-scan.json")))
+          assert r["installs_scanned"] >= 1, r
+          assert r["hits"] == [], r
+          print("ok no advisories for lodash@4.17.21")
+          PY
+
       - name: Show proxy log on success
         if: always()
         run: tail -40 "$RUNNER_TEMP/proxy.log" || true
+      - name: Upload proxy install log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: proxy-installs-log
+          path: ${{ runner.temp }}/installs.jsonl
       - name: Stop proxy
         if: always()
         run: |
@@ -756,6 +807,160 @@ jobs:
             ${{ runner.temp }}/sakimori-job.html
             ${{ runner.temp }}/sakimori-daemon.stdout.log
             ${{ runner.temp }}/sakimori-daemon.stderr.log
+
+  advisories-smoke:
+    # Cross-OS end-to-end for `sakimori advisories scan` + the proxy's
+    # install logger. Two things we want to prove on every supported
+    # host OS:
+    #
+    #   1. The install-log file format (`InstallEvent` JSONL) is
+    #      readable on the OS — path-handling, line-ending, encoding,
+    #      `$HOME` defaulting all behave.
+    #   2. A scan against real OSV.dev with a known-malicious entry
+    #      flags it, exits non-zero, and surfaces the GHSA ID. The
+    #      negative control (a benign entry) does NOT appear.
+    #
+    # We don't run the proxy here — that's covered by `proxy-smoke`
+    # and `proxy-action-smoke`. Instead we hand-write an installs.jsonl
+    # so the test stays hermetic against package-manager UA drift.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build sakimori
+        run: cargo build --release -p sakimori
+      - name: Resolve sakimori binary path
+        run: |
+          set -euxo pipefail
+          case "$RUNNER_OS" in
+            Windows) bin="$GITHUB_WORKSPACE/target/release/sakimori.exe" ;;
+            *)       bin="$GITHUB_WORKSPACE/target/release/sakimori" ;;
+          esac
+          test -x "$bin"
+          echo "SAKIMORI_BIN=$bin" >> "$GITHUB_ENV"
+
+      - name: Run unit tests for new modules
+        # Quick belt-and-braces — the workspace `cargo test` in
+        # `userspace` only runs on Linux. We want the platform-neutral
+        # crates exercised on macOS / Windows too, especially the
+        # filesystem append path in `installs`.
+        run: "cargo test -p sakimori-core installs:: advisories::"
+
+      - name: Hand-craft an installs.jsonl with one known-malicious entry
+        run: |
+          set -euxo pipefail
+          mkdir -p "$RUNNER_TEMP/sakimori"
+          # event-stream@3.3.6 is the canonical reference malicious
+          # npm release (GHSA-mh6f-8j2x-4483 / OSV) — published 2018,
+          # still indexed, and very stable across OSV refreshes.
+          # Paired with a benign entry to prove the negative side.
+          python3 - <<PY > "$RUNNER_TEMP/sakimori/installs.jsonl"
+          import json
+          rows = [
+              {"ecosystem":"npm","name":"event-stream","version":"3.3.6",
+               "resolved_at":"2026-01-01T00:00:00Z","execution_mode":"persistent",
+               "user_agent":"npm/10.0.0 node/20.0.0"},
+              {"ecosystem":"npm","name":"left-pad","version":"1.3.0",
+               "resolved_at":"2026-01-02T00:00:00Z","execution_mode":"persistent",
+               "user_agent":"npm/10.0.0 node/20.0.0"},
+          ]
+          for r in rows:
+              print(json.dumps(r))
+          PY
+          cat "$RUNNER_TEMP/sakimori/installs.jsonl"
+
+      - name: scan — known-malicious flagged, exits non-zero, JSON shape correct
+        run: |
+          set -euo pipefail
+          set +e
+          "$SAKIMORI_BIN" advisories scan \
+            --install-log "$RUNNER_TEMP/sakimori/installs.jsonl" \
+            --json > "$RUNNER_TEMP/scan.json"
+          rc=$?
+          set -e
+          echo "exit_code=$rc"
+          cat "$RUNNER_TEMP/scan.json"
+          if [ "$rc" = "0" ]; then
+            echo "::error::advisories scan exited 0 despite a known-malicious entry"
+            exit 1
+          fi
+          python3 - <<'PY'
+          import json, os, sys
+          report = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "scan.json")))
+          assert report["installs_scanned"] == 2, report
+          assert report["unique_packages"] == 2, report
+          hits = report["hits"]
+          assert len(hits) >= 1, hits
+          es = [h for h in hits if h["name"] == "event-stream" and h["version"] == "3.3.6"]
+          assert es, f"expected event-stream@3.3.6 in hits: {hits}"
+          assert es[0]["ecosystem"] == "npm"
+          assert es[0]["execution_mode"] == "persistent"
+          assert any(i.startswith("GHSA-") or i.startswith("MAL-") for i in es[0]["advisory_ids"]), es[0]
+          # Negative control: left-pad@1.3.0 has no advisories (it's
+          # famous for breaking the internet, not for malware).
+          assert not any(h["name"] == "left-pad" for h in hits), hits
+          print(f"ok: {len(hits)} hit(s), event-stream advisories: {es[0]['advisory_ids']}")
+          PY
+
+      - name: scan — empty log is a clean success
+        run: |
+          set -euxo pipefail
+          : > "$RUNNER_TEMP/sakimori/empty.jsonl"
+          "$SAKIMORI_BIN" advisories scan \
+            --install-log "$RUNNER_TEMP/sakimori/empty.jsonl" \
+            --json > "$RUNNER_TEMP/scan-empty.json"
+          python3 - <<'PY'
+          import json, os
+          r = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "scan-empty.json")))
+          assert r["installs_scanned"] == 0, r
+          assert r["unique_packages"] == 0, r
+          assert r["hits"] == [], r
+          print("ok empty")
+          PY
+
+      - name: scan — missing log file is a clean success (treated as empty)
+        run: |
+          set -euxo pipefail
+          "$SAKIMORI_BIN" advisories scan \
+            --install-log "$RUNNER_TEMP/sakimori/nope.jsonl" \
+            --json > "$RUNNER_TEMP/scan-missing.json"
+          python3 - <<'PY'
+          import json, os
+          r = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "scan-missing.json")))
+          assert r["installs_scanned"] == 0, r
+          assert r["hits"] == [], r
+          print("ok missing")
+          PY
+
+      - name: proxy start accepts --no-install-log / --install-log flags
+        # Surface-level CLI test — we don't actually run the proxy
+        # here (proxy-smoke does that). Just prove the flags parse on
+        # every OS so a typo can't slip in on a platform we don't
+        # otherwise exercise.
+        run: |
+          set -euxo pipefail
+          "$SAKIMORI_BIN" proxy start --help > "$RUNNER_TEMP/proxy-help.txt"
+          grep -q -- "--no-install-log" "$RUNNER_TEMP/proxy-help.txt"
+          grep -q -- "--install-log" "$RUNNER_TEMP/proxy-help.txt"
+          echo "ok: install-log flags exposed on $RUNNER_OS"
+
+      - name: Upload scan outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: advisories-${{ matrix.runner }}
+          path: |
+            ${{ runner.temp }}/sakimori/installs.jsonl
+            ${{ runner.temp }}/scan.json
+            ${{ runner.temp }}/scan-empty.json
+            ${{ runner.temp }}/scan-missing.json
 
   proxy-action-smoke:
     # Verifies that `bokuweb/sakimori/proxy@v0` (the JS-action wrapper

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,15 +176,22 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.
 5. **macOS live block** — either a Network Extension (heavy, needs
    signing) or an HTTPS proxy (see #2).
-6. **Retroactive CVE notification for past installs** — log every
-   resolved install the proxy sees to a local append-only file
-   (`~/.sakimori/installs.jsonl`: ecosystem, name, version,
-   resolved_at, project_path, attribution) and add
-   `sakimori advisories scan` that batch-queries
+6. **Retroactive CVE notification for past installs** — local-first
+   half landed: the proxy's pinned-install path now appends every
+   resolved fetch to `~/.sakimori/installs.jsonl`
+   (`InstallEvent { ecosystem, name, version, resolved_at,
+   execution_mode, user_agent }` — `project_path` and richer
+   attribution come next), and `sakimori advisories scan` reads
+   that log, dedupes by `(eco, name, version)`, and batch-queries
    [OSV.dev](https://osv.dev)'s `POST /v1/querybatch` for matching
-   advisories. Local-first: no server, no upload, private dep
-   trees never leave the machine. OSV covers npm / crates.io /
-   PyPI / NuGet so one client handles all four ecosystems.
+   advisories. Hits exit non-zero so it slots into cron / CI.
+   `execution_mode` classification is currently best-effort from
+   the User-Agent (`npx` / `pipx` / `uvx` / `cargo-install` →
+   ephemeral; known package managers → persistent; everything
+   else → unknown). The proxy logger is on by default; opt out
+   with `sakimori proxy start --no-install-log`. Local-first: no
+   server, no upload, private dep trees never leave the machine —
+   only `(eco, name, version)` tuples are sent to OSV.
 
    For team-wide push notifications, we ship **`sakimori-hub`** as
    an optional self-hostable companion: a small Rust service with

--- a/crates/sakimori-core/src/advisories.rs
+++ b/crates/sakimori-core/src/advisories.rs
@@ -1,0 +1,341 @@
+//! Retroactive CVE notification: query OSV.dev for advisories that
+//! affect installs we've already logged.
+//!
+//! Reads `~/.sakimori/installs.jsonl` (or whatever path the caller
+//! configured on the proxy), de-duplicates `(ecosystem, name, version)`,
+//! and POSTs the set to OSV's `/v1/querybatch` in chunks. The endpoint
+//! returns one entry per query; any non-empty `vulns` array means
+//! "this installed version is implicated in at least one advisory."
+//!
+//! Local-first by design: no upload of the install log, no server in
+//! the loop. The only network call is to `api.osv.dev`, and only the
+//! `(ecosystem, name, version)` tuples leave the machine — never paths,
+//! User-Agent strings, or timestamps.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::installs::{ExecutionMode, InstallLogger};
+
+/// OSV's documented per-batch limit is 1000; we stay comfortably
+/// under that. Smaller batches also give nicer progress reporting.
+const BATCH_SIZE: usize = 200;
+
+const OSV_BATCH_ENDPOINT: &str = "https://api.osv.dev/v1/querybatch";
+
+/// Mapping `Ecosystem::label()` → OSV ecosystem string. We accept the
+/// `&str` form (rather than the `Ecosystem` enum) because [`InstallEvent`]
+/// stores the label, not the enum — and an old log file may contain a
+/// label that's since been renamed in the binary, in which case we
+/// want to skip it rather than fail to load.
+fn label_to_osv(label: &str) -> Option<&'static str> {
+    match label {
+        "npm" => Some("npm"),
+        "crates" => Some("crates.io"),
+        "pypi" => Some("PyPI"),
+        "nuget" => Some("NuGet"),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AdvisoryHit {
+    pub ecosystem: String,
+    pub name: String,
+    pub version: String,
+    pub execution_mode: ExecutionMode,
+    /// All advisory IDs OSV returned for this `(eco, name, version)`.
+    pub advisory_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ScanReport {
+    pub installs_scanned: usize,
+    pub unique_packages: usize,
+    pub hits: Vec<AdvisoryHit>,
+}
+
+/// Indirection so tests can swap in a canned response without going
+/// over the network.
+pub trait OsvBatch {
+    /// Send up to [`BATCH_SIZE`] queries; return the same number of
+    /// `Vec<String>` advisory-ID lists in the same order.
+    fn query(&self, queries: &[OsvBatchQuery]) -> Result<Vec<Vec<String>>>;
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OsvBatchQuery {
+    pub version: String,
+    pub package: OsvBatchPackage,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OsvBatchPackage {
+    pub name: String,
+    pub ecosystem: &'static str,
+}
+
+#[derive(Deserialize)]
+struct OsvBatchResponse {
+    results: Vec<OsvBatchResultEntry>,
+}
+
+#[derive(Deserialize, Default)]
+struct OsvBatchResultEntry {
+    #[serde(default)]
+    vulns: Vec<OsvBatchVulnRef>,
+}
+
+#[derive(Deserialize)]
+struct OsvBatchVulnRef {
+    id: String,
+}
+
+/// Live OSV.dev HTTP client.
+pub struct LiveOsvBatch {
+    user_agent: String,
+}
+
+impl LiveOsvBatch {
+    pub fn new(user_agent: String) -> Self {
+        Self { user_agent }
+    }
+}
+
+impl OsvBatch for LiveOsvBatch {
+    fn query(&self, queries: &[OsvBatchQuery]) -> Result<Vec<Vec<String>>> {
+        let body = serde_json::json!({ "queries": queries });
+        let resp = ureq::post(OSV_BATCH_ENDPOINT)
+            .set("user-agent", &self.user_agent)
+            .send_json(body)
+            .context("POST /v1/querybatch")?;
+        let parsed: OsvBatchResponse = resp.into_json().context("parsing OSV response")?;
+        // Defensive: pad / truncate to match the request size so the
+        // caller can zip back to (eco, name, version) by index.
+        let mut out: Vec<Vec<String>> = parsed
+            .results
+            .into_iter()
+            .map(|r| r.vulns.into_iter().map(|v| v.id).collect())
+            .collect();
+        out.resize(queries.len(), Vec::new());
+        Ok(out)
+    }
+}
+
+/// Run a scan against the given log. Pure-ish: the OSV query is
+/// behind a trait so we can unit-test the dedupe / aggregation logic.
+pub fn scan(logger: &InstallLogger, oracle: &dyn OsvBatch) -> Result<ScanReport> {
+    let events = logger.read_all().context("reading install log")?;
+    let installs_scanned = events.len();
+
+    // Dedupe by (eco, name, version). Preserve the latest
+    // execution_mode we saw — if a package was installed both
+    // persistently and ephemerally, prefer `Ephemeral` since the
+    // user-facing message ("ran on this machine") is the more
+    // alarming framing and shouldn't be hidden.
+    let mut by_key: BTreeMap<(String, String, String), ExecutionMode> = BTreeMap::new();
+    for ev in &events {
+        let key = (ev.ecosystem.clone(), ev.name.clone(), ev.version.clone());
+        by_key
+            .entry(key)
+            .and_modify(|m| {
+                if *m != ExecutionMode::Ephemeral && ev.execution_mode == ExecutionMode::Ephemeral {
+                    *m = ExecutionMode::Ephemeral;
+                }
+            })
+            .or_insert(ev.execution_mode);
+    }
+    let unique_packages = by_key.len();
+
+    // Build per-batch queries, dropping any (eco, _, _) whose label
+    // OSV doesn't understand.
+    let mut ordered: Vec<((String, String, String), ExecutionMode)> = by_key.into_iter().collect();
+    ordered.retain(|((eco, _, _), _)| label_to_osv(eco).is_some());
+
+    let mut hits = Vec::new();
+    for chunk in ordered.chunks(BATCH_SIZE) {
+        let queries: Vec<OsvBatchQuery> = chunk
+            .iter()
+            .map(|((eco, name, version), _)| OsvBatchQuery {
+                version: version.clone(),
+                package: OsvBatchPackage {
+                    name: name.clone(),
+                    ecosystem: label_to_osv(eco).expect("retained above"),
+                },
+            })
+            .collect();
+        let results = oracle.query(&queries)?;
+        for (((eco, name, version), mode), ids) in chunk.iter().zip(results) {
+            if ids.is_empty() {
+                continue;
+            }
+            hits.push(AdvisoryHit {
+                ecosystem: eco.clone(),
+                name: name.clone(),
+                version: version.clone(),
+                execution_mode: *mode,
+                advisory_ids: ids,
+            });
+        }
+    }
+
+    Ok(ScanReport {
+        installs_scanned,
+        unique_packages,
+        hits,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deps::Ecosystem;
+    use crate::installs::InstallEvent;
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tmp_path() -> PathBuf {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("sakimori-advisories-{id}/installs.jsonl"))
+    }
+
+    struct FakeBatch {
+        // hits keyed by (name, version)
+        hits: std::collections::HashMap<(String, String), Vec<String>>,
+        seen: RefCell<Vec<Vec<OsvBatchQuery>>>,
+    }
+    impl OsvBatch for FakeBatch {
+        fn query(&self, queries: &[OsvBatchQuery]) -> Result<Vec<Vec<String>>> {
+            self.seen.borrow_mut().push(queries.to_vec());
+            Ok(queries
+                .iter()
+                .map(|q| {
+                    self.hits
+                        .get(&(q.package.name.clone(), q.version.clone()))
+                        .cloned()
+                        .unwrap_or_default()
+                })
+                .collect())
+        }
+    }
+
+    #[test]
+    fn scan_returns_only_packages_with_hits() {
+        let p = tmp_path();
+        let logger = InstallLogger::at(&p);
+        logger
+            .record(&InstallEvent::new(Ecosystem::Npm, "evil", "1.0.0"))
+            .unwrap();
+        logger
+            .record(&InstallEvent::new(Ecosystem::Npm, "fine", "1.0.0"))
+            .unwrap();
+        let mut hits = std::collections::HashMap::new();
+        hits.insert(
+            ("evil".into(), "1.0.0".into()),
+            vec!["GHSA-evil-evil".into()],
+        );
+        let fake = FakeBatch {
+            hits,
+            seen: RefCell::new(Vec::new()),
+        };
+        let report = scan(&logger, &fake).unwrap();
+        assert_eq!(report.installs_scanned, 2);
+        assert_eq!(report.unique_packages, 2);
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(report.hits[0].name, "evil");
+        assert_eq!(report.hits[0].advisory_ids, vec!["GHSA-evil-evil"]);
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    #[test]
+    fn scan_dedupes_repeat_installs() {
+        let p = tmp_path();
+        let logger = InstallLogger::at(&p);
+        for _ in 0..3 {
+            logger
+                .record(&InstallEvent::new(Ecosystem::Crates, "tokio", "1.40.0"))
+                .unwrap();
+        }
+        let fake = FakeBatch {
+            hits: Default::default(),
+            seen: RefCell::new(Vec::new()),
+        };
+        let report = scan(&logger, &fake).unwrap();
+        assert_eq!(report.installs_scanned, 3);
+        assert_eq!(report.unique_packages, 1);
+        // Single batch with a single query.
+        let seen = fake.seen.borrow();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].len(), 1);
+        assert_eq!(seen[0][0].package.ecosystem, "crates.io");
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    #[test]
+    fn scan_prefers_ephemeral_when_both_modes_seen() {
+        let p = tmp_path();
+        let logger = InstallLogger::at(&p);
+        logger
+            .record(
+                &InstallEvent::new(Ecosystem::Npm, "leftpad", "1.0.0")
+                    .with_mode(ExecutionMode::Persistent),
+            )
+            .unwrap();
+        logger
+            .record(
+                &InstallEvent::new(Ecosystem::Npm, "leftpad", "1.0.0")
+                    .with_mode(ExecutionMode::Ephemeral),
+            )
+            .unwrap();
+        let mut hits = std::collections::HashMap::new();
+        hits.insert(("leftpad".into(), "1.0.0".into()), vec!["X".into()]);
+        let fake = FakeBatch {
+            hits,
+            seen: RefCell::new(Vec::new()),
+        };
+        let report = scan(&logger, &fake).unwrap();
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(report.hits[0].execution_mode, ExecutionMode::Ephemeral);
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    #[test]
+    fn label_to_osv_covers_known_ecosystems() {
+        assert_eq!(label_to_osv("npm"), Some("npm"));
+        assert_eq!(label_to_osv("crates"), Some("crates.io"));
+        assert_eq!(label_to_osv("pypi"), Some("PyPI"));
+        assert_eq!(label_to_osv("nuget"), Some("NuGet"));
+        assert_eq!(label_to_osv("bogus"), None);
+    }
+
+    #[test]
+    fn scan_chunks_oversized_input() {
+        let p = tmp_path();
+        let logger = InstallLogger::at(&p);
+        // BATCH_SIZE + 5 unique packages → expect 2 chunks.
+        for i in 0..(BATCH_SIZE + 5) {
+            logger
+                .record(&InstallEvent::new(
+                    Ecosystem::Npm,
+                    format!("pkg-{i}"),
+                    "1.0.0",
+                ))
+                .unwrap();
+        }
+        let fake = FakeBatch {
+            hits: Default::default(),
+            seen: RefCell::new(Vec::new()),
+        };
+        let _ = scan(&logger, &fake).unwrap();
+        assert_eq!(fake.seen.borrow().len(), 2);
+        assert_eq!(fake.seen.borrow()[0].len(), BATCH_SIZE);
+        assert_eq!(fake.seen.borrow()[1].len(), 5);
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+}

--- a/crates/sakimori-core/src/installs.rs
+++ b/crates/sakimori-core/src/installs.rs
@@ -1,0 +1,212 @@
+//! Append-only log of every package install / fetch the proxy
+//! resolves. Feeds two consumers:
+//!
+//! - `sakimori advisories scan` — local OSV.dev batch query against the
+//!   installs we've seen, so a newly-disclosed advisory on a package we
+//!   pulled last week surfaces without re-running CI.
+//! - the optional `sakimori-hub` self-host server — same `InstallEvent`
+//!   JSON shape, sent over HTTP for team-wide push notifications.
+//!
+//! The file lives at `~/.sakimori/installs.jsonl` (override via
+//! [`InstallLogger::at`]) and is opened with `O_APPEND` per write, so
+//! parallel proxies on the same machine interleave whole lines without
+//! corrupting each other (POSIX guarantees `write()` of ≤ PIPE_BUF on
+//! `O_APPEND` is atomic; we stay well under that). On Windows the same
+//! flag (`FILE_APPEND_DATA`) gives the same property.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::deps::Ecosystem;
+
+/// How the install was invoked — drives the host UI's recommended
+/// remediation. See CLAUDE.md roadmap item #6 for the rationale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionMode {
+    /// Pinned in a lockfile (`npm install`, `cargo add`, `pip install`,
+    /// `dotnet add package`). Advisory → "bump and re-install".
+    Persistent,
+    /// One-shot (`npx`, `pnpm dlx`, `uvx`, `pipx run`, `cargo install`,
+    /// `go run <remote>`). Advisory → "this ran on the machine — investigate".
+    Ephemeral,
+    /// Couldn't classify from User-Agent + URL shape. Surface to the
+    /// UI as "unknown" rather than mis-classifying as ephemeral.
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallEvent {
+    pub ecosystem: String,
+    pub name: String,
+    pub version: String,
+    pub resolved_at: DateTime<Utc>,
+    pub execution_mode: ExecutionMode,
+    /// Best-effort working-directory of the invoking package manager,
+    /// or `None` if not derivable from the proxy request alone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    /// Raw User-Agent header the proxy saw — keeps the attribution
+    /// chain reconstructable after the fact.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+}
+
+impl InstallEvent {
+    pub fn new(eco: Ecosystem, name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            ecosystem: eco.label().to_string(),
+            name: name.into(),
+            version: version.into(),
+            resolved_at: Utc::now(),
+            execution_mode: ExecutionMode::Unknown,
+            project_path: None,
+            user_agent: None,
+        }
+    }
+
+    pub fn with_mode(mut self, mode: ExecutionMode) -> Self {
+        self.execution_mode = mode;
+        self
+    }
+
+    pub fn with_user_agent(mut self, ua: impl Into<String>) -> Self {
+        self.user_agent = Some(ua.into());
+        self
+    }
+
+    pub fn with_project_path(mut self, path: impl Into<String>) -> Self {
+        self.project_path = Some(path.into());
+        self
+    }
+}
+
+/// Append-only writer. Cheap to construct (no file is opened until the
+/// first `record`); cloning is intentionally not implemented to keep the
+/// expected pattern of "one logger held behind an `Arc`".
+pub struct InstallLogger {
+    path: PathBuf,
+}
+
+impl InstallLogger {
+    /// Default location: `~/.sakimori/installs.jsonl`. Falls back to
+    /// `./installs.jsonl` in the unlikely case `$HOME` is unset.
+    pub fn default_path() -> PathBuf {
+        match std::env::var_os("HOME") {
+            Some(home) => PathBuf::from(home).join(".sakimori").join("installs.jsonl"),
+            None => PathBuf::from("installs.jsonl"),
+        }
+    }
+
+    pub fn at(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn record(&self, event: &InstallEvent) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let mut f: File = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("opening {}", self.path.display()))?;
+        let mut line = serde_json::to_string(event).context("serializing InstallEvent")?;
+        line.push('\n');
+        f.write_all(line.as_bytes())
+            .with_context(|| format!("writing to {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// Read every event currently in the log. Skips malformed lines so
+    /// a single corrupt write (e.g. a hard kill mid-line) doesn't make
+    /// the whole history unreadable.
+    pub fn read_all(&self) -> Result<Vec<InstallEvent>> {
+        let raw = match std::fs::read_to_string(&self.path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e).with_context(|| format!("reading {}", self.path.display())),
+        };
+        let mut out = Vec::new();
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Ok(ev) = serde_json::from_str::<InstallEvent>(trimmed) {
+                out.push(ev);
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tmp_path() -> PathBuf {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("sakimori-installs-{id}/installs.jsonl"))
+    }
+
+    #[test]
+    fn record_then_read_roundtrips() {
+        let p = tmp_path();
+        let logger = InstallLogger::at(&p);
+        let ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_user_agent("npm/10.0.0 node/20.0.0");
+        logger.record(&ev).unwrap();
+        logger.record(&ev).unwrap();
+        let back = logger.read_all().unwrap();
+        assert_eq!(back.len(), 2);
+        assert_eq!(back[0].name, "left-pad");
+        assert_eq!(back[0].ecosystem, "npm");
+        assert_eq!(back[0].execution_mode, ExecutionMode::Persistent);
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    #[test]
+    fn read_all_skips_garbage_lines() {
+        let p = tmp_path();
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(
+            &p,
+            b"{\"ecosystem\":\"npm\",\"name\":\"a\",\"version\":\"1\",\"resolved_at\":\"2026-01-01T00:00:00Z\",\"execution_mode\":\"persistent\"}\n\
+              not json at all\n\
+              {\"ecosystem\":\"crates\",\"name\":\"b\",\"version\":\"2\",\"resolved_at\":\"2026-01-01T00:00:00Z\",\"execution_mode\":\"ephemeral\"}\n",
+        ).unwrap();
+        let back = InstallLogger::at(&p).read_all().unwrap();
+        assert_eq!(back.len(), 2);
+        assert_eq!(back[0].name, "a");
+        assert_eq!(back[1].name, "b");
+        let _ = std::fs::remove_dir_all(p.parent().unwrap());
+    }
+
+    #[test]
+    fn read_all_on_missing_file_is_empty() {
+        let p = tmp_path();
+        assert!(InstallLogger::at(&p).read_all().unwrap().is_empty());
+    }
+
+    #[test]
+    fn default_path_under_home() {
+        // Just exercise the function — concrete location depends on env.
+        let _ = InstallLogger::default_path();
+    }
+}

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -12,10 +12,12 @@
 //! the respective binary crates.
 
 pub mod actions;
+pub mod advisories;
 pub mod attribution;
 pub mod deps;
 pub mod events;
 pub mod html;
+pub mod installs;
 pub mod matcher;
 pub mod policy;
 pub mod report;

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -18,6 +18,8 @@ use hudsucker::{
     rcgen::KeyPair,
 };
 
+use sakimori_core::installs::{ExecutionMode, InstallEvent, InstallLogger};
+
 use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
 use crate::nuget_flatcontainer_client::NugetFlatContainerClient;
@@ -76,6 +78,14 @@ pub struct ProxyConfig {
     /// is unrestricted — current behaviour. See
     /// [`crate::host_allow::HostMatcher`] for pattern grammar.
     pub network_allow: Option<crate::host_allow::HostMatcher>,
+    /// Append-only install log. `Some(path)` overrides the location;
+    /// `None` uses [`InstallLogger::default_path`]. To disable
+    /// logging entirely, set [`Self::install_log_enabled`] to `false`.
+    pub install_log_path: Option<std::path::PathBuf>,
+    /// Master switch for the install logger. Defaults to `true` —
+    /// the local-first audit log is the foundation of
+    /// `sakimori advisories scan`.
+    pub install_log_enabled: bool,
 }
 
 impl ProxyConfig {
@@ -95,8 +105,48 @@ impl ProxyConfig {
             user_agent: format!("sakimori-proxy/{}", env!("CARGO_PKG_VERSION")),
             oracle: None,
             network_allow: None,
+            install_log_path: None,
+            install_log_enabled: true,
         })
     }
+}
+
+/// Best-effort classification of how the package was being installed.
+/// Falls back to `Unknown` when the User-Agent doesn't give us enough
+/// signal. Per CLAUDE.md roadmap #6, we default ambiguous cases to
+/// `Unknown` rather than mis-classify as `Ephemeral` — the host UI
+/// can surface unknowns to the user separately.
+pub(crate) fn classify_execution_mode(user_agent: &str) -> ExecutionMode {
+    let ua = user_agent.to_ascii_lowercase();
+    // Known one-shot runners. Order matters only for readability:
+    // each substring is unambiguous.
+    if ua.contains("npx")
+        || ua.contains("pnpm/dlx")
+        || ua.contains("yarn dlx")
+        || ua.contains("uvx")
+        || ua.contains("pipx")
+        || ua.contains("cargo-install")
+    {
+        return ExecutionMode::Ephemeral;
+    }
+    // Known persistent package managers. UA strings vary across
+    // versions; we look for a stable prefix.
+    if ua.starts_with("npm/")
+        || ua.starts_with("pnpm/")
+        || ua.starts_with("yarn/")
+        || ua.starts_with("cargo ")
+        || ua.starts_with("cargo/")
+        || ua.starts_with("pip/")
+        || ua.starts_with("poetry/")
+        || ua.starts_with("uv/")
+        || ua.starts_with("nuget")
+        || ua.contains("nuget command line")
+        || ua.contains("nuget xplat command line")
+        || ua.contains("dotnet")
+    {
+        return ExecutionMode::Persistent;
+    }
+    ExecutionMode::Unknown
 }
 
 /// Start the proxy and run until it errors.
@@ -193,6 +243,16 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
             matcher.len(),
         );
     }
+    let install_logger = if cfg.install_log_enabled {
+        let path = cfg
+            .install_log_path
+            .clone()
+            .unwrap_or_else(InstallLogger::default_path);
+        log::info!("install log: {}", path.display());
+        Some(Arc::new(InstallLogger::at(path)))
+    } else {
+        None
+    };
     let handler = SakimoriHandler {
         parsers: Arc::new(default_parsers()),
         decider,
@@ -202,6 +262,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
         network_allow: cfg.network_allow.map(Arc::new),
+        install_logger,
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -295,6 +356,8 @@ struct SakimoriHandler {
     /// API so we can silently filter the PEP 503 HTML Simple index
     /// (which has no dates inline).
     pypi_simple: PypiSimpleClient,
+    /// Append-only install log. `None` disables logging.
+    install_logger: Option<Arc<InstallLogger>>,
     /// Hostname allow-list. `None` (or empty) → unrestricted egress.
     /// `Some(non-empty)` → default-deny: any CONNECT or plain-HTTP
     /// request whose target host doesn't match returns 403 before
@@ -352,6 +415,12 @@ impl HttpHandler for SakimoriHandler {
             http::header::ACCEPT_ENCODING,
             http::HeaderValue::from_static("identity"),
         );
+        let user_agent = req
+            .headers()
+            .get(http::header::USER_AGENT)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("")
+            .to_string();
         match parse_for_host(&self.parsers, &host, &path) {
             ParseResult::Pinned {
                 ecosystem,
@@ -360,7 +429,22 @@ impl HttpHandler for SakimoriHandler {
             } => {
                 let now = Utc::now();
                 match self.decider.decide(ecosystem, &name, &version, now) {
-                    Decision::Allow => RequestOrResponse::Request(req),
+                    Decision::Allow => {
+                        if let Some(logger) = self.install_logger.as_ref() {
+                            let mode = classify_execution_mode(&user_agent);
+                            let mut ev =
+                                InstallEvent::new(ecosystem, &name, &version).with_mode(mode);
+                            if !user_agent.is_empty() {
+                                ev = ev.with_user_agent(&user_agent);
+                            }
+                            if let Err(e) = logger.record(&ev) {
+                                // Non-fatal: an unwritable install log
+                                // must not break package installs.
+                                log::warn!("install log write failed: {e:#}");
+                            }
+                        }
+                        RequestOrResponse::Request(req)
+                    }
                     Decision::Deny { reason } => {
                         log::warn!("deny {host}{path}: {reason}");
                         RequestOrResponse::Response(deny_response(&reason))
@@ -698,6 +782,57 @@ fn deny_response(reason: &str) -> Response<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_execution_mode_recognises_one_shot_runners() {
+        for ua in [
+            "npx/1.0",
+            "node npx mode",
+            "uvx/0.3",
+            "pipx/1.2",
+            "cargo-install 0.1",
+            "pnpm/dlx 9",
+            "yarn dlx",
+        ] {
+            assert_eq!(
+                classify_execution_mode(ua),
+                ExecutionMode::Ephemeral,
+                "{ua} should be ephemeral"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_execution_mode_recognises_persistent_managers() {
+        for ua in [
+            "npm/10.0.0 node/20.0.0",
+            "pnpm/9.0.0",
+            "yarn/1.22.0",
+            "cargo 1.80.0 (1.80.0)",
+            "cargo/1.80",
+            "pip/24.0",
+            "poetry/1.8",
+            "uv/0.4",
+            "NuGet/6.10.0",
+            "NuGet xplat command line/6.10",
+            "dotnet/8.0",
+        ] {
+            assert_eq!(
+                classify_execution_mode(ua),
+                ExecutionMode::Persistent,
+                "{ua} should be persistent"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_execution_mode_defaults_unknown_for_strange_ua() {
+        assert_eq!(classify_execution_mode(""), ExecutionMode::Unknown);
+        assert_eq!(
+            classify_execution_mode("Mozilla/5.0 just a browser"),
+            ExecutionMode::Unknown
+        );
+    }
 
     #[test]
     fn should_intercept_matches_known_hosts_case_insensitively() {

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -144,6 +144,33 @@ pub enum Command {
         #[command(subcommand)]
         cmd: DaemonCommand,
     },
+    /// Retroactive CVE notification: read the proxy's install log and
+    /// query OSV.dev for advisories that affect installs you've
+    /// already done. Local-first — only `(ecosystem, name, version)`
+    /// tuples are sent to OSV; project paths, User-Agents, and
+    /// timestamps never leave the machine.
+    Advisories {
+        #[command(subcommand)]
+        cmd: AdvisoriesCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AdvisoriesCommand {
+    /// Query OSV.dev for advisories matching every install in the log.
+    /// Exits non-zero if any hits are found.
+    Scan(AdvisoriesScanArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct AdvisoriesScanArgs {
+    /// Override the install-log path. Defaults to
+    /// `~/.sakimori/installs.jsonl`.
+    #[arg(long)]
+    pub install_log: Option<PathBuf>,
+    /// Emit machine-readable JSON instead of the default human report.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -596,6 +623,16 @@ pub struct ProxyStartArgs {
     /// `$XDG_CONFIG_HOME/sakimori` (or `~/.config/sakimori`).
     #[arg(long)]
     pub config_dir: Option<PathBuf>,
+    /// Disable the local install log
+    /// (`~/.sakimori/installs.jsonl`). The log is the input for
+    /// `sakimori advisories scan`; turning it off opts out of
+    /// retroactive CVE notification.
+    #[arg(long)]
+    pub no_install_log: bool,
+    /// Override the install-log path. Defaults to
+    /// `~/.sakimori/installs.jsonl`.
+    #[arg(long)]
+    pub install_log: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -858,6 +895,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 user_agent: format!("sakimori-proxy/{}", env!("CARGO_PKG_VERSION")),
                 oracle: None,
                 network_allow,
+                install_log_path: args.install_log,
+                install_log_enabled: !args.no_install_log,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())
@@ -930,7 +969,55 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Daemon {
             cmd: DaemonCommand::Stop(args),
         } => run_daemon_stop(args),
+        Command::Advisories {
+            cmd: AdvisoriesCommand::Scan(args),
+        } => run_advisories_scan(args),
     }
+}
+
+fn run_advisories_scan(args: AdvisoriesScanArgs) -> Result<()> {
+    use sakimori_core::advisories::{LiveOsvBatch, scan};
+    use sakimori_core::installs::{ExecutionMode, InstallLogger};
+
+    let path = args.install_log.unwrap_or_else(InstallLogger::default_path);
+    let logger = InstallLogger::at(&path);
+    let oracle = LiveOsvBatch::new(format!("sakimori/{}", env!("CARGO_PKG_VERSION")));
+    let report = scan(&logger, &oracle)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!(
+            "scanned {} install(s), {} unique package(s) from {}",
+            report.installs_scanned,
+            report.unique_packages,
+            path.display()
+        );
+        if report.hits.is_empty() {
+            println!("no matching advisories");
+        } else {
+            println!("{} package(s) implicated:\n", report.hits.len());
+            for hit in &report.hits {
+                let tag = match hit.execution_mode {
+                    ExecutionMode::Persistent => "persistent",
+                    ExecutionMode::Ephemeral => "ephemeral — code ran on this machine",
+                    ExecutionMode::Unknown => "unknown mode",
+                };
+                println!(
+                    "  {} {}@{}  [{}]\n    {}",
+                    hit.ecosystem,
+                    hit.name,
+                    hit.version,
+                    tag,
+                    hit.advisory_ids.join(", "),
+                );
+            }
+        }
+    }
+    if !report.hits.is_empty() {
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 async fn run_daemon_start(args: DaemonStartArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

Implements the local-first half of [roadmap #6](https://github.com/bokuweb/coronarium/blob/main/CLAUDE.md) (retroactive CVE notification).

- **proxy** now appends every pinned `(ecosystem, name, version)` fetch to `~/.sakimori/installs.jsonl` as an `InstallEvent` (resolved_at, execution_mode, user_agent). On by default; opt out with `--no-install-log` or override with `--install-log <path>`.
- **new `sakimori advisories scan`** reads the log, dedupes by `(eco, name, version)`, and batch-queries OSV.dev's `/v1/querybatch`. Hits exit non-zero so it slots into cron / CI. Local-first: only `(eco, name, version)` tuples leave the machine — never paths, timestamps, or User-Agents.
- **execution_mode** is best-effort from the User-Agent: `npx` / `pipx` / `uvx` / `cargo-install` → `ephemeral`; known package managers → `persistent`; otherwise `unknown`. The host UI distinction matters because ephemeral installs can't be "fixed" by bumping a lockfile.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 382 tests pass (10 new across `installs::` + `advisories::`)
- [x] `actionlint .github/workflows/ci.yml` — my additions clean
- [ ] CI: new **`advisories-smoke`** job runs on Ubuntu / macOS / Windows:
  - platform-neutral unit tests
  - real OSV.dev query against a hand-crafted log with `event-stream@3.3.6` (canonical malicious npm release) + benign control
  - empty / missing log edge cases
  - `--no-install-log` / `--install-log` flag exposure
- [ ] CI: **`proxy-smoke`** extended to fetch a pinned tarball (`lodash-4.17.21.tgz`) through the proxy and assert an `InstallEvent` with `execution_mode: persistent` was recorded, then round-trips through `advisories scan`.

## Out of scope (follow-ups)

- `project_path` detection — needs `install-gate shellenv` to export `SAKIMORI_PROJECT=$PWD`
- alert-fatigue gating (severity ≥ High / KEV filter) for the ephemeral-mode notifier
- `sakimori-hub` `/ingest` HTTP exporter and OTLP exporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)