### PR TITLE
Shai-Hulud-class supply-chain defences: policy presets + IOC scanner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,16 +573,25 @@ of value-per-implementation-cost.
     with `deps watch` — the proxy is the only layer that can
     catch the script *before* it runs.
 16. **Persistence-write rule pack** (Shai-Hulud-class defence) —
-    a curated `file.deny` rule set covering the locations
-    worm-style malware writes for OS-level persistence:
-    `~/Library/LaunchAgents/**`, `~/Library/LaunchDaemons/**`,
-    `/Library/Launch{Agents,Daemons}/**`, `~/.config/systemd/user/**`,
-    `/etc/systemd/system/**`, crontab spool dirs, `~/.ssh/**`
-    (especially `authorized_keys` / `config`), shell rc files
-    (`~/.bashrc`, `~/.zshrc`, `~/.profile`), and Claude/VS Code
-    workspace hooks (`.claude/**.mjs`, `.vscode/tasks.json`).
-    Ships as `coronarium policy preset persistence` that prints
-    a ready-to-merge YAML block. Combined with the v0.23
+    ✅ implemented as `sakimori policy preset persistence`. Renders
+    a `file.deny` YAML block covering OS-level persistence
+    locations: macOS launchd (`/Library/Launch{Agents,Daemons}/`,
+    `$HOME/Library/Launch{Agents,Daemons}/`), Linux systemd
+    (`/etc/systemd/system/`, `$HOME/.config/systemd/user/`,
+    `$HOME/.config/autostart/`), cron spool / drop-in dirs
+    (`/var/spool/cron/`, `/etc/cron.{d,hourly,daily,weekly,monthly}/`,
+    `/etc/init.d/`), SSH (`$HOME/.ssh/`), and shell rc / profile
+    files (`.bashrc`, `.bash_profile`, `.bash_logout`, `.profile`,
+    `.zshrc`, `.zprofile`, `.zshenv`). Per-user paths expand from
+    `$HOME` or `--home /path`; omitted home falls back to system
+    paths plus a comment noting the gap. The preset deliberately
+    exceeds the Linux 8-entry kernel cap on `file.deny` under
+    `mode: block` — the YAML header tells the operator to prune to
+    the 8 highest-value entries or use `mode: audit` (uncapped).
+    Workspace-relative paths (`.claude/setup.mjs`, `.vscode/tasks.json`)
+    are deliberately *not* in this preset — the file matcher is
+    absolute-prefix only, so those belong to the IOC workspace
+    scanner (item 18). Combined with the v0.23
     attribution layer, a write to any of these paths from a
     package-manager-attributed subtree is the highest-confidence
     "this install is malicious" signal sakimori can produce —
@@ -590,24 +599,23 @@ of value-per-implementation-cost.
     legitimate reason for `npm install` to touch
     `~/Library/LaunchAgents/`. Block-mode SIGKILLs the writer.
 17. **Cloud-credential exfiltration tripwire** (Shai-Hulud-class
-    defence) — a curated `network.deny` rule pack covering the
-    egress patterns observed in the May 2026 wave: AWS IMDS
-    (`169.254.169.254`), `sts.amazonaws.com`,
-    `secretsmanager.*.amazonaws.com`, `ssm.*.amazonaws.com`,
-    GCP metadata (`metadata.google.internal`,
-    `169.254.169.254` with `Metadata-Flavor: Google`), Azure IMDS,
-    Vault default ports, and the well-known crypto-wallet
-    exfiltration endpoints. Pairs with v0.33's SNI-based proxy
-    egress filter so the rule fires on the *hostname the client
-    asked for*, not a CDN-rotated IP. Attribution surface: when
-    the offending PID's ancestor chain contains a package
-    manager (already classified by `attribution::Attribution`),
-    the event is upgraded to a distinct `cloud_secret_egress`
-    category in the JSON log + step summary, with a different
-    UI affordance — "your install just touched your cloud
-    credentials" is qualitatively different from "your build
-    talked to S3". Ships as
-    `coronarium policy preset cloud-secret-egress`.
+    defence) — ✅ first slice implemented as
+    `sakimori policy preset cloud-secret-egress`. Renders a
+    `network.deny` YAML block covering the link-local IMDS IP
+    (`169.254.169.254` — AWS / GCP / Azure all share it),
+    `metadata.google.internal`, `metadata.azure.com`, and
+    `sts.amazonaws.com`. `NetRule.target` is hostname/IP/CIDR
+    (no wildcards in the supervisor layer), so wildcarded
+    endpoints (`secretsmanager.*.amazonaws.com`,
+    `ssm.*.amazonaws.com`, regional STS variants) are not in
+    this preset — they'll land once the proxy gains a deny-list
+    HostMatcher and the preset learns to emit SNI patterns
+    alongside the cgroup-level rules. Follow-ups still on the
+    table: Vault default ports, crypto-wallet exfiltration
+    endpoints, and the "package-manager-attributed →
+    cloud_secret_egress" event category in the JSON log + step
+    summary (the proxy-side SNI deny pairing is the natural
+    pre-req for the latter).
 18. **Known-IOC workspace scanner** — extend `coronarium
     workspace diff` (and `sakimori run --snapshot-workspace`)
     with a known-bad-path index of file paths and content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,22 +616,30 @@ of value-per-implementation-cost.
     cloud_secret_egress" event category in the JSON log + step
     summary (the proxy-side SNI deny pairing is the natural
     pre-req for the latter).
