### PR TITLE
feat: opt-in pre-syscall block via do_sys_openat2 kprobe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ __pycache__/
 # are not part of the main workspace and shouldn't be tracked.
 crates/sakimori-win/target/
 crates/sakimori-win/Cargo.lock
+
+# Same story for sakimori-ebpf — built separately via nightly +
+# `bpfel-unknown-none` target.
+crates/sakimori-ebpf/target/
+crates/sakimori-ebpf/Cargo.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,15 +174,25 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
 4. **Linux file/exec block via `bpf_override_return`** — clean
    pre-syscall block, requires runtime detection of
    CONFIG_BPF_KPROBE_OVERRIDE and a well-timed kprobe.
-   Partial progress (v0.37): `crate::kprobe_override::detect()`
+   Partial progress (v0.37–v0.38): `crate::kprobe_override::detect()`
    reads `/boot/config-$(uname -r)` and reports
-   `Available` / `Unsupported` / `Unknown` so the rest of the
-   loader can light up the kprobe path opportunistically, and
-   `sakimori doctor` surfaces a "Kernel pre-syscall block" row
-   with strength-aware messaging (the warn path explicitly
-   reassures users that the existing SIGKILL tripwire is still
-   in effect). The kprobe BPF program + attach path is the
-   next slice.
+   `Available` / `Unsupported` / `Unknown`, surfaced through
+   `sakimori doctor` as a strength-aware "Kernel pre-syscall
+   block" row (warn path reassures users the SIGKILL tripwire is
+   still in effect). v0.38 lands the kernel-side half: a kprobe
+   on `do_sys_openat2` (which sits behind every `open` / `openat`
+   / `openat2` entry) that runs the same `FILE_DENY_PREFIX` match
+   as the tracepoint and calls `bpf_override_return(-EPERM)` on a
+   hit — so `file.deny` becomes a real pre-syscall block, not
+   just a SIGKILL tripwire. Behaviour-preserving by default:
+   the attach is opt-in via `SAKIMORI_ENABLE_KPROBE_OVERRIDE=1`
+   while we gather cross-kernel field data; without that flag the
+   existing tracepoint + SIGKILL path is unchanged. The kprobe
+   path is strictly additive — verifier reject, missing
+   error-injection allowlist on `do_sys_openat2`, or missing
+   capability all degrade silently to the tripwire fallback
+   with a single `log::warn!`. The exec-side counterpart (a
+   kprobe on `__x64_sys_execve` etc.) is the next slice.
 5. **macOS live block** — either a Network Extension (heavy, needs
    signing) or an HTTPS proxy (see #2).
 6. **Retroactive CVE notification for past installs** — local-first

--- a/crates/sakimori-ebpf/src/main.rs
+++ b/crates/sakimori-ebpf/src/main.rs
@@ -28,9 +28,9 @@ use aya_ebpf::{
         bpf_get_current_comm, bpf_get_current_pid_tgid, bpf_get_current_uid_gid,
         bpf_probe_read_user, bpf_probe_read_user_str_bytes, bpf_send_signal,
     },
-    macros::{cgroup_sock_addr, map, tracepoint},
+    macros::{cgroup_sock_addr, kprobe, map, tracepoint},
     maps::{Array, HashMap, RingBuf},
-    programs::{SockAddrContext, TracePointContext},
+    programs::{ProbeContext, SockAddrContext, TracePointContext},
 };
 use sakimori_common::{
     COMM_LEN, Connect4Event, Connect6Event, EVENT_KIND_CONNECT4, EVENT_KIND_CONNECT6,
@@ -61,8 +61,7 @@ static NET6: HashMap<Ipv6Key, u8> = HashMap::with_max_entries(1024, BPF_F_NO_PRE
 /// `policy.file.deny`; anything beyond falls through to userspace-only
 /// tagging.
 #[map]
-static FILE_DENY_PREFIX: Array<FileDenyPrefix> =
-    Array::with_max_entries(FILE_DENY_MAX_ENTRIES, 0);
+static FILE_DENY_PREFIX: Array<FileDenyPrefix> = Array::with_max_entries(FILE_DENY_MAX_ENTRIES, 0);
 
 #[inline(always)]
 fn settings() -> Settings {
@@ -81,7 +80,11 @@ fn make_header(kind: u32, verdict: u32) -> EventHeader {
     let mut comm = [0u8; COMM_LEN];
     if let Ok(c) = bpf_get_current_comm() {
         // bpf_get_current_comm returns exactly 16 bytes.
-        let n = if c.len() < COMM_LEN { c.len() } else { COMM_LEN };
+        let n = if c.len() < COMM_LEN {
+            c.len()
+        } else {
+            COMM_LEN
+        };
         let mut i = 0;
         while i < n {
             comm[i] = c[i];
@@ -200,6 +203,80 @@ pub fn sakimori_openat(ctx: TracePointContext) -> u32 {
     0
 }
 
+// ---------------------------------------------------------------------------
+// do_sys_openat2 kprobe — clean pre-syscall block via bpf_override_return
+// ---------------------------------------------------------------------------
+//
+// Roadmap #4 second slice. The tracepoint above is a "tripwire": the
+// open syscall has already started executing by the time we observe
+// it, so the strongest action we can take is `bpf_send_signal(SIGKILL)`
+// — the process dies before it can consume the resulting fd, but
+// the kernel did briefly enter the open path. A kprobe attached to
+// `do_sys_openat2` (which sits behind every open / openat / openat2
+// entry on modern kernels) can call `bpf_override_return(-EPERM)` to
+// short-circuit the kernel function entirely — the calling task sees
+// the syscall return `-EPERM` and can choose how to react. This is
+// the "true pre-syscall block" the README's Limitations section
+// promises as a roadmap item.
+//
+// Constraints:
+// - Requires `CONFIG_BPF_KPROBE_OVERRIDE=y` (detected by userspace
+//   via `crate::kprobe_override` in the loader crate).
+// - `do_sys_openat2` is annotated with `ALLOW_ERROR_INJECTION` in
+//   fs/open.c on modern kernels; older ones without that annotation
+//   reject the attach.
+// - Userspace gates loading behind an opt-in env var until field
+//   validation across kernel versions; the tracepoint's SIGKILL
+//   path is unchanged, so a kernel that rejects the attach degrades
+//   silently to the existing tripwire.
+
+/// Linux `-EPERM` as a kernel return value. `bpf_override_return`
+/// installs this as the value the kprobed function will return,
+/// so the calling task gets `openat2(...) = -EPERM` directly
+/// rather than the file descriptor it would otherwise have received.
+const NEG_EPERM: u64 = (-1i64) as u64;
+
+#[kprobe]
+pub fn sakimori_openat2_kprobe(ctx: ProbeContext) -> u32 {
+    // do_sys_openat2(int dfd, const char __user *filename, struct open_how *how)
+    // arg 1 is the user-space filename pointer.
+    let filename_ptr: *const u8 = match ctx.arg::<*const u8>(1) {
+        Some(p) if !p.is_null() => p,
+        _ => return 0,
+    };
+
+    let mut scratch = [0u8; FILE_DENY_PREFIX_LEN];
+    let scratch_len = unsafe {
+        match bpf_probe_read_user_str_bytes(filename_ptr, &mut scratch) {
+            Ok(read) => read.len(),
+            Err(_) => return 0,
+        }
+    };
+    if scratch_len == 0 {
+        return 0;
+    }
+
+    if !file_deny_matches(&scratch, scratch_len) {
+        return 0;
+    }
+    if settings().mode != 1 {
+        // audit mode — observation belongs to the tracepoint, which
+        // is what populates the ringbuf. The kprobe stays silent.
+        return 0;
+    }
+
+    // SAFETY: `ctx.regs` is the verifier-checked pt_regs pointer
+    // aya hands us; `bpf_override_return` is a kernel-supplied
+    // helper whose only precondition we control is that the
+    // attached function is in the error-injection allowlist —
+    // userspace verifies that at attach time via the kprobe-
+    // override probe in `crate::kprobe_override`.
+    unsafe {
+        let _ = aya_ebpf::helpers::r#gen::bpf_override_return(ctx.regs as *mut _, NEG_EPERM);
+    }
+    0
+}
+
 /// Linear scan of the FILE_DENY_PREFIX map. `FILE_DENY_MAX_ENTRIES = 8`
 /// keeps the unrolled program well within the verifier's instruction
 /// count budget even after in-lining the per-byte compare loop.
@@ -208,9 +285,7 @@ fn file_deny_matches(path: &[u8; FILE_DENY_PREFIX_LEN], path_len: usize) -> bool
     let mut i: u32 = 0;
     let mut hit = false;
     while i < FILE_DENY_MAX_ENTRIES {
-        if !hit
-            && let Some(slot) = unsafe { FILE_DENY_PREFIX.get(i) }
-        {
+        if !hit && let Some(slot) = unsafe { FILE_DENY_PREFIX.get(i) } {
             let needle = slot.len as usize;
             if needle > 0 && needle <= FILE_DENY_PREFIX_LEN && needle <= path_len {
                 let mut mismatch = false;

--- a/crates/sakimori/src/enforcer.rs
+++ b/crates/sakimori/src/enforcer.rs
@@ -104,10 +104,10 @@ fn env_opt_in(name: &str) -> bool {
     // Common truthy values; everything else (unset, "0", "false",
     // empty) is treated as opt-out so users can paste a `=0` into
     // CI to disable without removing the assignment.
-    match std::env::var(name).ok().as_deref() {
-        Some("1" | "true" | "yes" | "on") => true,
-        _ => false,
-    }
+    matches!(
+        std::env::var(name).ok().as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    )
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/sakimori/src/enforcer.rs
+++ b/crates/sakimori/src/enforcer.rs
@@ -40,6 +40,16 @@ impl Enforcer {
                 .context("attaching sys_enter_openat")?;
         }
 
+        // Roadmap #4: opportunistic pre-syscall block via
+        // bpf_override_return on a do_sys_openat2 kprobe. Strictly
+        // additive — the SIGKILL tripwire on the tracepoint stays
+        // armed regardless, so any attach failure here degrades
+        // silently to the existing behaviour. Gated behind an
+        // opt-in env var while we collect cross-kernel field data.
+        if should_attempt_kprobe_override() {
+            try_attach_openat2_kprobe(bpf);
+        }
+
         if let Some(cgroup) = cgroup {
             let fd = cgroup.as_file()?;
             for name in ["sakimori_connect4", "sakimori_connect6"] {
@@ -55,6 +65,86 @@ impl Enforcer {
         populate_network_maps(bpf, policy, resolver).await?;
         populate_file_maps(bpf, policy)?;
         Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_attempt_kprobe_override() -> bool {
+    // The env-var gate is the user's opt-in switch; the detection
+    // probe filters out kernels that don't have
+    // CONFIG_BPF_KPROBE_OVERRIDE. We require both: an opted-in
+    // user on a kernel without the support would silently fall
+    // back, but on the (more common) opted-out user we don't even
+    // probe.
+    if !env_opt_in("SAKIMORI_ENABLE_KPROBE_OVERRIDE") {
+        return false;
+    }
+    let status = crate::kprobe_override::detect();
+    match status {
+        crate::kprobe_override::KprobeOverrideStatus::Available { .. } => true,
+        crate::kprobe_override::KprobeOverrideStatus::Unsupported { .. } => {
+            log::info!(
+                "SAKIMORI_ENABLE_KPROBE_OVERRIDE set but kernel lacks CONFIG_BPF_KPROBE_OVERRIDE; \
+                 staying on SIGKILL-tripwire fallback"
+            );
+            false
+        }
+        crate::kprobe_override::KprobeOverrideStatus::Unknown { reason } => {
+            log::info!(
+                "SAKIMORI_ENABLE_KPROBE_OVERRIDE set but kernel-config readability is unknown \
+                 ({reason}); attempting attach anyway"
+            );
+            true
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn env_opt_in(name: &str) -> bool {
+    // Common truthy values; everything else (unset, "0", "false",
+    // empty) is treated as opt-out so users can paste a `=0` into
+    // CI to disable without removing the assignment.
+    match std::env::var(name).ok().as_deref() {
+        Some("1" | "true" | "yes" | "on") => true,
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn try_attach_openat2_kprobe(bpf: &mut aya::Ebpf) {
+    let Some(prog) = bpf.program_mut("sakimori_openat2_kprobe") else {
+        log::debug!("sakimori_openat2_kprobe program not in object; skipping");
+        return;
+    };
+    let kp: &mut aya::programs::KProbe = match prog.try_into() {
+        Ok(k) => k,
+        Err(e) => {
+            log::warn!("sakimori_openat2_kprobe: not a KProbe program: {e:#}");
+            return;
+        }
+    };
+    if let Err(e) = kp.load() {
+        log::warn!(
+            "sakimori_openat2_kprobe: verifier rejected load ({e:#}); \
+             staying on SIGKILL-tripwire fallback"
+        );
+        return;
+    }
+    match kp.attach("do_sys_openat2", 0) {
+        Ok(_) => {
+            log::info!(
+                "sakimori_openat2_kprobe attached: file.deny is now a pre-syscall block \
+                 (bpf_override_return → -EPERM)"
+            );
+        }
+        Err(e) => {
+            log::warn!(
+                "sakimori_openat2_kprobe: attach to do_sys_openat2 failed ({e:#}); \
+                 staying on SIGKILL-tripwire fallback. Common causes: \
+                 do_sys_openat2 not in this kernel's error-injection allowlist, \
+                 or missing CAP_SYS_ADMIN."
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Stacked on top of [#67](https://github.com/bokuweb/sakimori/pull/67) (detection plumbing). Once that merges, this PR's base will retarget to `main` automatically via `gh pr edit`.

## Summary
Second slice of roadmap #4. Lands the kernel-side half of the upgrade from "SIGKILL tripwire" to "real pre-syscall block":

- **eBPF**: new `sakimori_openat2_kprobe` program attached to `do_sys_openat2` (the convergence point for `open` / `openat` / `openat2`). Same `FILE_DENY_PREFIX` match as the existing tracepoint; on a deny hit it calls `bpf_override_return(ctx, -EPERM)` so the kernel function never executes its body — the calling task sees the syscall return `-EPERM`.
- **Userspace**: `Enforcer::attach` tries the kprobe opportunistically when `SAKIMORI_ENABLE_KPROBE_OVERRIDE=1` is set AND `kprobe_override::detect()` says the kernel was built with `CONFIG_BPF_KPROBE_OVERRIDE=y`.

## Why opt-in
The tracepoint + SIGKILL path stays armed unconditionally, so this PR is **behaviour-preserving by default**. The env-var gate buys us a slow rollout window to gather field data across kernel versions on:
- presence of `do_sys_openat2` in the kernel's error-injection allow-list (`ALLOW_ERROR_INJECTION` annotation in fs/open.c — present on 5.6+ but worth verifying per-distro)
- verifier acceptance of the new program (instruction-count + complexity budget)

Verifier reject / missing-allowlist / missing CAP_SYS_ADMIN all degrade silently to the existing tripwire fallback with a single `log::warn!` — no panic, no fail-hard.

## Out of scope (next slices)
- `__x64_sys_execve` kprobe for `process.deny_exec` — separate PR, same pattern.
- Coordination flag so the tracepoint's SIGKILL skips when the kprobe is active (today both fire on a deny hit; net effect is still correct but the user loses the "graceful -EPERM" benefit they'd get from kprobe alone). Defer until the kprobe attach itself is validated in the field.
- Flipping the env-var gate from opt-in to opt-out, then removing it.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 396 passing
- [x] `cargo +nightly-2026-01-01 build --release --target bpfel-unknown-none -Z build-std=core --manifest-path crates/sakimori-ebpf/Cargo.toml` — clean (only 2 pre-existing warnings unchanged)
- [ ] **Linux runtime validation** (gating real-world rollout, not this PR's merge): run a `file.deny: ['/etc/shadow']` policy in block mode under `SAKIMORI_ENABLE_KPROBE_OVERRIDE=1` on Ubuntu 22.04/24.04 + Amazon Linux 2023; assert `cat /etc/shadow` exits with `-EPERM` rather than just getting SIGKILLed. CI doesn't have this matrix today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)