### PR TITLE
feat: opt-in OTLP/HTTP exporter for proxy install events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,15 +205,21 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
    can run yourself if you want push notifications across a team."
 
    On top of (not instead of) the native `/ingest`, the proxy
-   also offers an **opt-in OTLP exporter** (`sakimori proxy start
-   --otlp-endpoint <url>`) that emits each install as an OTLP
-   LogRecord with `package.*` attributes (`package.ecosystem`,
+   also offers an **opt-in OTLP exporter** — ✅ implemented in
+   v0.36 — via `sakimori proxy start --otlp-endpoint <url>` plus
+   repeatable `--otlp-header K=V` for vendor auth. Every allowed
+   install is dispatched as an OTLP/HTTP **JSON** `LogRecord`
+   carrying `package.*` attributes (`package.ecosystem`,
    `package.name`, `package.version`, `package.resolved_at`,
-   `package.project_path`). This lets users fan installs out to
-   any existing observability backend — Datadog / Honeycomb / Loki
-   / a self-run otel-collector — without standing up sakimori-hub.
-   The two transports coexist: pick `/ingest` for advisory push
-   notifications, OTLP for general observability, both for either.
+   `package.execution_mode`, plus `package.project_path` /
+   `package.user_agent` when present). Dispatch is fire-and-forget
+   on a `spawn_blocking` worker so a slow / unreachable collector
+   never blocks an install; failures are `log::warn!`-only. The
+   user passes the full URL (typically `…/v1/logs`) — sakimori
+   does not auto-suffix because collectors may mount OTLP on a
+   custom path. The two transports coexist: pick `/ingest` for
+   advisory push notifications, OTLP for general observability,
+   both for either.
 
    **npx** works for free here (same `registry.npmjs.org` path
    the npm rewriter already handles); **Homebrew** does *not* fit

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod install;
 pub mod nuget_flatcontainer_client;
 pub mod osv;
 pub mod osv_mirror;
+pub mod otlp;
 pub mod parser;
 pub mod proxy;
 pub mod pypi_simple_client;