-18. **Known-IOC workspace scanner** — extend `coronarium
-    workspace diff` (and `sakimori run --snapshot-workspace`)
-    with a known-bad-path index of file paths and content
-    fingerprints observed in current supply-chain worm campaigns:
-    `.claude/setup.mjs`, `.github/workflows/codeql_analysis.yml`
-    (when the repo doesn't legitimately use CodeQL),
-    `{dune_word}-{dune_word}-{3-digit}` repo names created via
-    the GitHub API during install, and authored-by
-    `claude <claude@users.noreply.github.com>` commits where the
-    user did not invoke Claude. Distinct from the generic
-    workspace-drift check because it elevates specific drift
-    patterns from "something changed" to "this is the Shai-Hulud
-    fingerprint". The index ships as a versioned YAML
-    (`coronarium-iocs.yml`) bundled with the binary, refreshable
-    by `coronarium iocs update`. Conservatively scoped: hits
-    surface as ❌ in the step summary; no auto-quarantine.
+18. **Known-IOC workspace scanner** — ✅ first slice implemented as
+    `sakimori workspace scan-iocs <DIR>`. New
+    `sakimori_core::iocs` module walks the workspace honouring the
+    same skip list as `tamper` (`.git`, `node_modules`, `target`,
+    …) and reports hits against a bundled IOC catalog
+    (`crates/sakimori-core/iocs/coronarium-iocs.yml`, loaded via
+    `include_str!`). Pattern shapes: `relative_path` (exact-match
+    from the workspace root; cheap stat-only check) and `basename`
+    (basename anywhere in the tree; triggers the walk). Per-pattern
+    severity is `error` (fails the CLI with non-zero exit; gates
+    CI) or `warn` (surfaces only); operators suppress a triaged
+    false positive with `--allow-id <id>`. Custom feeds via
+    `--index <file>` (same schema). Hits are sorted stably by
+    `(pattern_id, path)` for snapshot-friendly output. Bundled
+    catalog seeded with two Shai-Hulud markers: the
+    `.claude/setup.mjs` drop (error) and the spoofed
+    `codeql_analysis.yml` (warn — real CodeQL workflows are
+    confusable). Follow-ups: content-fingerprint patterns (hash of
+    a known-bad blob), commit-author IOCs (the
+    `claude@users.noreply.github.com` worm marker — needs git
+    inspection, not just file walk), repo-name IOCs (the
+    dune-word-pattern names — needs GitHub API), and
+    `sakimori iocs update` to refresh the bundled YAML from an
+    upstream feed.
 
 Explicitly **out of scope** (different product philosophy, not
 a missing feature):

--- a/README.md
+++ b/README.md
@@ -766,6 +766,22 @@ enforce, prune to your 8 most critical paths and flip the `mode:`
 field to `block`. The cloud-secret-egress preset ships in
 `mode: block` (no cap on `network.deny`).
 
+**Known-IOC workspace scan (`workspace scan-iocs`):** walk a
+workspace and flag files whose existence is a known supply-chain
+compromise marker (e.g. `.claude/setup.mjs` dropped by the
+Shai-Hulud npm worm). Distinct from `workspace diff` — diff catches
+"something changed during the build," scan-iocs catches "this file
+exists at all, which it shouldn't." The catalog is shipped bundled
+in the binary (versioned YAML); override with `--index <file>` for
+private feeds, suppress a triaged false positive with `--allow-id
+<id>`. Exits non-zero on any Error-severity hit so it composes with
+CI gates; Warn-severity hits surface but don't gate.
+
+```bash
+sakimori workspace scan-iocs $GITHUB_WORKSPACE
+sakimori workspace scan-iocs . --json
+```
+
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm
 - **host column** (PTR-resolved reverse DNS for connect events)

--- a/README.md
+++ b/README.md
@@ -745,6 +745,25 @@ commented `# observed_exec:` block — `process.deny_exec` is
 deliberately left empty because the suggester can't know which of
 the binaries the build actually wanted.
 
+**Curated rule packs (`policy preset`):** ready-to-merge YAML blocks
+for known supply-chain attack patterns. Currently shipped:
+
+- `sakimori policy preset persistence` — `file.deny` tripwire for
+  OS-level persistence writes (launchd / systemd / cron / shell rc
+  / `~/.ssh`). Per-user paths expand from `$HOME` (override with
+  `--home /path`); system paths always included.
+- `sakimori policy preset cloud-secret-egress` — `network.deny`
+  tripwire for AWS / GCP / Azure IMDS and STS-style secret
+  endpoints. Pairs with `sakimori proxy start --network-allow ...`
+  for SNI-level enforcement.
+
+Both presets print to stdout (or `-o policy.yml`) with explanatory
+comment headers so the operator can pick the entries that fit their
+threat model and merge into an existing policy. The persistence
+preset deliberately exceeds the Linux 8-entry kernel cap on
+`file.deny` under `mode: block` — prune to the most critical
+locations, or keep the full list under `mode: audit` (uncapped).
+
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm
 - **host column** (PTR-resolved reverse DNS for connect events)

--- a/README.md
+++ b/README.md
@@ -760,9 +760,11 @@ for known supply-chain attack patterns. Currently shipped:
 Both presets print to stdout (or `-o policy.yml`) with explanatory
 comment headers so the operator can pick the entries that fit their
 threat model and merge into an existing policy. The persistence
-preset deliberately exceeds the Linux 8-entry kernel cap on
-`file.deny` under `mode: block` — prune to the most critical
-locations, or keep the full list under `mode: audit` (uncapped).
+preset ships in `mode: audit` because its full list exceeds the
+Linux 8-entry kernel cap on `file.deny` under `mode: block`; to
+enforce, prune to your 8 most critical paths and flip the `mode:`
+field to `block`. The cloud-secret-egress preset ships in
+`mode: block` (no cap on `network.deny`).
 
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm

--- a/crates/sakimori-core/iocs/coronarium-iocs.yml
+++ b/crates/sakimori-core/iocs/coronarium-iocs.yml
@@ -1,0 +1,41 @@
+# Known-IOC index for `sakimori workspace scan-iocs`.
+#
+# Each pattern surfaces a specific file fingerprint observed in active
+# supply-chain worm campaigns. Conservatively scoped: a hit means
+# *this file's existence is a known compromise marker*, not "this file
+# looks suspicious." We do not auto-quarantine; the CLI just reports
+# and exits non-zero.
+#
+# When a known-good repo legitimately has one of these files (rare —
+# e.g. a real `.github/workflows/codeql_analysis.yml` actually used
+# for CodeQL scanning), pass `--allow-id <id>` to suppress it.
+#
+# Bumping `version` triggers no client behaviour today; it exists so
+# a future `sakimori iocs update` can compare local vs. upstream.
+
+version: 1
+
+patterns:
+  - id: shai-hulud-claude-setup
+    description: >-
+      Shai-Hulud npm worm (May 2026) drop site. The malicious
+      postinstall writes `.claude/setup.mjs` to the workspace so the
+      next Claude Code invocation auto-executes attacker code. No
+      legitimate Claude Code workflow places a setup.mjs at this
+      path.
+    severity: error
+    match:
+      kind: relative_path
+      path: .claude/setup.mjs
+
+  - id: shai-hulud-fake-codeql-workflow
+    description: >-
+      Shai-Hulud second wave — drops a workflow file masquerading as
+      a CodeQL analysis job (`codeql_analysis.yml`) that actually
+      exfiltrates `secrets.*` to an attacker-controlled webhook.
+      Real CodeQL workflows are usually named `codeql.yml` and call
+      `github/codeql-action/*`; review carefully before suppressing.
+    severity: warn
+    match:
+      kind: relative_path
+      path: .github/workflows/codeql_analysis.yml

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -130,7 +130,18 @@ impl ScanReport {
 /// Walk `root` and report every IOC that matches. `allow_ids` is a
 /// set of pattern ids the caller has already triaged as false
 /// positives — they're skipped silently.
+///
+/// Errors when `root` does not exist or is not a directory. The
+/// loud failure is deliberate: a CI gate fed a stale or mistyped
+/// `$GITHUB_WORKSPACE` would otherwise see "0 hits, exit 0" and
+/// silently pass — exactly the worst behaviour for a tool whose
+/// job is to fail noisy.
 pub fn scan(root: &Path, catalog: &Catalog, allow_ids: &BTreeSet<String>) -> Result<ScanReport> {
+    let meta = std::fs::metadata(root)
+        .with_context(|| format!("scan root {} is not accessible", root.display()))?;
+    if !meta.is_dir() {
+        anyhow::bail!("scan root {} exists but is not a directory", root.display());
+    }
     let canon = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let skip: BTreeSet<&str> = DEFAULT_SKIP_DIRS.iter().copied().collect();
 
@@ -342,6 +353,32 @@ mod tests {
         assert_eq!(report.hits.len(), 1, "must skip node_modules/");
         assert!(report.hits[0].path.starts_with("src/"));
         assert!(!report.has_error(), "warn-only hits don't gate CI");
+    }
+
+    #[test]
+    fn nonexistent_root_errors_loudly_not_silently_clean() {
+        // Regression for the codex review finding: a CI gate fed
+        // an unset / mistyped $GITHUB_WORKSPACE must fail loudly,
+        // not return "0 hits, exit 0".
+        let cat = Catalog::bundled().unwrap();
+        let err = scan(
+            Path::new("/definitely/does/not/exist/sakimori-iocs-test"),
+            &cat,
+            &BTreeSet::new(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("not accessible"), "got: {err}");
+    }
+
+    #[test]
+    fn file_root_errors_not_silently_clean() {
+        let tmp = Tmp::new();
+        let f = tmp.0.join("not-a-dir.txt");
+        fs::write(&f, b"x").unwrap();
+        let cat = Catalog::bundled().unwrap();
+        let err = scan(&f, &cat, &BTreeSet::new()).unwrap_err().to_string();
+        assert!(err.contains("not a directory"), "got: {err}");
     }
 
     #[test]

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -1,0 +1,372 @@
+//! Known-IOC workspace scanner.
+//!
+//! Walks a workspace root looking for files whose existence is a
+//! known supply-chain-compromise fingerprint (see roadmap item 18).
+//! Distinct from [`crate::tamper`]: tamper diff says "something
+//! changed during the build"; this says "this specific file is a
+//! known attacker marker, regardless of whether it changed."
+//!
+//! The catalog is shipped bundled in the binary (loaded from
+//! `iocs/coronarium-iocs.yml` via [`include_str!`]); callers can
+//! override with a file path for testing or private feeds.
+//!
+//! Conservatively scoped:
+//! - Hits surface as a structured report; the CLI exits non-zero on
+//!   any `Severity::Error` hit so it composes with CI gates.
+//! - No auto-quarantine, no auto-delete.
+//! - The walker honours the same skip list as [`crate::tamper`] so
+//!   build-artefact churn doesn't drown the signal.
+
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::tamper::DEFAULT_SKIP_DIRS;
+
+/// Bundled IOC index. Refreshed by editing
+/// `crates/sakimori-core/iocs/coronarium-iocs.yml`; a future
+/// `sakimori iocs update` will do this from an upstream feed.
+pub const BUNDLED_CATALOG_YAML: &str = include_str!("../iocs/coronarium-iocs.yml");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    /// CI-gate fail. Reserved for IOCs we have high confidence are
+    /// real compromise markers in any context.
+    Error,
+    /// Surface but don't fail. Used for fingerprints that have a
+    /// plausible benign explanation (e.g. a legitimate CodeQL job
+    /// confusable with the worm-dropped lookalike).
+    Warn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MatchSpec {
+    /// Path relative to the workspace root, matched exactly after
+    /// normalising both sides to forward slashes.
+    RelativePath { path: String },
+    /// File basename, matched anywhere in the tree.
+    Basename { name: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Pattern {
+    pub id: String,
+    pub description: String,
+    pub severity: Severity,
+    #[serde(rename = "match")]
+    pub match_spec: MatchSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Catalog {
+    pub version: u32,
+    pub patterns: Vec<Pattern>,
+}
+
+impl Catalog {
+    /// Parse the bundled YAML index. Always succeeds for releases —
+    /// the test [`tests::bundled_catalog_parses`] guards against
+    /// breakage on the way in.
+    pub fn bundled() -> Result<Self> {
+        Self::from_yaml(BUNDLED_CATALOG_YAML)
+    }
+
+    pub fn from_yaml(text: &str) -> Result<Self> {
+        let cat: Catalog = serde_yaml::from_str(text).context("parsing IOC catalog YAML")?;
+        cat.validate()?;
+        Ok(cat)
+    }
+
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("reading IOC catalog {}", path.display()))?;
+        Self::from_yaml(&text)
+    }
+
+    fn validate(&self) -> Result<()> {
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        for p in &self.patterns {
+            if !seen.insert(p.id.as_str()) {
+                anyhow::bail!("duplicate IOC pattern id `{}`", p.id);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Hit {
+    pub pattern_id: String,
+    pub description: String,
+    pub severity: Severity,
+    /// Path relative to the scanned root, with forward slashes.
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ScanReport {
+    pub root: PathBuf,
+    pub hits: Vec<Hit>,
+}
+
+impl ScanReport {
+    pub fn is_clean(&self) -> bool {
+        self.hits.is_empty()
+    }
+
+    /// True if any hit is at [`Severity::Error`]. The CLI maps this
+    /// to its non-zero exit code so it gates a CI step.
+    pub fn has_error(&self) -> bool {
+        self.hits.iter().any(|h| h.severity == Severity::Error)
+    }
+}
+
+/// Walk `root` and report every IOC that matches. `allow_ids` is a
+/// set of pattern ids the caller has already triaged as false
+/// positives — they're skipped silently.
+pub fn scan(root: &Path, catalog: &Catalog, allow_ids: &BTreeSet<String>) -> Result<ScanReport> {
+    let canon = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let skip: BTreeSet<&str> = DEFAULT_SKIP_DIRS.iter().copied().collect();
+
+    let mut report = ScanReport {
+        root: canon.clone(),
+        hits: Vec::new(),
+    };
+
+    // For relative_path patterns we can stat() the absolute path
+    // directly and skip the walk; that's both faster and avoids
+    // false negatives when a parent dir happens to be on the skip
+    // list (e.g. an attacker-dropped `node_modules/.bin/postinstall`
+    // wouldn't matter today but the skip list might shrink later).
+    for pat in &catalog.patterns {
+        if allow_ids.contains(&pat.id) {
+            continue;
+        }
+        if let MatchSpec::RelativePath { path } = &pat.match_spec {
+            let abs = canon.join(path);
+            if abs.exists() {
+                report.hits.push(Hit {
+                    pattern_id: pat.id.clone(),
+                    description: pat.description.clone(),
+                    severity: pat.severity,
+                    path: normalise_rel(path),
+                });
+            }
+        }
+    }
+
+    // Basename patterns require a walk. Only walk if at least one
+    // such pattern is present and unallowed — saves the IO cost
+    // when the catalog only has relative_path entries.
+    let basename_patterns: Vec<&Pattern> = catalog
+        .patterns
+        .iter()
+        .filter(|p| !allow_ids.contains(&p.id))
+        .filter(|p| matches!(p.match_spec, MatchSpec::Basename { .. }))
+        .collect();
+
+    if !basename_patterns.is_empty() {
+        walk_for_basenames(&canon, &canon, &skip, &basename_patterns, &mut report.hits);
+    }
+
+    // Stable order: pattern id then path. Useful both for human
+    // readability and for snapshot-style assertions.
+    report
+        .hits
+        .sort_by(|a, b| (&a.pattern_id, &a.path).cmp(&(&b.pattern_id, &b.path)));
+
+    Ok(report)
+}
+
+fn walk_for_basenames(
+    root: &Path,
+    dir: &Path,
+    skip: &BTreeSet<&str>,
+    patterns: &[&Pattern],
+    hits: &mut Vec<Hit>,
+) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(it) => it,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        let path = entry.path();
+        let ft = match entry.file_type() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
+            if skip.contains(name_str.as_ref()) {
+                continue;
+            }
+            walk_for_basenames(root, &path, skip, patterns, hits);
+        } else if ft.is_file() || ft.is_symlink() {
+            for pat in patterns {
+                if let MatchSpec::Basename { name: target } = &pat.match_spec
+                    && name_str == target.as_str()
+                {
+                    let rel = path
+                        .strip_prefix(root)
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| path.to_string_lossy().to_string());
+                    hits.push(Hit {
+                        pattern_id: pat.id.clone(),
+                        description: pat.description.clone(),
+                        severity: pat.severity,
+                        path: normalise_rel(&rel),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn normalise_rel(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Minimal tmpdir helper; mirrors what `tamper.rs` does. Atomic
+    /// counter so parallel tests don't collide.
+    struct Tmp(PathBuf);
+    impl Tmp {
+        fn new() -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static N: AtomicU64 = AtomicU64::new(0);
+            let pid = std::process::id();
+            let n = N.fetch_add(1, Ordering::Relaxed);
+            let p = std::env::temp_dir().join(format!("sakimori-iocs-test-{pid}-{n}"));
+            fs::create_dir_all(&p).unwrap();
+            Tmp(p)
+        }
+    }
+    impl Drop for Tmp {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn bundled_catalog_parses() {
+        let cat = Catalog::bundled().expect("bundled YAML must parse");
+        assert!(!cat.patterns.is_empty());
+        // Spot-check: the headline Shai-Hulud entry is there.
+        assert!(
+            cat.patterns
+                .iter()
+                .any(|p| p.id == "shai-hulud-claude-setup")
+        );
+    }
+
+    #[test]
+    fn duplicate_pattern_id_rejected() {
+        let bad = "version: 1\npatterns:\n\
+                   - id: dup\n  description: x\n  severity: error\n  match: {kind: basename, name: a}\n\
+                   - id: dup\n  description: y\n  severity: warn\n  match: {kind: basename, name: b}\n";
+        let err = Catalog::from_yaml(bad).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn relative_path_pattern_hits_when_file_present() {
+        let tmp = Tmp::new();
+        fs::create_dir_all(tmp.0.join(".claude")).unwrap();
+        fs::write(tmp.0.join(".claude/setup.mjs"), b"// pwn\n").unwrap();
+
+        let cat = Catalog::bundled().unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert!(
+            report
+                .hits
+                .iter()
+                .any(|h| h.pattern_id == "shai-hulud-claude-setup")
+        );
+        assert!(report.has_error());
+    }
+
+    #[test]
+    fn relative_path_pattern_silent_when_file_absent() {
+        let tmp = Tmp::new();
+        fs::write(tmp.0.join("README.md"), b"# clean\n").unwrap();
+        let cat = Catalog::bundled().unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert!(report.is_clean());
+        assert!(!report.has_error());
+    }
+
+    #[test]
+    fn allow_id_suppresses_a_hit() {
+        let tmp = Tmp::new();
+        fs::create_dir_all(tmp.0.join(".claude")).unwrap();
+        fs::write(tmp.0.join(".claude/setup.mjs"), b"x").unwrap();
+        let cat = Catalog::bundled().unwrap();
+        let mut allow = BTreeSet::new();
+        allow.insert("shai-hulud-claude-setup".to_string());
+        let report = scan(&tmp.0, &cat, &allow).unwrap();
+        assert!(
+            report.is_clean(),
+            "allow-list must suppress matching hits, got {:?}",
+            report.hits
+        );
+    }
+
+    #[test]
+    fn basename_pattern_walks_subdirs_but_skips_build_artefacts() {
+        let tmp = Tmp::new();
+        // Two copies of a basename: one inside `node_modules` (must
+        // be skipped) and one in real source (must be found).
+        fs::create_dir_all(tmp.0.join("node_modules/evil")).unwrap();
+        fs::write(tmp.0.join("node_modules/evil/dropper.js"), b"x").unwrap();
+        fs::create_dir_all(tmp.0.join("src/util")).unwrap();
+        fs::write(tmp.0.join("src/util/dropper.js"), b"x").unwrap();
+
+        let cat = Catalog::from_yaml(
+            "version: 1\npatterns:\n\
+             - id: test-basename\n  description: t\n  severity: warn\n  \
+             match: {kind: basename, name: dropper.js}\n",
+        )
+        .unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert_eq!(report.hits.len(), 1, "must skip node_modules/");
+        assert!(report.hits[0].path.starts_with("src/"));
+        assert!(!report.has_error(), "warn-only hits don't gate CI");
+    }
+
+    #[test]
+    fn hits_sort_stably_by_id_then_path() {
+        let tmp = Tmp::new();
+        fs::create_dir_all(tmp.0.join("a")).unwrap();
+        fs::create_dir_all(tmp.0.join("b")).unwrap();
+        fs::write(tmp.0.join("a/x.txt"), b"").unwrap();
+        fs::write(tmp.0.join("b/x.txt"), b"").unwrap();
+        let cat = Catalog::from_yaml(
+            "version: 1\npatterns:\n\
+             - id: zzz\n  description: t\n  severity: warn\n  match: {kind: basename, name: x.txt}\n\
+             - id: aaa\n  description: t\n  severity: warn\n  match: {kind: basename, name: x.txt}\n",
+        ).unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        let ids: Vec<&str> = report.hits.iter().map(|h| h.pattern_id.as_str()).collect();
+        assert_eq!(ids, vec!["aaa", "aaa", "zzz", "zzz"]);
+        for id in ["aaa", "zzz"] {
+            let paths: Vec<&str> = report
+                .hits
+                .iter()
+                .filter(|h| h.pattern_id == id)
+                .map(|h| h.path.as_str())
+                .collect();
+            assert_eq!(paths, vec!["a/x.txt", "b/x.txt"]);
+        }
+    }
+}

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -261,44 +261,45 @@ fn walk_for_content(
                 continue;
             }
             walk_for_content(root, &path, skip, patterns, hits);
-        } else if ft.is_file() {
-            // Hash lazily, only if at least one Sha256 pattern
-            // applies to this basename (or is unscoped). Bare
-            // Basename matches don't need the hash at all.
-            let mut hash: Option<String> = None;
-            for pat in patterns {
-                match &pat.match_spec {
-                    MatchSpec::Basename { name: target } if name_str == target.as_str() => {
+            continue;
+        }
+
+        // Basename matches fire on both regular files and symlinks
+        // — a worm dropping a marker file as a symlink (e.g. into
+        // a tmpfs decoy) must still be flagged by name. Sha256
+        // matches only fire on regular files: following a symlink
+        // would let an attacker point at a benign target and evade
+        // the content hash.
+        if !ft.is_file() && !ft.is_symlink() {
+            continue;
+        }
+        let mut hash: Option<String> = None;
+        for pat in patterns {
+            match &pat.match_spec {
+                MatchSpec::Basename { name: target } if name_str == target.as_str() => {
+                    push_hit(pat, root, &path, hits);
+                }
+                MatchSpec::Sha256 {
+                    sha256: expected,
+                    basename,
+                } if ft.is_file() => {
+                    if let Some(b) = basename
+                        && name_str != b.as_str()
+                    {
+                        continue;
+                    }
+                    if hash.is_none() {
+                        hash = hash_file_capped(&path, MAX_HASH_BYTES);
+                    }
+                    if let Some(h) = &hash
+                        && h == expected
+                    {
                         push_hit(pat, root, &path, hits);
                     }
-                    MatchSpec::Sha256 {
-                        sha256: expected,
-                        basename,
-                    } => {
-                        if let Some(b) = basename
-                            && name_str != b.as_str()
-                        {
-                            continue;
-                        }
-                        if hash.is_none() {
-                            hash = hash_file_capped(&path, MAX_HASH_BYTES);
-                        }
-                        if let Some(h) = &hash
-                            && h == expected
-                        {
-                            push_hit(pat, root, &path, hits);
-                        }
-                    }
-                    _ => {}
                 }
+                _ => {}
             }
         }
-        // Symlinks are not followed: a worm dropper could symlink
-        // to a benign file to escape a Sha256 match. The Basename
-        // path could in principle still match the link name, but
-        // we leave it out — the tamper module already records
-        // symlinks by target string and is the right home for that
-        // class of detection.
     }
 }
 
@@ -472,6 +473,64 @@ mod tests {
         let cat = Catalog::bundled().unwrap();
         let err = scan(&f, &cat, &BTreeSet::new()).unwrap_err().to_string();
         assert!(err.contains("not a directory"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn basename_pattern_matches_symlink_by_name_sha256_skips_it() {
+        // Regression for the codex review on 87f2a24: switching the
+        // walker from `is_file() || is_symlink()` to `is_file()`
+        // had silently dropped basename matches on symlinks. The
+        // sha256 path must still skip them (no symlink-following).
+        use std::os::unix::fs::symlink;
+        let tmp = Tmp::new();
+        let target = tmp.0.join("real-target.txt");
+        let link = tmp.0.join("dropper.js");
+        fs::write(&target, b"payload\n").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let expected_hash = {
+            let mut h = Sha256::new();
+            h.update(b"payload\n");
+            format!("{:x}", h.finalize())
+        };
+        let yaml = format!(
+            "version: 1\npatterns:\n\
+             - id: by-name\n  description: t\n  severity: warn\n  \
+             match: {{kind: basename, name: dropper.js}}\n\
+             - id: by-hash\n  description: t\n  severity: warn\n  \
+             match: {{kind: sha256, sha256: {expected_hash}}}\n"
+        );
+        let cat = Catalog::from_yaml(&yaml).unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+
+        let by_name: Vec<_> = report
+            .hits
+            .iter()
+            .filter(|h| h.pattern_id == "by-name")
+            .collect();
+        assert_eq!(
+            by_name.len(),
+            1,
+            "basename must match the symlink, got {:?}",
+            report.hits
+        );
+        assert_eq!(by_name[0].path, "dropper.js");
+
+        // The real target ("real-target.txt") is the only regular
+        // file matching the hash. The symlink is not followed and
+        // does not double-count.
+        let by_hash: Vec<_> = report
+            .hits
+            .iter()
+            .filter(|h| h.pattern_id == "by-hash")
+            .collect();
+        assert_eq!(
+            by_hash.len(),
+            1,
+            "sha256 must fire once (the regular file only)"
+        );
+        assert_eq!(by_hash[0].path, "real-target.txt");
     }
 
     #[test]

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -19,11 +19,14 @@
 
 use std::{
     collections::BTreeSet,
+    fs,
+    io::Read,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::tamper::DEFAULT_SKIP_DIRS;
 
@@ -52,7 +55,25 @@ pub enum MatchSpec {
     RelativePath { path: String },
     /// File basename, matched anywhere in the tree.
     Basename { name: String },
+    /// Content fingerprint — SHA-256 of the file contents in lowercase
+    /// hex. Walks the tree like `Basename` does. Optional `basename`
+    /// narrows which files are hashed so the catalog can stay cheap
+    /// (a bare `Sha256` with no `basename` would force hashing every
+    /// regular file under the root). Files larger than
+    /// [`MAX_HASH_BYTES`] are skipped without being hashed.
+    Sha256 {
+        sha256: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        basename: Option<String>,
+    },
 }
+
+/// Hard cap on file size for content-fingerprint matches. The scanner
+/// silently skips bigger files rather than spending unbounded IO; in
+/// practice every worm dropper observed in the wild has been < 1 MiB,
+/// and an attacker who pads a 16 MiB blob is also one a `Basename`
+/// pattern would catch. 16 MiB is a generous margin over that.
+pub const MAX_HASH_BYTES: u64 = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Pattern {
@@ -94,6 +115,22 @@ impl Catalog {
         for p in &self.patterns {
             if !seen.insert(p.id.as_str()) {
                 anyhow::bail!("duplicate IOC pattern id `{}`", p.id);
+            }
+            if let MatchSpec::Sha256 { sha256, .. } = &p.match_spec {
+                // 64 lowercase hex chars. Reject early so a typo in
+                // the catalog surfaces at load time, not at scan time
+                // (where it would silently never match).
+                if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+                    anyhow::bail!(
+                        "IOC pattern `{}`: sha256 must be 64 hex chars, got `{}` (len {})",
+                        p.id,
+                        sha256,
+                        sha256.len()
+                    );
+                }
+                if sha256.chars().any(|c| c.is_ascii_uppercase()) {
+                    anyhow::bail!("IOC pattern `{}`: sha256 must be lowercase hex", p.id);
+                }
             }
         }
         Ok(())
@@ -172,18 +209,23 @@ pub fn scan(root: &Path, catalog: &Catalog, allow_ids: &BTreeSet<String>) -> Res
         }
     }
 
-    // Basename patterns require a walk. Only walk if at least one
-    // such pattern is present and unallowed — saves the IO cost
-    // when the catalog only has relative_path entries.
-    let basename_patterns: Vec<&Pattern> = catalog
+    // Basename + sha256 patterns require a walk. Only walk if at
+    // least one such pattern is present and unallowed — saves the
+    // IO cost when the catalog only has relative_path entries.
+    let walk_patterns: Vec<&Pattern> = catalog
         .patterns
         .iter()
         .filter(|p| !allow_ids.contains(&p.id))
-        .filter(|p| matches!(p.match_spec, MatchSpec::Basename { .. }))
+        .filter(|p| {
+            matches!(
+                p.match_spec,
+                MatchSpec::Basename { .. } | MatchSpec::Sha256 { .. }
+            )
+        })
         .collect();
 
-    if !basename_patterns.is_empty() {
-        walk_for_basenames(&canon, &canon, &skip, &basename_patterns, &mut report.hits);
+    if !walk_patterns.is_empty() {
+        walk_for_content(&canon, &canon, &skip, &walk_patterns, &mut report.hits);
     }
 
     // Stable order: pattern id then path. Useful both for human
@@ -195,14 +237,14 @@ pub fn scan(root: &Path, catalog: &Catalog, allow_ids: &BTreeSet<String>) -> Res
     Ok(report)
 }
 
-fn walk_for_basenames(
+fn walk_for_content(
     root: &Path,
     dir: &Path,
     skip: &BTreeSet<&str>,
     patterns: &[&Pattern],
     hits: &mut Vec<Hit>,
 ) {
-    let entries = match std::fs::read_dir(dir) {
+    let entries = match fs::read_dir(dir) {
         Ok(it) => it,
         Err(_) => return,
     };
@@ -218,26 +260,77 @@ fn walk_for_basenames(
             if skip.contains(name_str.as_ref()) {
                 continue;
             }
-            walk_for_basenames(root, &path, skip, patterns, hits);
-        } else if ft.is_file() || ft.is_symlink() {
+            walk_for_content(root, &path, skip, patterns, hits);
+        } else if ft.is_file() {
+            // Hash lazily, only if at least one Sha256 pattern
+            // applies to this basename (or is unscoped). Bare
+            // Basename matches don't need the hash at all.
+            let mut hash: Option<String> = None;
             for pat in patterns {
-                if let MatchSpec::Basename { name: target } = &pat.match_spec
-                    && name_str == target.as_str()
-                {
-                    let rel = path
-                        .strip_prefix(root)
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| path.to_string_lossy().to_string());
-                    hits.push(Hit {
-                        pattern_id: pat.id.clone(),
-                        description: pat.description.clone(),
-                        severity: pat.severity,
-                        path: normalise_rel(&rel),
-                    });
+                match &pat.match_spec {
+                    MatchSpec::Basename { name: target } if name_str == target.as_str() => {
+                        push_hit(pat, root, &path, hits);
+                    }
+                    MatchSpec::Sha256 {
+                        sha256: expected,
+                        basename,
+                    } => {
+                        if let Some(b) = basename
+                            && name_str != b.as_str()
+                        {
+                            continue;
+                        }
+                        if hash.is_none() {
+                            hash = hash_file_capped(&path, MAX_HASH_BYTES);
+                        }
+                        if let Some(h) = &hash
+                            && h == expected
+                        {
+                            push_hit(pat, root, &path, hits);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
+        // Symlinks are not followed: a worm dropper could symlink
+        // to a benign file to escape a Sha256 match. The Basename
+        // path could in principle still match the link name, but
+        // we leave it out — the tamper module already records
+        // symlinks by target string and is the right home for that
+        // class of detection.
     }
+}
+
+fn push_hit(pat: &Pattern, root: &Path, path: &Path, hits: &mut Vec<Hit>) {
+    let rel = path
+        .strip_prefix(root)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string_lossy().to_string());
+    hits.push(Hit {
+        pattern_id: pat.id.clone(),
+        description: pat.description.clone(),
+        severity: pat.severity,
+        path: normalise_rel(&rel),
+    });
+}
+
+fn hash_file_capped(path: &Path, max_bytes: u64) -> Option<String> {
+    let meta = fs::metadata(path).ok()?;
+    if meta.len() > max_bytes {
+        return None;
+    }
+    let mut f = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf).ok()?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Some(format!("{:x}", hasher.finalize()))
 }
 
 fn normalise_rel(path: &str) -> String {
@@ -379,6 +472,113 @@ mod tests {
         let cat = Catalog::bundled().unwrap();
         let err = scan(&f, &cat, &BTreeSet::new()).unwrap_err().to_string();
         assert!(err.contains("not a directory"), "got: {err}");
+    }
+
+    #[test]
+    fn sha256_pattern_matches_by_content_not_path() {
+        let tmp = Tmp::new();
+        let body = b"// shai-hulud dropper payload\n";
+        // Same payload at two different paths — both must hit.
+        fs::create_dir_all(tmp.0.join("a")).unwrap();
+        fs::create_dir_all(tmp.0.join("b/nested")).unwrap();
+        fs::write(tmp.0.join("a/innocent-name.js"), body).unwrap();
+        fs::write(tmp.0.join("b/nested/another.js"), body).unwrap();
+        fs::write(tmp.0.join("decoy.js"), b"// completely different\n").unwrap();
+
+        let expected = {
+            let mut h = Sha256::new();
+            h.update(body);
+            format!("{:x}", h.finalize())
+        };
+        let yaml = format!(
+            "version: 1\npatterns:\n\
+             - id: known-dropper\n  description: t\n  severity: error\n  \
+             match: {{kind: sha256, sha256: {expected}}}\n"
+        );
+        let cat = Catalog::from_yaml(&yaml).unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert_eq!(
+            report.hits.len(),
+            2,
+            "both copies must hit, got {:?}",
+            report.hits
+        );
+        assert!(report.has_error());
+    }
+
+    #[test]
+    fn sha256_with_basename_scope_skips_other_filenames() {
+        // Same bytes at two paths. Catalog scopes to one basename
+        // → only that file is hashed + matched.
+        let tmp = Tmp::new();
+        let body = b"payload\n";
+        fs::write(tmp.0.join("dropper.js"), body).unwrap();
+        fs::write(tmp.0.join("README.md"), body).unwrap();
+        let expected = {
+            let mut h = Sha256::new();
+            h.update(body);
+            format!("{:x}", h.finalize())
+        };
+        let yaml = format!(
+            "version: 1\npatterns:\n\
+             - id: scoped\n  description: t\n  severity: warn\n  \
+             match: {{kind: sha256, sha256: {expected}, basename: dropper.js}}\n"
+        );
+        let cat = Catalog::from_yaml(&yaml).unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert_eq!(report.hits.len(), 1);
+        assert_eq!(report.hits[0].path, "dropper.js");
+    }
+
+    #[test]
+    fn sha256_mismatch_does_not_fire() {
+        let tmp = Tmp::new();
+        fs::write(tmp.0.join("a.txt"), b"hello").unwrap();
+        // 64 zeros — won't match anything real.
+        let cat = Catalog::from_yaml(
+            "version: 1\npatterns:\n\
+             - id: never\n  description: t\n  severity: error\n  \
+             match: {kind: sha256, sha256: 0000000000000000000000000000000000000000000000000000000000000000}\n",
+        )
+        .unwrap();
+        let report = scan(&tmp.0, &cat, &BTreeSet::new()).unwrap();
+        assert!(report.is_clean());
+    }
+
+    #[test]
+    fn sha256_catalog_rejects_short_or_uppercase_hex() {
+        let short = "version: 1\npatterns:\n\
+                     - id: x\n  description: t\n  severity: warn\n  \
+                     match: {kind: sha256, sha256: deadbeef}\n";
+        let err = Catalog::from_yaml(short).unwrap_err().to_string();
+        assert!(err.contains("64 hex chars"), "got: {err}");
+
+        let upper = format!(
+            "version: 1\npatterns:\n\
+             - id: y\n  description: t\n  severity: warn\n  \
+             match: {{kind: sha256, sha256: {}}}\n",
+            "A".repeat(64)
+        );
+        let err = Catalog::from_yaml(&upper).unwrap_err().to_string();
+        assert!(err.contains("lowercase"), "got: {err}");
+    }
+
+    #[test]
+    fn sha256_skips_files_over_size_cap() {
+        // Build a catalog whose sha256 we'll never compute (the
+        // file is > MAX_HASH_BYTES so the hasher short-circuits).
+        // Match is by-basename in addition so the test is fast.
+        let tmp = Tmp::new();
+        // Write a small placeholder; we'll override MAX_HASH_BYTES
+        // by checking the hash_file_capped helper directly because
+        // 16 MiB writes would make the test slow.
+        let f = tmp.0.join("payload");
+        fs::write(&f, b"abc").unwrap();
+        // 1-byte cap → 3-byte file is over the cap → returns None.
+        assert!(hash_file_capped(&f, 1).is_none());
+        // Plenty-large cap → hashes fine.
+        let h = hash_file_capped(&f, 1024).expect("hash should succeed under the cap");
+        assert_eq!(h.len(), 64);
     }
 
     #[test]

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod deps;
 pub mod events;
 pub mod html;
 pub mod installs;
+pub mod iocs;
 pub mod matcher;
 pub mod policy;
 pub mod presets;

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod html;
 pub mod installs;
 pub mod matcher;
 pub mod policy;
+pub mod presets;
 pub mod report;
 pub mod stats;
 pub mod suggest;

--- a/crates/sakimori-core/src/presets.rs
+++ b/crates/sakimori-core/src/presets.rs
@@ -98,9 +98,21 @@ pub struct PresetCtx {
 }
 
 /// Build the [`Policy`] for the requested preset.
+///
+/// The persistence preset is rendered in `mode: audit` because its
+/// `file.deny` list deliberately exceeds the kernel-side 8-entry cap
+/// — emitting `mode: block` would produce a policy that fails the
+/// project's own [`Policy::validate`]. The header in
+/// [`format_yaml`] tells the operator to flip to `mode: block` only
+/// after pruning to the cap. The cloud-secret-egress preset stays in
+/// `mode: block` (no equivalent cap on `network.deny`).
 pub fn build(preset: Preset, ctx: &PresetCtx) -> Policy {
+    let mode = match preset {
+        Preset::Persistence => Mode::Audit,
+        Preset::CloudSecretEgress => Mode::Block,
+    };
     let mut policy = Policy {
-        mode: Mode::Block,
+        mode,
         network: NetworkPolicy {
             default: DefaultDecision::Allow,
             allow: Vec::new(),
@@ -222,9 +234,10 @@ pub fn format_yaml(preset: Preset, ctx: &PresetCtx) -> Result<String> {
                 );
             }
             out.push_str(
-                "# Kernel-side block (Linux) caps file.deny at 8 entries — prune to your \
-                 8 most critical\n# locations under `mode: block`, or keep the full list \
-                 under `mode: audit` (uncapped).\n",
+                "# Emitted as `mode: audit` because the Linux kernel caps file.deny at 8 \
+                 entries under\n# `mode: block` and this list deliberately exceeds that. \
+                 To enforce: prune to the 8 most\n# critical paths for your threat model, \
+                 then flip `mode:` to `block`.\n",
             );
         }
         Preset::CloudSecretEgress => {
@@ -317,7 +330,9 @@ mod tests {
         assert!(!p.file.deny.is_empty());
         assert!(p.network.deny.is_empty());
         assert_eq!(p.file.default, DefaultDecision::Allow);
-        assert_eq!(p.mode, Mode::Block);
+        // Audit, not block — the deny list exceeds the kernel 8-entry
+        // cap on purpose, so block mode would fail `Policy::validate`.
+        assert_eq!(p.mode, Mode::Audit);
     }
 
     #[test]
@@ -326,6 +341,28 @@ mod tests {
         assert!(!p.network.deny.is_empty());
         assert!(p.file.deny.is_empty());
         assert_eq!(p.network.default, DefaultDecision::Allow);
+        assert_eq!(p.mode, Mode::Block);
+    }
+
+    #[test]
+    fn rendered_presets_pass_their_own_effective_mode_validation() {
+        // Regression for the codex review finding: a rendered preset
+        // written straight to a policy file must load + validate
+        // under the mode it ships in. Persistence ships audit
+        // (uncapped); cloud-secret-egress ships block (no cap).
+        for preset in Preset::all() {
+            let yaml = format_yaml(
+                *preset,
+                &PresetCtx {
+                    home: Some("/h".into()),
+                },
+            )
+            .unwrap();
+            let parsed: Policy = serde_yaml::from_str(&yaml).unwrap();
+            parsed
+                .validate(parsed.mode)
+                .unwrap_or_else(|e| panic!("{} fails validation: {e}", preset.name()));
+        }
     }
 
     #[test]

--- a/crates/sakimori-core/src/presets.rs
+++ b/crates/sakimori-core/src/presets.rs
@@ -1,0 +1,380 @@
+//! Curated policy rule packs for known supply-chain attack patterns.
+//!
+//! Each preset returns a [`Policy`] populated with only the relevant
+//! deny rules. The CLI subcommand `sakimori policy preset <name>`
+//! renders one as a YAML block annotated with explanatory comments so
+//! the operator can drop it into an existing policy file or use it
+//! standalone.
+//!
+//! Presets are intentionally conservative: every rule is something
+//! that should never legitimately fire during a `npm install` /
+//! `cargo build` / `pip install`. False positives here are a strong
+//! signal of compromise, not noise.
+//!
+//! Kernel cap reminder: `file.deny` is limited to 8 entries under
+//! `mode: block` on Linux (see [`sakimori_common::FILE_DENY_MAX_ENTRIES`]).
+//! The persistence preset exceeds that on purpose — the user picks the
+//! 8 highest-value entries for their threat model and leaves the rest
+//! for audit mode (which is uncapped).
+//!
+//! Out of scope here: workspace-relative paths (`.claude/setup.mjs`,
+//! `.vscode/tasks.json`). The file matcher is absolute-prefix only, so
+//! those belong to the IOC workspace scanner (roadmap item 18), not
+//! `file.deny`.
+
+use std::str::FromStr;
+
+use anyhow::{Result, anyhow};
+
+use crate::policy::{
+    DefaultDecision, EnvPolicy, FilePolicy, Mode, NetRule, NetworkPolicy, Policy, ProcessPolicy,
+};
+
+/// One of the curated rule packs. See module docs for the design
+/// philosophy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Preset {
+    /// File-write tripwire for OS-level persistence locations
+    /// (launchd / systemd / cron / shell-rc / ~/.ssh).
+    Persistence,
+    /// Network-egress tripwire for cloud metadata services and
+    /// secret-bearing endpoints (AWS / GCP / Azure IMDS + STS).
+    CloudSecretEgress,
+}
+
+impl Preset {
+    /// Canonical CLI name (kebab-case).
+    pub fn name(&self) -> &'static str {
+        match self {
+            Preset::Persistence => "persistence",
+            Preset::CloudSecretEgress => "cloud-secret-egress",
+        }
+    }
+
+    /// All preset names, for `--help` discovery.
+    pub fn all() -> &'static [Preset] {
+        &[Preset::Persistence, Preset::CloudSecretEgress]
+    }
+
+    /// One-line description shown above the YAML block.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Preset::Persistence => {
+                "Tripwire for OS-level persistence writes — launchd / systemd / cron / \
+                 shell-rc / ~/.ssh. Any package-manager subtree touching these is a strong \
+                 signal of a worm-style supply-chain compromise (Shai-Hulud class)."
+            }
+            Preset::CloudSecretEgress => {
+                "Tripwire for cloud-credential exfiltration — AWS / GCP / Azure metadata \
+                 services and STS-style secret endpoints. Pairs with the proxy's SNI \
+                 filter (v0.33+) so a CDN-rotated IP can't slip past the IP-only rules."
+            }
+        }
+    }
+}
+
+impl FromStr for Preset {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "persistence" => Ok(Preset::Persistence),
+            "cloud-secret-egress" => Ok(Preset::CloudSecretEgress),
+            other => Err(anyhow!(
+                "unknown preset `{other}` (known: persistence, cloud-secret-egress)"
+            )),
+        }
+    }
+}
+
+/// Inputs for rendering a preset. `home` is consulted by
+/// [`Preset::Persistence`] to expand `~/.ssh` etc. into absolute paths
+/// the file matcher understands.
+#[derive(Debug, Clone, Default)]
+pub struct PresetCtx {
+    /// Home directory to expand into. When `None`, the per-user entries
+    /// are omitted from the rendered policy and a comment notes that
+    /// the operator should add them by hand.
+    pub home: Option<String>,
+}
+
+/// Build the [`Policy`] for the requested preset.
+pub fn build(preset: Preset, ctx: &PresetCtx) -> Policy {
+    let mut policy = Policy {
+        mode: Mode::Block,
+        network: NetworkPolicy {
+            default: DefaultDecision::Allow,
+            allow: Vec::new(),
+            deny: Vec::new(),
+        },
+        file: FilePolicy {
+            default: DefaultDecision::Allow,
+            allow: Vec::new(),
+            deny: Vec::new(),
+        },
+        process: ProcessPolicy::default(),
+        env: EnvPolicy::default(),
+    };
+    match preset {
+        Preset::Persistence => {
+            policy.file.deny = persistence_paths(ctx.home.as_deref());
+        }
+        Preset::CloudSecretEgress => {
+            policy.network.deny = cloud_secret_egress_rules();
+        }
+    }
+    policy
+}
+
+/// Concrete file-prefix list for [`Preset::Persistence`]. Visible for
+/// tests; the CLI goes through [`build`].
+pub fn persistence_paths(home: Option<&str>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+
+    // System-wide persistence (no $HOME needed).
+    out.extend(
+        [
+            // macOS launchd
+            "/Library/LaunchAgents/",
+            "/Library/LaunchDaemons/",
+            // Linux systemd (system scope)
+            "/etc/systemd/system/",
+            "/etc/init.d/",
+            // Linux cron
+            "/var/spool/cron/",
+            "/etc/cron.d/",
+            "/etc/cron.hourly/",
+            "/etc/cron.daily/",
+            "/etc/cron.weekly/",
+            "/etc/cron.monthly/",
+        ]
+        .iter()
+        .map(|s| (*s).to_string()),
+    );
+
+    if let Some(home) = home {
+        let h = home.trim_end_matches('/');
+        out.extend([
+            // macOS per-user launchd
+            format!("{h}/Library/LaunchAgents/"),
+            format!("{h}/Library/LaunchDaemons/"),
+            // Linux per-user systemd + autostart
+            format!("{h}/.config/systemd/user/"),
+            format!("{h}/.config/autostart/"),
+            // SSH
+            format!("{h}/.ssh/"),
+            // Shell rc / profile — common worm injection targets.
+            // Listed as exact files (no trailing slash) so the
+            // matcher doesn't accidentally allow a directory.
+            format!("{h}/.bashrc"),
+            format!("{h}/.bash_profile"),
+            format!("{h}/.bash_logout"),
+            format!("{h}/.profile"),
+            format!("{h}/.zshrc"),
+            format!("{h}/.zprofile"),
+            format!("{h}/.zshenv"),
+        ]);
+    }
+
+    out
+}
+
+/// Concrete `network.deny` rules for [`Preset::CloudSecretEgress`].
+/// Visible for tests; the CLI goes through [`build`].
+pub fn cloud_secret_egress_rules() -> Vec<NetRule> {
+    // No ports = match every port for the target. Belt-and-braces:
+    // include the IMDS IP literal alongside the hostnames, since
+    // cgroup-side enforcement sees an IP and the hostname-keyed rules
+    // only fire after DNS resolution catches up.
+    let target = |s: &str| NetRule {
+        target: s.to_string(),
+        ports: Vec::new(),
+    };
+    vec![
+        // AWS / GCP / Azure share the link-local IMDS IP.
+        target("169.254.169.254"),
+        // GCP metadata (always resolves to 169.254.169.254 but the
+        // hostname appears in user code).
+        target("metadata.google.internal"),
+        // Azure IMDS (same IP, different naming).
+        target("metadata.azure.com"),
+        // AWS STS — the "assume this role" endpoint.
+        target("sts.amazonaws.com"),
+    ]
+}
+
+/// Render a preset as a YAML block, prefixed with a comment header
+/// explaining what it is and how to merge it.
+pub fn format_yaml(preset: Preset, ctx: &PresetCtx) -> Result<String> {
+    let policy = build(preset, ctx);
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Generated by `sakimori policy preset {}`.\n# {}\n",
+        preset.name(),
+        preset.description(),
+    ));
+    match preset {
+        Preset::Persistence => {
+            if ctx.home.is_none() {
+                out.push_str(
+                    "# NOTE: --home was not supplied, so per-user paths \
+                     (~/.ssh, shell rc) were omitted.\n#       Re-run with --home \
+                     /path/to/home to include them.\n",
+                );
+            }
+            out.push_str(
+                "# Kernel-side block (Linux) caps file.deny at 8 entries — prune to your \
+                 8 most critical\n# locations under `mode: block`, or keep the full list \
+                 under `mode: audit` (uncapped).\n",
+            );
+        }
+        Preset::CloudSecretEgress => {
+            out.push_str(
+                "# Pair with `sakimori proxy start --network-allow ...` for SNI-level \
+                 enforcement;\n# the rules below are eBPF-cgroup enforced (Linux) and \
+                 fire on IP/hostname resolution.\n",
+            );
+        }
+    }
+    out.push_str(&serde_yaml::to_string(&policy)?);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_name_round_trip() {
+        for p in Preset::all() {
+            assert_eq!(Preset::from_str(p.name()).unwrap(), *p);
+        }
+    }
+
+    #[test]
+    fn unknown_preset_errors() {
+        assert!(Preset::from_str("nope").is_err());
+    }
+
+    #[test]
+    fn persistence_without_home_keeps_only_system_paths() {
+        let paths = persistence_paths(None);
+        assert!(paths.iter().any(|p| p == "/Library/LaunchAgents/"));
+        assert!(paths.iter().any(|p| p == "/etc/systemd/system/"));
+        assert!(paths.iter().any(|p| p == "/etc/cron.d/"));
+        assert!(
+            !paths.iter().any(|p| p.contains(".ssh")),
+            "no $HOME → no per-user entries"
+        );
+    }
+
+    #[test]
+    fn persistence_with_home_expands_user_paths() {
+        let paths = persistence_paths(Some("/Users/alice"));
+        assert!(paths.iter().any(|p| p == "/Users/alice/.ssh/"));
+        assert!(paths.iter().any(|p| p == "/Users/alice/.zshrc"));
+        assert!(
+            paths
+                .iter()
+                .any(|p| p == "/Users/alice/Library/LaunchAgents/")
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p == "/Users/alice/.config/systemd/user/")
+        );
+    }
+
+    #[test]
+    fn persistence_strips_trailing_slash_on_home() {
+        let with = persistence_paths(Some("/home/bob/"));
+        let without = persistence_paths(Some("/home/bob"));
+        assert_eq!(with, without, "trailing slash on --home must not matter");
+    }
+
+    #[test]
+    fn cloud_egress_includes_imds_ip_literal() {
+        let rules = cloud_secret_egress_rules();
+        assert!(rules.iter().any(|r| r.target == "169.254.169.254"));
+        assert!(rules.iter().any(|r| r.target == "sts.amazonaws.com"));
+        for r in &rules {
+            assert!(
+                r.ports.is_empty(),
+                "every-port match for {} (was {:?})",
+                r.target,
+                r.ports
+            );
+        }
+    }
+
+    #[test]
+    fn build_persistence_sets_file_deny_not_network() {
+        let p = build(
+            Preset::Persistence,
+            &PresetCtx {
+                home: Some("/h".into()),
+            },
+        );
+        assert!(!p.file.deny.is_empty());
+        assert!(p.network.deny.is_empty());
+        assert_eq!(p.file.default, DefaultDecision::Allow);
+        assert_eq!(p.mode, Mode::Block);
+    }
+
+    #[test]
+    fn build_cloud_egress_sets_network_deny_not_file() {
+        let p = build(Preset::CloudSecretEgress, &PresetCtx::default());
+        assert!(!p.network.deny.is_empty());
+        assert!(p.file.deny.is_empty());
+        assert_eq!(p.network.default, DefaultDecision::Allow);
+    }
+
+    #[test]
+    fn format_yaml_persistence_announces_missing_home() {
+        let s = format_yaml(Preset::Persistence, &PresetCtx::default()).unwrap();
+        assert!(s.contains("--home was not supplied"));
+        assert!(s.contains("file:"));
+        assert!(s.contains("/Library/LaunchAgents/"));
+    }
+
+    #[test]
+    fn format_yaml_persistence_with_home_omits_warning() {
+        let s = format_yaml(
+            Preset::Persistence,
+            &PresetCtx {
+                home: Some("/Users/alice".into()),
+            },
+        )
+        .unwrap();
+        assert!(!s.contains("--home was not supplied"));
+        assert!(s.contains("/Users/alice/.ssh/"));
+    }
+
+    #[test]
+    fn format_yaml_cloud_egress_mentions_proxy_pairing() {
+        let s = format_yaml(Preset::CloudSecretEgress, &PresetCtx::default()).unwrap();
+        assert!(s.contains("--network-allow"));
+        assert!(s.contains("169.254.169.254"));
+    }
+
+    #[test]
+    fn format_yaml_round_trips_as_loadable_policy() {
+        // What the CLI emits must parse back into a Policy via the
+        // same loader real users hit (`Policy::from_file` indirectly).
+        for preset in Preset::all() {
+            let yaml = format_yaml(
+                *preset,
+                &PresetCtx {
+                    home: Some("/h".into()),
+                },
+            )
+            .unwrap();
+            let parsed: Policy = serde_yaml::from_str(&yaml).expect("yaml parses as Policy");
+            // Validate against a permissive mode so the file-deny cap
+            // doesn't trip on the persistence preset (deliberately
+            // exceeds 8 — see module docs).
+            parsed
+                .validate(Mode::Audit)
+                .expect("rendered policy passes audit-mode validation");
+        }
+    }
+}

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -393,6 +393,30 @@ pub enum PolicyCommand {
     /// block so you can pick which to deny — the suggester never
     /// auto-populates `process.deny_exec`.
     Suggest(PolicySuggestArgs),
+    /// Emit a curated rule pack for a known supply-chain attack
+    /// pattern (persistence-write, cloud-secret egress, ...) as a
+    /// ready-to-merge YAML block. See `--help` for the available
+    /// preset names.
+    Preset(PolicyPresetArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct PolicyPresetArgs {
+    /// Preset name. Known values:
+    ///   `persistence` — file.deny tripwire for launchd / systemd /
+    ///   cron / shell-rc / ~/.ssh.
+    ///   `cloud-secret-egress` — network.deny tripwire for cloud
+    ///   metadata services (AWS / GCP / Azure IMDS + STS).
+    pub name: String,
+    /// Where to write the rendered policy. Defaults to stdout.
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
+    /// Home directory used to expand `~/.ssh` etc. into absolute
+    /// paths. Defaults to `$HOME`. Only consulted by the
+    /// `persistence` preset; omitted entries cause the corresponding
+    /// per-user paths to be skipped.
+    #[arg(long, value_name = "PATH")]
+    pub home: Option<PathBuf>,
 }
 
 #[derive(Debug, Parser)]
@@ -1011,6 +1035,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Policy {
             cmd: PolicyCommand::Suggest(args),
         } => run_policy_suggest(args),
+        Command::Policy {
+            cmd: PolicyCommand::Preset(args),
+        } => run_policy_preset(args),
         Command::Actions {
             cmd: ActionsCommand::Audit(args),
         } => run_actions_audit(args),
@@ -1519,6 +1546,30 @@ fn run_policy_suggest(args: PolicySuggestArgs) -> Result<()> {
             std::fs::write(&path, yaml)
                 .with_context(|| format!("writing suggested policy to {}", path.display()))?;
             eprintln!("sakimori: wrote suggested policy to {}", path.display());
+        }
+        None => print!("{yaml}"),
+    }
+    Ok(())
+}
+
+fn run_policy_preset(args: PolicyPresetArgs) -> Result<()> {
+    use std::str::FromStr;
+    let preset = sakimori_core::presets::Preset::from_str(&args.name)?;
+    let home = args
+        .home
+        .map(|p| p.to_string_lossy().into_owned())
+        .or_else(|| std::env::var("HOME").ok());
+    let ctx = sakimori_core::presets::PresetCtx { home };
+    let yaml = sakimori_core::presets::format_yaml(preset, &ctx)?;
+    match args.output {
+        Some(path) => {
+            std::fs::write(&path, yaml)
+                .with_context(|| format!("writing preset policy to {}", path.display()))?;
+            eprintln!(
+                "sakimori: wrote preset `{}` to {}",
+                preset.name(),
+                path.display()
+            );
         }
         None => print!("{yaml}"),
     }

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -294,6 +294,28 @@ pub enum WorkspaceCommand {
     /// files. Exits non-zero when there's any drift (suppress with
     /// `--allow-drift`).
     Diff(WorkspaceDiffArgs),
+    /// Scan a directory against the bundled known-IOC index and
+    /// report any matching files (Shai-Hulud-class fingerprints).
+    /// Exits non-zero on any Error-severity hit; Warn-severity hits
+    /// surface but don't gate. Use `--allow-id` to suppress a
+    /// pattern the operator has already triaged as benign.
+    ScanIocs(WorkspaceScanIocsArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct WorkspaceScanIocsArgs {
+    /// Directory to scan.
+    pub dir: PathBuf,
+    /// Override the bundled IOC catalog with a custom YAML file
+    /// (same schema as `crates/sakimori-core/iocs/coronarium-iocs.yml`).
+    #[arg(long, value_name = "FILE")]
+    pub index: Option<PathBuf>,
+    /// Suppress a specific pattern by id. Repeatable.
+    #[arg(long = "allow-id", value_name = "ID")]
+    pub allow_id: Vec<String>,
+    /// Emit machine-readable JSON instead of the default text report.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -1047,6 +1069,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Workspace {
             cmd: WorkspaceCommand::Diff(args),
         } => run_workspace_diff(args),
+        Command::Workspace {
+            cmd: WorkspaceCommand::ScanIocs(args),
+        } => run_workspace_scan_iocs(args),
         Command::Daemon {
             cmd: DaemonCommand::Start(args),
         } => run_daemon_start(args).await,
@@ -1202,6 +1227,47 @@ fn run_workspace_diff(args: WorkspaceDiffArgs) -> Result<()> {
     }
 
     if !dif.is_clean() && !args.allow_drift {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn run_workspace_scan_iocs(args: WorkspaceScanIocsArgs) -> Result<()> {
+    use std::collections::BTreeSet;
+    let catalog = match &args.index {
+        Some(p) => sakimori_core::iocs::Catalog::from_file(p)?,
+        None => sakimori_core::iocs::Catalog::bundled()?,
+    };
+    let allow: BTreeSet<String> = args.allow_id.into_iter().collect();
+    let report = sakimori_core::iocs::scan(&args.dir, &catalog, &allow)?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else if report.is_clean() {
+        eprintln!(
+            "sakimori: scanned {} — no known IOCs matched (catalog v{}, {} pattern(s))",
+            report.root.display(),
+            catalog.version,
+            catalog.patterns.len(),
+        );
+    } else {
+        eprintln!(
+            "sakimori: {} IOC hit(s) in {} (catalog v{})\n",
+            report.hits.len(),
+            report.root.display(),
+            catalog.version,
+        );
+        for h in &report.hits {
+            let tag = match h.severity {
+                sakimori_core::iocs::Severity::Error => "ERROR",
+                sakimori_core::iocs::Severity::Warn => "WARN ",
+            };
+            println!("[{}] {}  {}", tag, h.pattern_id, h.path);
+            println!("        {}", h.description.replace('\n', " "));
+        }
+    }
+
+    if report.has_error() {
         std::process::exit(1);
     }
     Ok(())


### PR DESCRIPTION
## Summary

Three new operator-facing surfaces for catching Shai-Hulud-class
supply-chain attacks, all conservatively scoped: report and exit
non-zero, no auto-quarantine.

- **`sakimori policy preset persistence`** — ready-to-merge YAML
  block for OS-level persistence write tripwires (launchd /
  systemd / cron / shell-rc / `~/.ssh`). Per-user paths expand
  from `$HOME` or `--home`; ships in `mode: audit` because the
  full list exceeds the Linux 8-entry kernel cap on `file.deny`
  under `mode: block` (header tells the operator how to prune +
  enforce). Roadmap item 16.
- **`sakimori policy preset cloud-secret-egress`** — ready-to-merge
  `network.deny` block for AWS / GCP / Azure IMDS + STS. Includes
  the link-local `169.254.169.254` literal so the cgroup-side rule
  fires even before DNS catches up. Roadmap item 17 (first slice;
  wildcard endpoints land with a proxy SNI deny-list follow-up).
- **`sakimori workspace scan-iocs <DIR>`** — walks a workspace
  honouring the same skip list as `workspace diff` and flags files
  matching a bundled IOC catalog. Three pattern kinds:
  `relative_path` (exact path from root, stat-only), `basename`
  (anywhere in tree, file or symlink), `sha256` (content hash,
  files only, capped at 16 MiB, optional `basename:` scope to keep
  hashing cheap). Bundled catalog seeded with two Shai-Hulud
  markers (`.claude/setup.mjs` and the spoofed
  `codeql_analysis.yml`). Custom feeds via `--index <file>`;
  triaged false positives via `--allow-id <id>`. Exits non-zero on
  any Error-severity hit. Roadmap item 18.

Codex review caught three real bugs across the iterations and
each has its own follow-up commit:

- `2176b5e` — persistence preset was emitting `mode: block` with
  >8 file.deny entries → fails our own validate(); switched to
  `mode: audit`.
- `04b99ea` — scan-iocs silently returned "0 hits, exit 0" when
  the root directory didn't exist (CI gate failure mode); now
  errors loudly.
- `5c3c84a` — adding sha256 support accidentally regressed
  basename matching on symlinks; restored.

## Test plan

- [x] `cargo test --workspace` — 212 sakimori-core tests pass (15
  new for iocs, 13 for presets)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Manual smoke: `sakimori policy preset persistence --home /Users/alice`
  prints expanded paths; `sakimori workspace scan-iocs <dir>` exits 1
  with `[ERROR] shai-hulud-claude-setup` on a workspace containing
  `.claude/setup.mjs`
- [x] Each commit independently reviewed by Codex; final state
  Codex-approved
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)