### PR TITLE
feat: detect CONFIG_BPF_KPROBE_OVERRIDE + doctor surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,15 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.
+   Partial progress (v0.37): `crate::kprobe_override::detect()`
+   reads `/boot/config-$(uname -r)` and reports
+   `Available` / `Unsupported` / `Unknown` so the rest of the
+   loader can light up the kprobe path opportunistically, and
+   `sakimori doctor` surfaces a "Kernel pre-syscall block" row
+   with strength-aware messaging (the warn path explicitly
+   reassures users that the existing SIGKILL tripwire is still
+   in effect). The kprobe BPF program + attach path is the
+   next slice.
 5. **macOS live block** — either a Network Extension (heavy, needs
    signing) or an HTTPS proxy (see #2).
 6. **Retroactive CVE notification for past installs** — local-first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,15 +205,21 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
    can run yourself if you want push notifications across a team."
 
    On top of (not instead of) the native `/ingest`, the proxy
-   also offers an **opt-in OTLP exporter** (`sakimori proxy start
-   --otlp-endpoint <url>`) that emits each install as an OTLP
-   LogRecord with `package.*` attributes (`package.ecosystem`,
+   also offers an **opt-in OTLP exporter** — ✅ implemented in
+   v0.36 — via `sakimori proxy start --otlp-endpoint <url>` plus
+   repeatable `--otlp-header K=V` for vendor auth. Every allowed
+   install is dispatched as an OTLP/HTTP **JSON** `LogRecord`
+   carrying `package.*` attributes (`package.ecosystem`,
    `package.name`, `package.version`, `package.resolved_at`,
-   `package.project_path`). This lets users fan installs out to
-   any existing observability backend — Datadog / Honeycomb / Loki
-   / a self-run otel-collector — without standing up sakimori-hub.
-   The two transports coexist: pick `/ingest` for advisory push
-   notifications, OTLP for general observability, both for either.
+   `package.execution_mode`, plus `package.project_path` /
+   `package.user_agent` when present). Dispatch is fire-and-forget
+   on a `spawn_blocking` worker so a slow / unreachable collector
+   never blocks an install; failures are `log::warn!`-only. The
+   user passes the full URL (typically `…/v1/logs`) — sakimori
+   does not auto-suffix because collectors may mount OTLP on a
+   custom path. The two transports coexist: pick `/ingest` for
+   advisory push notifications, OTLP for general observability,
+   both for either.
 
    **npx** works for free here (same `registry.npmjs.org` path
    the npm rewriter already handles); **Homebrew** does *not* fit

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod install;
 pub mod nuget_flatcontainer_client;
 pub mod osv;
 pub mod osv_mirror;
+pub mod otlp;
 pub mod parser;
 pub mod proxy;
 pub mod pypi_simple_client;

--- a/crates/sakimori-proxy/src/otlp.rs
+++ b/crates/sakimori-proxy/src/otlp.rs
@@ -1,0 +1,259 @@
+//! Opt-in OTLP/HTTP log exporter for install events.
+//!
+//! Roadmap item #6 (CLAUDE.md): on top of the local `/ingest`
+//! transport for sakimori-hub, the proxy can also emit each
+//! resolved install as an OTLP `LogRecord` so users can fan
+//! installs out to any existing observability backend
+//! (Datadog / Honeycomb / Loki / otel-collector) without
+//! standing up sakimori-hub.
+//!
+//! Wire format: OTLP/HTTP **JSON** (Content-Type `application/json`)
+//! against an `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`-shaped URL. The
+//! user provides the full URL (e.g. `https://otel.example.com/v1/logs`);
+//! we don't auto-append `/v1/logs` because some collectors mount
+//! OTLP on a custom path.
+//!
+//! Dispatch is fire-and-forget on a `spawn_blocking` worker: an
+//! install must never block on the exporter, and any export
+//! failure is a `log::warn!` — not a propagated error.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+
+/// Best-effort OTLP/HTTP log exporter. Cheap to clone via `Arc`.
+pub struct OtlpExporter {
+    endpoint: String,
+    headers: Vec<(String, String)>,
+    user_agent: String,
+    service_name: String,
+    service_version: String,
+}
+
+impl OtlpExporter {
+    pub fn new(endpoint: String, headers: Vec<(String, String)>, user_agent: String) -> Self {
+        Self {
+            endpoint,
+            headers,
+            user_agent,
+            service_name: "sakimori-proxy".to_string(),
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Build the OTLP `ExportLogsServiceRequest` JSON payload for a
+    /// single install event. Public for testing.
+    pub fn build_payload(&self, event: &InstallEvent) -> Value {
+        build_payload(event, &self.service_name, &self.service_version)
+    }
+
+    /// Fire-and-forget dispatch. Returns immediately; the actual
+    /// HTTP POST runs on a `spawn_blocking` worker so the hudsucker
+    /// async handler is never blocked on network I/O. Failure is
+    /// logged at `warn` level — installs must not break because the
+    /// observability backend is down.
+    pub fn dispatch(self: &Arc<Self>, event: &InstallEvent) {
+        let payload = self.build_payload(event);
+        let endpoint = self.endpoint.clone();
+        let headers = self.headers.clone();
+        let ua = self.user_agent.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = post_otlp(&endpoint, &headers, &ua, &payload) {
+                log::warn!("OTLP export to {endpoint} failed: {e:#}");
+            }
+        });
+    }
+}
+
+fn post_otlp(
+    endpoint: &str,
+    headers: &[(String, String)],
+    user_agent: &str,
+    body: &Value,
+) -> Result<()> {
+    let mut req = ureq::post(endpoint)
+        .set("content-type", "application/json")
+        .set("user-agent", user_agent)
+        .timeout(std::time::Duration::from_millis(3000));
+    for (k, v) in headers {
+        req = req.set(k, v);
+    }
+    let resp = req
+        .send_json(body.clone())
+        .with_context(|| format!("POST {endpoint}"))?;
+    let status = resp.status();
+    if !(200..300).contains(&status) {
+        anyhow::bail!("OTLP endpoint returned {status}");
+    }
+    Ok(())
+}
+
+fn build_payload(event: &InstallEvent, service_name: &str, service_version: &str) -> Value {
+    // `timestamp_nanos_opt` returns `None` only for dates outside
+    // ~1677–2262; install timestamps are always `Utc::now()` so the
+    // fallback path is effectively unreachable, but degrade to 0
+    // rather than panic if it ever fires.
+    let nanos = event.resolved_at.timestamp_nanos_opt().unwrap_or(0);
+    // OTLP JSON encodes 64-bit ints as decimal strings (per the
+    // proto3 JSON mapping) so values > 2^53 round-trip safely
+    // through Javascript-flavoured parsers.
+    let ts = nanos.to_string();
+
+    let mode_str = match event.execution_mode {
+        ExecutionMode::Persistent => "persistent",
+        ExecutionMode::Ephemeral => "ephemeral",
+        ExecutionMode::Unknown => "unknown",
+    };
+
+    let mut attrs = vec![
+        attr_str("package.ecosystem", &event.ecosystem),
+        attr_str("package.name", &event.name),
+        attr_str("package.version", &event.version),
+        attr_str("package.resolved_at", &event.resolved_at.to_rfc3339()),
+        attr_str("package.execution_mode", mode_str),
+    ];
+    if let Some(p) = event.project_path.as_deref() {
+        attrs.push(attr_str("package.project_path", p));
+    }
+    if let Some(ua) = event.user_agent.as_deref() {
+        attrs.push(attr_str("package.user_agent", ua));
+    }
+
+    json!({
+        "resourceLogs": [{
+            "resource": {
+                "attributes": [
+                    attr_str("service.name", service_name),
+                    attr_str("service.version", service_version),
+                ],
+            },
+            "scopeLogs": [{
+                "scope": { "name": "sakimori-proxy", "version": service_version },
+                "logRecords": [{
+                    "timeUnixNano": ts,
+                    "observedTimeUnixNano": ts,
+                    "severityNumber": 9,
+                    "severityText": "INFO",
+                    "body": { "stringValue": "package install" },
+                    "attributes": attrs,
+                }],
+            }],
+        }],
+    })
+}
+
+fn attr_str(key: &str, value: &str) -> Value {
+    json!({ "key": key, "value": { "stringValue": value } })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use sakimori_core::deps::Ecosystem;
+
+    fn sample_event() -> InstallEvent {
+        let mut ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_user_agent("npm/10.0.0 node/20.0.0");
+        // Pin the timestamp so the assertion is deterministic.
+        ev.resolved_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        ev
+    }
+
+    #[test]
+    fn payload_shape_matches_otlp() {
+        let exp = OtlpExporter::new(
+            "https://example.invalid/v1/logs".into(),
+            vec![],
+            "sakimori-test/0".into(),
+        );
+        let p = exp.build_payload(&sample_event());
+
+        // Top-level shape: one resourceLogs / one scopeLogs / one logRecord.
+        let logs = &p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
+        assert_eq!(logs["severityText"], "INFO");
+        assert_eq!(logs["body"]["stringValue"], "package install");
+        let expected_ns = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .timestamp_nanos_opt()
+            .unwrap()
+            .to_string();
+        assert_eq!(logs["timeUnixNano"], expected_ns);
+        assert_eq!(logs["observedTimeUnixNano"], expected_ns);
+
+        let attrs = logs["attributes"].as_array().expect("attributes array");
+        let get = |k: &str| -> Option<String> {
+            attrs.iter().find_map(|a| {
+                if a["key"] == k {
+                    a["value"]["stringValue"].as_str().map(str::to_string)
+                } else {
+                    None
+                }
+            })
+        };
+        assert_eq!(get("package.ecosystem").as_deref(), Some("npm"));
+        assert_eq!(get("package.name").as_deref(), Some("left-pad"));
+        assert_eq!(get("package.version").as_deref(), Some("1.3.0"));
+        assert_eq!(get("package.execution_mode").as_deref(), Some("persistent"));
+        assert_eq!(
+            get("package.user_agent").as_deref(),
+            Some("npm/10.0.0 node/20.0.0")
+        );
+        assert!(
+            get("package.resolved_at")
+                .unwrap()
+                .starts_with("2026-01-02")
+        );
+
+        // Resource attributes carry service identity.
+        let res_attrs = p["resourceLogs"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap();
+        assert!(
+            res_attrs.iter().any(
+                |a| a["key"] == "service.name" && a["value"]["stringValue"] == "sakimori-proxy"
+            )
+        );
+    }
+
+    #[test]
+    fn unknown_mode_serialises_as_unknown() {
+        let exp = OtlpExporter::new("http://x".into(), vec![], "ua".into());
+        let mut ev = sample_event();
+        ev.execution_mode = ExecutionMode::Unknown;
+        let p = exp.build_payload(&ev);
+        let attrs = p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let mode = attrs
+            .iter()
+            .find(|a| a["key"] == "package.execution_mode")
+            .unwrap();
+        assert_eq!(mode["value"]["stringValue"], "unknown");
+    }
+
+    #[test]
+    fn project_path_attribute_omitted_when_missing() {
+        let exp = OtlpExporter::new("http://x".into(), vec![], "ua".into());
+        let p = exp.build_payload(&sample_event());
+        let attrs = p["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]["attributes"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert!(
+            !attrs.iter().any(|a| a["key"] == "package.project_path"),
+            "absent project_path must not be serialised"
+        );
+    }
+}

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -86,6 +86,17 @@ pub struct ProxyConfig {
     /// the local-first audit log is the foundation of
     /// `sakimori advisories scan`.
     pub install_log_enabled: bool,
+    /// Optional OTLP/HTTP logs endpoint. When `Some`, every allowed
+    /// install dispatches a fire-and-forget `LogRecord` (with
+    /// `package.*` attributes) to this URL in addition to the local
+    /// install log. The URL must include the OTLP path (typically
+    /// `…/v1/logs`); we don't auto-suffix because collectors may
+    /// mount OTLP on a custom path.
+    pub otlp_endpoint: Option<String>,
+    /// Extra headers attached to every OTLP request — typically
+    /// `Authorization: Bearer …` for vendor backends. Ignored when
+    /// `otlp_endpoint` is `None`.
+    pub otlp_headers: Vec<(String, String)>,
 }
 
 impl ProxyConfig {
@@ -107,6 +118,8 @@ impl ProxyConfig {
             network_allow: None,
             install_log_path: None,
             install_log_enabled: true,
+            otlp_endpoint: None,
+            otlp_headers: Vec::new(),
         })
     }
 }