--- a/crates/sakimori-proxy/src/otlp.rs
+++ b/crates/sakimori-proxy/src/otlp.rs
@@ -1,0 +1,259 @@
+//! Opt-in OTLP/HTTP log exporter for install events.
+//!
+//! Roadmap item #6 (CLAUDE.md): on top of the local `/ingest`
+//! transport for sakimori-hub, the proxy can also emit each
+//! resolved install as an OTLP `LogRecord` so users can fan
+//! installs out to any existing observability backend
+//! (Datadog / Honeycomb / Loki / otel-collector) without
+//! standing up sakimori-hub.
+//!
+//! Wire format: OTLP/HTTP **JSON** (Content-Type `application/json`)
+//! against an `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`-shaped URL. The
+//! user provides the full URL (e.g. `https://otel.example.com/v1/logs`);
+//! we don't auto-append `/v1/logs` because some collectors mount
+//! OTLP on a custom path.
+//!
+//! Dispatch is fire-and-forget on a `spawn_blocking` worker: an
+//! install must never block on the exporter, and any export
+//! failure is a `log::warn!` — not a propagated error.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+
+/// Best-effort OTLP/HTTP log exporter. Cheap to clone via `Arc`.
+pub struct OtlpExporter {
+    endpoint: String,
+    headers: Vec<(String, String)>,
+    user_agent: String,
+    service_name: String,
+    service_version: String,
+}
+
+impl OtlpExporter {
+    pub fn new(endpoint: String, headers: Vec<(String, String)>, user_agent: String) -> Self {
+        Self {
+            endpoint,
+            headers,
+            user_agent,
+            service_name: "sakimori-proxy".to_string(),
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Build the OTLP `ExportLogsServiceRequest` JSON payload for a
+    /// single install event. Public for testing.
+    pub fn build_payload(&self, event: &InstallEvent) -> Value {
+        build_payload(event, &self.service_name, &self.service_version)
+    }
+
+    /// Fire-and-forget dispatch. Returns immediately; the actual
+    /// HTTP POST runs on a `spawn_blocking` worker so the hudsucker
+    /// async handler is never blocked on network I/O. Failure is
+    /// logged at `warn` level — installs must not break because the
+    /// observability backend is down.
+    pub fn dispatch(self: &Arc<Self>, event: &InstallEvent) {
+        let payload = self.build_payload(event);
+        let endpoint = self.endpoint.clone();
+        let headers = self.headers.clone();
+        let ua = self.user_agent.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = post_otlp(&endpoint, &headers, &ua, &payload) {
+                log::warn!("OTLP export to {endpoint} failed: {e:#}");
+            }
+        });
+    }
+}
+
+fn post_otlp(
+    endpoint: &str,
+    headers: &[(String, String)],
+    user_agent: &str,
+    body: &Value,
+) -> Result<()> {
+    let mut req = ureq::post(endpoint)
+        .set("content-type", "application/json")
+        .set("user-agent", user_agent)
+        .timeout(std::time::Duration::from_millis(3000));
+    for (k, v) in headers {
+        req = req.set(k, v);
+    }
+    let resp = req
+        .send_json(body.clone())
+        .with_context(|| format!("POST {endpoint}"))?;
+    let status = resp.status();
+    if !(200..300).contains(&status) {
+        anyhow::bail!("OTLP endpoint returned {status}");
+    }
+    Ok(())
+}
+
+fn build_payload(event: &InstallEvent, service_name: &str, service_version: &str) -> Value {
+    // `timestamp_nanos_opt` returns `None` only for dates outside
+    // ~1677–2262; install timestamps are always `Utc::now()` so the
+    // fallback path is effectively unreachable, but degrade to 0
+    // rather than panic if it ever fires.
+    let nanos = event.resolved_at.timestamp_nanos_opt().unwrap_or(0);
+    // OTLP JSON encodes 64-bit ints as decimal strings (per the
+    // proto3 JSON mapping) so values > 2^53 round-trip safely
+    // through Javascript-flavoured parsers.
+    let ts = nanos.to_string();
+
+    let mode_str = match event.execution_mode {
+        ExecutionMode::Persistent => "persistent",
+        ExecutionMode::Ephemeral => "ephemeral",
+        ExecutionMode::Unknown => "unknown",
+    };
+
+    let mut attrs = vec![
+        attr_str("package.ecosystem", &event.ecosystem),
+        attr_str("package.name", &event.name),
+        attr_str("package.version", &event.version),
+        attr_str("package.resolved_at", &event.resolved_at.to_rfc3339()),
+        attr_str("package.execution_mode", mode_str),
+    ];
+    if let Some(p) = event.project_path.as_deref() {
+        attrs.push(attr_str("package.project_path", p));
+    }
+    if let Some(ua) = event.user_agent.as_deref() {
+        attrs.push(attr_str("package.user_agent", ua));
+    }
+
+    json!({
+        "resourceLogs": [{
+            "resource": {
+                "attributes": [
+                    attr_str("service.name", service_name),
+                    attr_str("service.version", service_version),
+                ],
+            },
+            "scopeLogs": [{
+                "scope": { "name": "sakimori-proxy", "version": service_version },
+                "logRecords": [{
+                    "timeUnixNano": ts,
+                    "observedTimeUnixNano": ts,
+                    "severityNumber": 9,
+                    "severityText": "INFO",
+                    "body": { "stringValue": "package install" },
+                    "attributes": attrs,
+                }],
+            }],
+        }],
+    })
+}
+
+fn attr_str(key: &str, value: &str) -> Value {
+    json!({ "key": key, "value": { "stringValue": value } })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use sakimori_core::deps::Ecosystem;
+
+    fn sample_event() -> InstallEvent {
+        let mut ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_user_agent("npm/10.0.0 node/20.0.0");
+        // Pin the timestamp so the assertion is deterministic.
+        ev.resolved_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        ev
+    }
+
+    #[test]
+    fn payload_shape_matches_otlp() {
+        let exp = OtlpExporter::new(
+            "https://example.invalid/v1/logs".into(),
+            vec![],
+            "sakimori-test/0".into(),
+        );
+        let p = exp.build_payload(&sample_event());
+
+        // Top-level shape: one resourceLogs / one scopeLogs / one logRecord.
+        let logs = &p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
+        assert_eq!(logs["severityText"], "INFO");
+        assert_eq!(logs["body"]["stringValue"], "package install");
+        let expected_ns = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .timestamp_nanos_opt()
+            .unwrap()
+            .to_string();
+        assert_eq!(logs["timeUnixNano"], expected_ns);
+        assert_eq!(logs["observedTimeUnixNano"], expected_ns);
+
+        let attrs = logs["attributes"].as_array().expect("attributes array");
+        let get = |k: &str| -> Option<String> {
+            attrs.iter().find_map(|a| {
+                if a["key"] == k {
+                    a["value"]["stringValue"].as_str().map(str::to_string)
+                } else {
+                    None
+                }
+            })
+        };
+        assert_eq!(get("package.ecosystem").as_deref(), Some("npm"));
+        assert_eq!(get("package.name").as_deref(), Some("left-pad"));
+        assert_eq!(get("package.version").as_deref(), Some("1.3.0"));
+        assert_eq!(get("package.execution_mode").as_deref(), Some("persistent"));
+        assert_eq!(
+            get("package.user_agent").as_deref(),
+            Some("npm/10.0.0 node/20.0.0")
+        );
+        assert!(
+            get("package.resolved_at")
+                .unwrap()
+                .starts_with("2026-01-02")
+        );
+
+        // Resource attributes carry service identity.
+        let res_attrs = p["resourceLogs"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap();
+        assert!(
+            res_attrs.iter().any(
+                |a| a["key"] == "service.name" && a["value"]["stringValue"] == "sakimori-proxy"
+            )
+        );
+    }
+
+    #[test]
+    fn unknown_mode_serialises_as_unknown() {
+        let exp = OtlpExporter::new("http://x".into(), vec![], "ua".into());
+        let mut ev = sample_event();
+        ev.execution_mode = ExecutionMode::Unknown;
+        let p = exp.build_payload(&ev);
+        let attrs = p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let mode = attrs
+            .iter()
+            .find(|a| a["key"] == "package.execution_mode")
+            .unwrap();
+        assert_eq!(mode["value"]["stringValue"], "unknown");
+    }
+
+    #[test]
+    fn project_path_attribute_omitted_when_missing() {
+        let exp = OtlpExporter::new("http://x".into(), vec![], "ua".into());
+        let p = exp.build_payload(&sample_event());
+        let attrs = p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert!(
+            !attrs.iter().any(|a| a["key"] == "package.project_path"),
+            "absent project_path must not be serialised"
+        );
+    }
+}

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -86,6 +86,17 @@ pub struct ProxyConfig {
     /// the local-first audit log is the foundation of
     /// `sakimori advisories scan`.
     pub install_log_enabled: bool,
+    /// Optional OTLP/HTTP logs endpoint. When `Some`, every allowed
+    /// install dispatches a fire-and-forget `LogRecord` (with
+    /// `package.*` attributes) to this URL in addition to the local
+    /// install log. The URL must include the OTLP path (typically
+    /// `…/v1/logs`); we don't auto-suffix because collectors may
+    /// mount OTLP on a custom path.
+    pub otlp_endpoint: Option<String>,
+    /// Extra headers attached to every OTLP request — typically
+    /// `Authorization: Bearer …` for vendor backends. Ignored when
+    /// `otlp_endpoint` is `None`.
+    pub otlp_headers: Vec<(String, String)>,
 }
 
 impl ProxyConfig {
@@ -107,6 +118,8 @@ impl ProxyConfig {
             network_allow: None,
             install_log_path: None,
             install_log_enabled: true,
+            otlp_endpoint: None,
+            otlp_headers: Vec::new(),
         })
     }
 }
@@ -253,6 +266,14 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
     } else {
         None
     };
+    let otlp_exporter = cfg.otlp_endpoint.as_ref().map(|endpoint| {
+        log::info!("OTLP log export → {endpoint}");
+        Arc::new(crate::otlp::OtlpExporter::new(
+            endpoint.clone(),
+            cfg.otlp_headers.clone(),
+            cfg.user_agent.clone(),
+        ))
+    });
     let handler = SakimoriHandler {
         parsers: Arc::new(default_parsers()),
         decider,
@@ -263,6 +284,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
         network_allow: cfg.network_allow.map(Arc::new),
         install_logger,
+        otlp_exporter,
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -358,6 +380,12 @@ struct SakimoriHandler {
     pypi_simple: PypiSimpleClient,
     /// Append-only install log. `None` disables logging.
     install_logger: Option<Arc<InstallLogger>>,
+    /// Optional OTLP/HTTP log exporter. `None` disables OTLP fan-out.
+    /// Coexists with `install_logger`: per CLAUDE.md roadmap #6 the
+    /// two transports complement each other (`/ingest` is for
+    /// sakimori-hub push notifications, OTLP is for generic
+    /// observability backends).
+    otlp_exporter: Option<Arc<crate::otlp::OtlpExporter>>,
     /// Hostname allow-list. `None` (or empty) → unrestricted egress.
     /// `Some(non-empty)` → default-deny: any CONNECT or plain-HTTP
     /// request whose target host doesn't match returns 403 before
@@ -430,17 +458,22 @@ impl HttpHandler for SakimoriHandler {
                 let now = Utc::now();
                 match self.decider.decide(ecosystem, &name, &version, now) {
                     Decision::Allow => {
-                        if let Some(logger) = self.install_logger.as_ref() {
+                        if self.install_logger.is_some() || self.otlp_exporter.is_some() {
                             let mode = classify_execution_mode(&user_agent);
                             let mut ev =
                                 InstallEvent::new(ecosystem, &name, &version).with_mode(mode);
                             if !user_agent.is_empty() {
                                 ev = ev.with_user_agent(&user_agent);
                             }
-                            if let Err(e) = logger.record(&ev) {
+                            if let Some(logger) = self.install_logger.as_ref()
+                                && let Err(e) = logger.record(&ev)
+                            {
                                 // Non-fatal: an unwritable install log
                                 // must not break package installs.
                                 log::warn!("install log write failed: {e:#}");
+                            }
+                            if let Some(exporter) = self.otlp_exporter.as_ref() {
+                                exporter.dispatch(&ev);
                             }
                         }
                         RequestOrResponse::Request(req)

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -633,6 +633,28 @@ pub struct ProxyStartArgs {
     /// `~/.sakimori/installs.jsonl`.
     #[arg(long)]
     pub install_log: Option<PathBuf>,
+    /// Opt-in OTLP/HTTP logs endpoint. When set, every allowed
+    /// install is also exported as an OTLP `LogRecord` with
+    /// `package.*` attributes — for fan-out to Datadog / Honeycomb /
+    /// Loki / a self-run otel-collector without standing up
+    /// sakimori-hub. Pass the full URL (typically ending in
+    /// `/v1/logs`); we don't auto-suffix. Coexists with the local
+    /// install log.
+    #[arg(long, value_name = "URL")]
+    pub otlp_endpoint: Option<String>,
+    /// Additional header sent on every OTLP request, in `KEY=VALUE`
+    /// form. Repeatable. Typical use: `--otlp-header
+    /// Authorization="Bearer …"` for vendor backends. Ignored when
+    /// `--otlp-endpoint` is not set.
+    #[arg(long = "otlp-header", value_name = "K=V", value_parser = parse_kv)]
+    pub otlp_headers: Vec<(String, String)>,
+}
+
+fn parse_kv(s: &str) -> std::result::Result<(String, String), String> {
+    match s.split_once('=') {
+        Some((k, v)) if !k.is_empty() => Ok((k.to_string(), v.to_string())),
+        _ => Err(format!("expected KEY=VALUE, got `{s}`")),
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -897,6 +919,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 network_allow,
                 install_log_path: args.install_log,
                 install_log_enabled: !args.no_install_log,
+                otlp_endpoint: args.otlp_endpoint,
+                otlp_headers: args.otlp_headers,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())


### PR DESCRIPTION
## Summary
- Adds `sakimori proxy start --otlp-endpoint <url>` (plus repeatable `--otlp-header K=V` for vendor auth) — every allowed install is dispatched as an OTLP/HTTP **JSON** `LogRecord` with `package.*` attributes (`ecosystem`, `name`, `version`, `resolved_at`, `execution_mode`, optional `project_path` / `user_agent`).
- Coexists with the local install log: pick `/ingest` (future sakimori-hub) for advisory push notifications, OTLP for generic observability, both for either.
- Fire-and-forget on a `spawn_blocking` worker — a slow / unreachable collector never blocks an install; failures are `log::warn!`-only.
- Closes the OTLP half of roadmap item #6 in CLAUDE.md.

## Design notes
- OTLP/HTTP JSON (Content-Type `application/json`), not protobuf — keeps the dep tree small (reuses the existing `ureq` + `serde_json`).
- User passes the full URL (typically `…/v1/logs`); we don't auto-suffix, since collectors may mount OTLP on a custom path.
- 64-bit `timeUnixNano` values are serialised as decimal strings per the proto3 JSON mapping.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (385 passing; 3 new unit tests in `otlp::tests` cover payload shape, `unknown` execution mode, and absent-`project_path` omission)
- [ ] Manual smoke against an `otel-collector` instance — recommended before tagging the release, not part of CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)