@@ -253,6 +266,14 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
     } else {
         None
     };
+    let otlp_exporter = cfg.otlp_endpoint.as_ref().map(|endpoint| {
+        log::info!("OTLP log export → {endpoint}");
+        Arc::new(crate::otlp::OtlpExporter::new(
+            endpoint.clone(),
+            cfg.otlp_headers.clone(),
+            cfg.user_agent.clone(),
+        ))
+    });
     let handler = SakimoriHandler {
         parsers: Arc::new(default_parsers()),
         decider,
@@ -263,6 +284,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
         network_allow: cfg.network_allow.map(Arc::new),
         install_logger,
+        otlp_exporter,
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
@@ -358,6 +380,12 @@ struct SakimoriHandler {
     pypi_simple: PypiSimpleClient,
     /// Append-only install log. `None` disables logging.
     install_logger: Option<Arc<InstallLogger>>,
+    /// Optional OTLP/HTTP log exporter. `None` disables OTLP fan-out.
+    /// Coexists with `install_logger`: per CLAUDE.md roadmap #6 the
+    /// two transports complement each other (`/ingest` is for
+    /// sakimori-hub push notifications, OTLP is for generic
+    /// observability backends).
+    otlp_exporter: Option<Arc<crate::otlp::OtlpExporter>>,
     /// Hostname allow-list. `None` (or empty) → unrestricted egress.
     /// `Some(non-empty)` → default-deny: any CONNECT or plain-HTTP
     /// request whose target host doesn't match returns 403 before
@@ -430,17 +458,22 @@ impl HttpHandler for SakimoriHandler {
                 let now = Utc::now();
                 match self.decider.decide(ecosystem, &name, &version, now) {
                     Decision::Allow => {
-                        if let Some(logger) = self.install_logger.as_ref() {
+                        if self.install_logger.is_some() || self.otlp_exporter.is_some() {
                             let mode = classify_execution_mode(&user_agent);
                             let mut ev =
                                 InstallEvent::new(ecosystem, &name, &version).with_mode(mode);
                             if !user_agent.is_empty() {
                                 ev = ev.with_user_agent(&user_agent);
                             }
-                            if let Err(e) = logger.record(&ev) {
+                            if let Some(logger) = self.install_logger.as_ref()
+                                && let Err(e) = logger.record(&ev)
+                            {
                                 // Non-fatal: an unwritable install log
                                 // must not break package installs.
                                 log::warn!("install log write failed: {e:#}");
+                            }
+                            if let Some(exporter) = self.otlp_exporter.as_ref() {
+                                exporter.dispatch(&ev);
                             }
                         }
                         RequestOrResponse::Request(req)

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -633,6 +633,28 @@ pub struct ProxyStartArgs {
     /// `~/.sakimori/installs.jsonl`.
     #[arg(long)]
     pub install_log: Option<PathBuf>,
+    /// Opt-in OTLP/HTTP logs endpoint. When set, every allowed
+    /// install is also exported as an OTLP `LogRecord` with
+    /// `package.*` attributes — for fan-out to Datadog / Honeycomb /
+    /// Loki / a self-run otel-collector without standing up
+    /// sakimori-hub. Pass the full URL (typically ending in
+    /// `/v1/logs`); we don't auto-suffix. Coexists with the local
+    /// install log.
+    #[arg(long, value_name = "URL")]
+    pub otlp_endpoint: Option<String>,
+    /// Additional header sent on every OTLP request, in `KEY=VALUE`
+    /// form. Repeatable. Typical use: `--otlp-header
+    /// Authorization="Bearer …"` for vendor backends. Ignored when
+    /// `--otlp-endpoint` is not set.
+    #[arg(long = "otlp-header", value_name = "K=V", value_parser = parse_kv)]
+    pub otlp_headers: Vec<(String, String)>,
+}
+
+fn parse_kv(s: &str) -> std::result::Result<(String, String), String> {
+    match s.split_once('=') {
+        Some((k, v)) if !k.is_empty() => Ok((k.to_string(), v.to_string())),
+        _ => Err(format!("expected KEY=VALUE, got `{s}`")),
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -897,6 +919,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 network_allow,
                 install_log_path: args.install_log,
                 install_log_enabled: !args.no_install_log,
+                otlp_endpoint: args.otlp_endpoint,
+                otlp_headers: args.otlp_headers,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -1566,6 +1566,7 @@ fn run_doctor(args: DoctorArgs) -> Result<()> {
         rc_path,
         daemon_unit_path,
         daemon_pidfile: args.daemon_pidfile,
+        kprobe_override: Some(crate::kprobe_override::detect()),
     };
     let results = crate::doctor::run_checks(&inputs);
     print!("{}", crate::doctor::render_report(&results));

--- a/crates/sakimori/src/doctor.rs
+++ b/crates/sakimori/src/doctor.rs
@@ -11,6 +11,8 @@ use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::kprobe_override::KprobeOverrideStatus;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckStatus {
     Ok,
@@ -128,6 +130,11 @@ pub struct DoctorInputs {
     /// and nothing told me" situations on long-running runners.
     /// `None` means "skip this check".
     pub daemon_pidfile: Option<PathBuf>,
+    /// Optional pre-detected kprobe-override status. When `Some`,
+    /// the doctor adds a "Kernel pre-syscall block" row reflecting
+    /// it. Detection itself is in [`crate::kprobe_override`] — the
+    /// doctor takes it as input so the renderer stays pure.
+    pub kprobe_override: Option<KprobeOverrideStatus>,
 }
 
 /// Run every check with the given inputs. Pure-ish — does read the
@@ -150,7 +157,41 @@ pub fn run_checks(inp: &DoctorInputs) -> Vec<CheckResult> {
     if let Some(p) = &inp.daemon_pidfile {
         out.push(check_daemon_pidfile(p));
     }
+    if let Some(k) = &inp.kprobe_override {
+        out.push(check_kprobe_override(k));
+    }
     out
+}
+
+fn check_kprobe_override(status: &KprobeOverrideStatus) -> CheckResult {
+    // Block-strength reporting: per CLAUDE.md roadmap #4 the
+    // file/exec deny path is a SIGKILL tripwire today; with
+    // CONFIG_BPF_KPROBE_OVERRIDE=y we can upgrade it to a real
+    // pre-syscall block. Until the kprobe userspace landing-pad
+    // exists, this check is purely informational — it does not
+    // (and must not) fail the doctor.
+    match status {
+        KprobeOverrideStatus::Available { config_path } => CheckResult::ok(
+            "Kernel pre-syscall block",
+            format!(
+                "CONFIG_BPF_KPROBE_OVERRIDE=y (from {})",
+                config_path.display()
+            ),
+        ),
+        KprobeOverrideStatus::Unsupported { config_path } => CheckResult::warn(
+            "Kernel pre-syscall block",
+            format!(
+                "kernel built without CONFIG_BPF_KPROBE_OVERRIDE (per {})",
+                config_path.display()
+            ),
+            "file.deny/exec.deny still work as SIGKILL tripwires; rebuild the kernel with CONFIG_BPF_KPROBE_OVERRIDE=y for true pre-syscall block",
+        ),
+        KprobeOverrideStatus::Unknown { reason } => CheckResult::warn(
+            "Kernel pre-syscall block",
+            format!("status unknown ({reason})"),
+            "install the matching linux-headers / kernel-devel package, or ignore — file.deny/exec.deny remain effective as SIGKILL tripwires",
+        ),
+    }
 }
 
 fn check_daemon_pidfile(path: &Path) -> CheckResult {
@@ -485,6 +526,36 @@ mod tests {
         let r = check_daemon_pidfile(&d);
         assert_eq!(r.status, CheckStatus::Ok);
         std::fs::remove_file(&d).ok();
+    }
+
+    #[test]
+    fn kprobe_override_available_is_ok() {
+        let r = check_kprobe_override(&KprobeOverrideStatus::Available {
+            config_path: PathBuf::from("/boot/config-6.6.0"),
+        });
+        assert_eq!(r.status, CheckStatus::Ok);
+        assert!(r.detail.contains("CONFIG_BPF_KPROBE_OVERRIDE"));
+    }
+
+    #[test]
+    fn kprobe_override_unsupported_is_warn_with_fallback_hint() {
+        let r = check_kprobe_override(&KprobeOverrideStatus::Unsupported {
+            config_path: PathBuf::from("/boot/config-5.10.0"),
+        });
+        assert_eq!(r.status, CheckStatus::Warn);
+        // Must reassure the user that file.deny/exec.deny still work.
+        let hint = r.hint.unwrap();
+        assert!(hint.contains("tripwire") || hint.contains("SIGKILL"));
+    }
+
+    #[test]
+    fn kprobe_override_unknown_is_warn_not_fail() {
+        // No readable kernel config — block strength is genuinely
+        // unknowable; we must not exit non-zero for this.
+        let r = check_kprobe_override(&KprobeOverrideStatus::Unknown {
+            reason: "missing /boot/config-x".into(),
+        });
+        assert_eq!(r.status, CheckStatus::Warn);
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/sakimori/src/kprobe_override.rs
+++ b/crates/sakimori/src/kprobe_override.rs
@@ -58,6 +58,10 @@ pub enum KprobeOverrideStatus {
 }
 
 impl KprobeOverrideStatus {
+    // Not used by the doctor surface — only the loader's kprobe-attach
+    // gate calls this, which lands in the follow-up PR. Kept here so
+    // that PR doesn't have to also touch this file.
+    #[allow(dead_code)]
     pub fn is_available(&self) -> bool {
         matches!(self, KprobeOverrideStatus::Available { .. })
     }

--- a/crates/sakimori/src/kprobe_override.rs
+++ b/crates/sakimori/src/kprobe_override.rs
@@ -1,0 +1,234 @@
+//! Runtime detection of `CONFIG_BPF_KPROBE_OVERRIDE`.
+//!
+//! Background — CLAUDE.md roadmap #4: today `file.deny` in `mode:
+//! block` is a "tripwire" (`bpf_send_signal(SIGKILL)` on the
+//! offending process after the open syscall has been issued). The
+//! file descriptor may briefly exist; the process dies before it
+//! can read from it. A clean pre-syscall block would attach a
+//! kprobe to `do_sys_openat2` and call `bpf_override_return(ctx,
+//! -EPERM)` so the syscall fails outright — but that helper is
+//! only available when the kernel was built with
+//! `CONFIG_BPF_KPROBE_OVERRIDE=y`.
+//!
+//! This module gives the rest of the codebase a *cheap, runtime*
+//! answer to "can we use kprobe override on this kernel?" so we
+//! can (a) light up the kprobe path opportunistically when it's
+//! available and (b) tell users via `sakimori doctor` how strong
+//! their block enforcement actually is.
+//!
+//! Detection strategy:
+//! 1. Try `/boot/config-$(uname -r)` — the canonical place
+//!    distros drop the kernel build config.
+//! 2. (Future) `/proc/config.gz` — gz-compressed text. Skipped for
+//!    now to avoid adding `flate2` as a dep; can be layered in
+//!    later behind a feature flag without changing the public API.
+//!
+//! When neither is readable we return `Unknown` rather than
+//! pretending the feature is off — the doctor surface treats
+//! that as a `warn` (informational) rather than a `fail`.
+//!
+//! The whole detection path is `cfg(target_os = "linux")`. On
+//! other platforms the public API still compiles but always
+//! returns `Unknown` so callers don't need their own cfg gates.
+
+use std::path::{Path, PathBuf};
+
+/// Result of probing the running kernel for `bpf_override_return`
+/// support. Surfaced both to the loader (gates whether we try to
+/// attach the kprobe at all) and to `sakimori doctor` (informs
+/// the user about block strength).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KprobeOverrideStatus {
+    /// `CONFIG_BPF_KPROBE_OVERRIDE=y` was found in a kernel config
+    /// we could read. `bpf_override_return` should work — provided
+    /// the target function (`do_sys_openat2`, `__x64_sys_execve`,
+    /// etc.) is in the kernel's error-injection allow-list, which
+    /// we check separately at attach time.
+    Available { config_path: PathBuf },
+    /// Kernel config was readable and explicitly says
+    /// `CONFIG_BPF_KPROBE_OVERRIDE` is not set (= n / = m / absent
+    /// entirely). `bpf_override_return` will be rejected by the
+    /// verifier — we must fall back to the SIGKILL tripwire.
+    Unsupported { config_path: PathBuf },
+    /// No readable kernel config in any expected location.
+    /// Block strength is genuinely unknown; the loader should
+    /// optimistically attempt the kprobe attach and degrade on
+    /// `EPERM` / verifier-reject rather than refuse outright.
+    Unknown { reason: String },
+}
+
+impl KprobeOverrideStatus {
+    pub fn is_available(&self) -> bool {
+        matches!(self, KprobeOverrideStatus::Available { .. })
+    }
+}
+
+/// Probe the current kernel. Pure-ish — reads files but mutates
+/// nothing. Cheap enough to call from `sakimori doctor` /
+/// startup paths without caching.
+#[cfg(target_os = "linux")]
+pub fn detect() -> KprobeOverrideStatus {
+    let release = match kernel_release() {
+        Some(r) => r,
+        None => {
+            return KprobeOverrideStatus::Unknown {
+                reason: "uname() failed".into(),
+            };
+        }
+    };
+    let path = PathBuf::from(format!("/boot/config-{release}"));
+    detect_from_config_file(&path)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn detect() -> KprobeOverrideStatus {
+    KprobeOverrideStatus::Unknown {
+        reason: "kprobe override is Linux-only".into(),
+    }
+}
+
+/// Test seam: scan a specific config file path. Exposed so the
+/// unit tests can feed in a synthetic kernel config without
+/// touching `/boot`.
+pub fn detect_from_config_file(path: &Path) -> KprobeOverrideStatus {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) => {
+            return KprobeOverrideStatus::Unknown {
+                reason: format!("reading {}: {e}", path.display()),
+            };
+        }
+    };
+    classify(&text, path)
+}
+
+/// Inspect kernel-config text for `CONFIG_BPF_KPROBE_OVERRIDE`.
+/// Public for direct unit testing without filesystem access.
+pub fn classify(config_text: &str, path: &Path) -> KprobeOverrideStatus {
+    // Distro kernel configs are line-oriented `KEY=VALUE` or
+    // `# KEY is not set`. We accept both `=y` and `=m` as
+    // "Available" — the helper itself doesn't care about module
+    // vs built-in. Anything else (explicit `not set`, missing
+    // entirely, garbled) → `Unsupported`.
+    for line in config_text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("CONFIG_BPF_KPROBE_OVERRIDE=") {
+            let val = rest.trim();
+            if val.eq_ignore_ascii_case("y") || val.eq_ignore_ascii_case("m") {
+                return KprobeOverrideStatus::Available {
+                    config_path: path.to_path_buf(),
+                };
+            } else {
+                return KprobeOverrideStatus::Unsupported {
+                    config_path: path.to_path_buf(),
+                };
+            }
+        }
+    }
+    KprobeOverrideStatus::Unsupported {
+        config_path: path.to_path_buf(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn kernel_release() -> Option<String> {
+    // SAFETY: `utsname` is a POD whose every field is a fixed
+    // C-string buffer; `uname()` writes into it and returns 0
+    // on success. The buffer is owned by us for the duration of
+    // the read; we copy the NUL-terminated `release` field out
+    // immediately.
+    use std::ffi::CStr;
+    let mut buf: libc::utsname = unsafe { std::mem::zeroed() };
+    let r = unsafe { libc::uname(&mut buf) };
+    if r != 0 {
+        return None;
+    }
+    let cstr = unsafe { CStr::from_ptr(buf.release.as_ptr()) };
+    Some(cstr.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_y_is_available() {
+        let cfg = "# noise\nCONFIG_BPF=y\nCONFIG_BPF_KPROBE_OVERRIDE=y\nCONFIG_OTHER=n\n";
+        let r = classify(cfg, Path::new("/boot/config-x"));
+        assert!(r.is_available(), "got {r:?}");
+    }
+
+    #[test]
+    fn classify_m_is_also_available() {
+        // The helper doesn't care about module vs built-in.
+        let cfg = "CONFIG_BPF_KPROBE_OVERRIDE=m\n";
+        let r = classify(cfg, Path::new("/boot/config-x"));
+        assert!(r.is_available(), "got {r:?}");
+    }
+
+    #[test]
+    fn classify_not_set_is_unsupported() {
+        let cfg = "# CONFIG_BPF_KPROBE_OVERRIDE is not set\nCONFIG_OTHER=y\n";
+        let r = classify(cfg, Path::new("/boot/config-x"));
+        assert!(
+            matches!(r, KprobeOverrideStatus::Unsupported { .. }),
+            "got {r:?}"
+        );
+    }
+
+    #[test]
+    fn classify_absent_is_unsupported() {
+        // Older kernels (pre-4.16) never had the symbol at all.
+        let cfg = "CONFIG_BPF=y\nCONFIG_TRACING=y\n";
+        let r = classify(cfg, Path::new("/boot/config-x"));
+        assert!(
+            matches!(r, KprobeOverrideStatus::Unsupported { .. }),
+            "got {r:?}"
+        );
+    }
+
+    #[test]
+    fn classify_n_value_is_unsupported() {
+        let cfg = "CONFIG_BPF_KPROBE_OVERRIDE=n\n";
+        let r = classify(cfg, Path::new("/boot/config-x"));
+        assert!(
+            matches!(r, KprobeOverrideStatus::Unsupported { .. }),
+            "got {r:?}"
+        );
+    }
+
+    #[test]
+    fn detect_from_missing_file_is_unknown() {
+        let r = detect_from_config_file(Path::new("/definitely/no/such/path"));
+        match r {
+            KprobeOverrideStatus::Unknown { reason } => assert!(
+                reason.contains("/definitely/no/such/path"),
+                "reason should name the path: {reason:?}"
+            ),
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_from_present_config_round_trips() {
+        let d = std::env::temp_dir().join(format!(
+            "sakimori-kprobe-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        let p = d.join("config-fake");
+        std::fs::write(&p, "CONFIG_BPF_KPROBE_OVERRIDE=y\n").unwrap();
+        assert!(detect_from_config_file(&p).is_available());
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_always_unknown() {
+        assert!(matches!(detect(), KprobeOverrideStatus::Unknown { .. }));
+    }
+}

--- a/crates/sakimori/src/main.rs
+++ b/crates/sakimori/src/main.rs
@@ -7,6 +7,7 @@ mod doctor;
 mod enforcer;
 mod events;
 mod install_gate;
+mod kprobe_override;
 mod loader;
 mod policy;
 mod resolve;


### PR DESCRIPTION
## Summary
First slice of roadmap #4 (Linux pre-syscall block via `bpf_override_return`). Adds:
- `crate::kprobe_override::detect()` — reads `/boot/config-$(uname -r)` and classifies as `Available` / `Unsupported` / `Unknown`.
- New "Kernel pre-syscall block" row in `sakimori doctor` with strength-aware messaging.

**Informational only** — the existing SIGKILL tripwire path is unchanged. The actual kprobe BPF program + attach is the next PR; this lands the detection plumbing so the loader can gate the attach attempt cheaply and users get an upfront diagnostic about block enforcement strength.

## Design notes
- `=y` and `=m` both count as Available (the helper doesn't care about builtin vs module).
- Unreadable config → `Unknown` (warn, not fail). The loader will optimistically attempt the kprobe attach and degrade on verifier reject — refusing outright would regress users who happen to be missing `linux-headers`.
- Warn path **explicitly reassures** that `file.deny` / `exec.deny` still work as SIGKILL tripwires. Losing the upgrade is not the same as losing protection, and the doctor surface has to say so or it reads like a regression.
- Detection is `cfg(target_os = "linux")`; non-Linux callers get a stub `Unknown` so no extra cfg gates leak into doctor / loader.
- No new deps. `/proc/config.gz` (gz) is deferred — would need flate2; can be added later behind a feature without changing the public API.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (396 passing; 11 new in `kprobe_override::tests` + `doctor::tests`)
- [ ] Manual: run `sakimori doctor` on a Linux box with `CONFIG_BPF_KPROBE_OVERRIDE=y` and one without — verify Ok vs Warn rendering. Not in CI.

## Follow-up
The kprobe BPF program (`do_sys_openat2`) + `bpf_override_return(-EPERM)` attach path. The detection lands here so the next PR can be focused on the kernel-side work + verifier wrangling without also touching userspace plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)