### PR TITLE
iocs: sakimori iocs update + override-aware loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,17 @@ sakimori workspace scan-iocs $GITHUB_WORKSPACE
 sakimori workspace scan-iocs . --json
 ```
 
+**Refreshing the IOC catalog:** `sakimori iocs update <url>` fetches
+a refreshed catalog (same YAML schema) from an upstream feed,
+validates it, and atomically writes it to
+`~/.sakimori/iocs.yml` (override `--output`). The scanner picks
+the override up automatically on the next run. Run
+`sakimori iocs where` to confirm which catalog is in effect; a
+corrupted override is detected and the scanner falls back to the
+bundled copy with a loud warning, never silently. Validation runs
+before the atomic rename — a malformed feed cannot clobber a
+working override on disk.
+
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm
 - **host column** (PTR-resolved reverse DNS for connect events)

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -53,16 +53,27 @@ pub const BUNDLED_CATALOG_YAML: &str = include_str!("../iocs/coronarium-iocs.yml
 /// Returns `None` only when every candidate env var is unset, in
 /// which case the CLI tells the operator to pass `--output`.
 pub fn default_override_path() -> Option<PathBuf> {
-    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+    resolve_override_path(|k| std::env::var_os(k))
+}
+
+/// Inner resolver with the env lookup injected. Lets tests exercise
+/// every branch without touching `std::env::set_var` — which is
+/// `unsafe` on Unix and racy with any other test in the same process
+/// reading the env in parallel.
+fn resolve_override_path<F>(env: F) -> Option<PathBuf>
+where
+    F: Fn(&str) -> Option<std::ffi::OsString>,
+{
+    if let Some(xdg) = env("XDG_DATA_HOME") {
         return Some(PathBuf::from(xdg).join("sakimori").join("iocs.yml"));
     }
-    if let Some(home) = std::env::var_os("HOME") {
+    if let Some(home) = env("HOME") {
         return Some(PathBuf::from(home).join(".sakimori").join("iocs.yml"));
     }
-    if let Some(la) = std::env::var_os("LOCALAPPDATA") {
+    if let Some(la) = env("LOCALAPPDATA") {
         return Some(PathBuf::from(la).join("sakimori").join("iocs.yml"));
     }
-    if let Some(up) = std::env::var_os("USERPROFILE") {
+    if let Some(up) = env("USERPROFILE") {
         return Some(PathBuf::from(up).join(".sakimori").join("iocs.yml"));
     }
     None
@@ -778,108 +789,53 @@ mod tests {
         assert_eq!(h.len(), 64);
     }
 
-    /// Drives `default_override_path` with a known env state to
-    /// exercise the resolution order without depending on the
-    /// developer machine's real env. Each candidate gets `var` (set
-    /// to a tmp value) or `remove`d for the test.
-    ///
-    /// `std::env::set_var` is process-global and `cargo test` runs
-    /// these in parallel, so we serialise via a mutex.
-    fn run_with_env(env: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let to_restore: Vec<(&str, Option<std::ffi::OsString>)> =
-            env.iter().map(|(k, _)| (*k, std::env::var_os(k))).collect();
-        for (k, v) in env {
-            match v {
-                Some(val) => unsafe { std::env::set_var(k, val) },
-                None => unsafe { std::env::remove_var(k) },
-            }
-        }
-        f();
-        for (k, v) in to_restore {
-            match v {
-                Some(val) => unsafe { std::env::set_var(k, val) },
-                None => unsafe { std::env::remove_var(k) },
-            }
-        }
+    /// Builds an env lookup from a map. Lets tests exercise the
+    /// resolver branches without ever touching `std::env::set_var`
+    /// (unsafe on Unix + racy with any parallel test reading env).
+    fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<std::ffi::OsString> {
+        let map: std::collections::HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |k: &str| map.get(k).map(std::ffi::OsString::from)
     }
 
     #[test]
     fn default_override_path_resolution_order() {
         // XDG wins when set.
-        run_with_env(
-            &[
-                ("XDG_DATA_HOME", Some("/xdg")),
-                ("HOME", Some("/home")),
-                ("LOCALAPPDATA", Some("C:/la")),
-                ("USERPROFILE", Some("C:/up")),
-            ],
-            || {
-                assert_eq!(
-                    default_override_path(),
-                    Some(PathBuf::from("/xdg/sakimori/iocs.yml"))
-                );
-            },
+        assert_eq!(
+            resolve_override_path(env_from(&[
+                ("XDG_DATA_HOME", "/xdg"),
+                ("HOME", "/home"),
+                ("LOCALAPPDATA", "C:/la"),
+                ("USERPROFILE", "C:/up"),
+            ])),
+            Some(PathBuf::from("/xdg/sakimori/iocs.yml"))
         );
         // HOME wins over Windows vars when XDG is unset.
-        run_with_env(
-            &[
-                ("XDG_DATA_HOME", None),
-                ("HOME", Some("/home")),
-                ("LOCALAPPDATA", Some("C:/la")),
-                ("USERPROFILE", Some("C:/up")),
-            ],
-            || {
-                assert_eq!(
-                    default_override_path(),
-                    Some(PathBuf::from("/home/.sakimori/iocs.yml"))
-                );
-            },
+        assert_eq!(
+            resolve_override_path(env_from(&[
+                ("HOME", "/home"),
+                ("LOCALAPPDATA", "C:/la"),
+                ("USERPROFILE", "C:/up"),
+            ])),
+            Some(PathBuf::from("/home/.sakimori/iocs.yml"))
         );
-        // Windows path: LOCALAPPDATA preferred over USERPROFILE.
-        run_with_env(
-            &[
-                ("XDG_DATA_HOME", None),
-                ("HOME", None),
-                ("LOCALAPPDATA", Some("C:/la")),
-                ("USERPROFILE", Some("C:/up")),
-            ],
-            || {
-                assert_eq!(
-                    default_override_path(),
-                    Some(PathBuf::from("C:/la/sakimori/iocs.yml"))
-                );
-            },
+        // Windows: LOCALAPPDATA preferred over USERPROFILE.
+        assert_eq!(
+            resolve_override_path(env_from(&[
+                ("LOCALAPPDATA", "C:/la"),
+                ("USERPROFILE", "C:/up"),
+            ])),
+            Some(PathBuf::from("C:/la/sakimori/iocs.yml"))
         );
         // USERPROFILE last-resort.
-        run_with_env(
-            &[
-                ("XDG_DATA_HOME", None),
-                ("HOME", None),
-                ("LOCALAPPDATA", None),
-                ("USERPROFILE", Some("C:/up")),
-            ],
-            || {
-                assert_eq!(
-                    default_override_path(),
-                    Some(PathBuf::from("C:/up/.sakimori/iocs.yml"))
-                );
-            },
+        assert_eq!(
+            resolve_override_path(env_from(&[("USERPROFILE", "C:/up")])),
+            Some(PathBuf::from("C:/up/.sakimori/iocs.yml"))
         );
-        // Nothing → None.
-        run_with_env(
-            &[
-                ("XDG_DATA_HOME", None),
-                ("HOME", None),
-                ("LOCALAPPDATA", None),
-                ("USERPROFILE", None),
-            ],
-            || {
-                assert_eq!(default_override_path(), None);
-            },
-        );
+        // Empty env → None.
+        assert_eq!(resolve_override_path(env_from(&[])), None);
     }
 
     #[test]

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -53,6 +53,10 @@ pub const BUNDLED_CATALOG_YAML: &str = include_str!("../iocs/coronarium-iocs.yml
 /// Returns `None` only when every candidate env var is unset, in
 /// which case the CLI tells the operator to pass `--output`.
 pub fn default_override_path() -> Option<PathBuf> {
+    // Closure (not bare `std::env::var_os`) because `var_os` is
+    // generic over `AsRef<OsStr>` and the resolver needs a concrete
+    // `Fn(&str) -> _`. Clippy is fine with this form; the bare path
+    // would also trip type inference.
     resolve_override_path(|k| std::env::var_os(k))
 }
 

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -37,15 +37,35 @@ pub const BUNDLED_CATALOG_YAML: &str = include_str!("../iocs/coronarium-iocs.yml
 
 /// User-writable IOC override location. Honoured by
 /// [`Catalog::load_with_fallback`]: present + parseable = used;
-/// absent or unparseable = fall back to bundled. Resolved from
-/// `$HOME` (or `$XDG_DATA_HOME` if set) at call time, not at
-/// compile time, so a test running with a tmp `HOME` doesn't
+/// absent or unparseable = fall back to bundled. Resolved at call
+/// time, not compile time, so tests with a tmp `HOME` don't
 /// accidentally read the developer's real cache.
+///
+/// Resolution order (first hit wins):
+/// 1. `$XDG_DATA_HOME/sakimori/iocs.yml` (Linux/XDG-aware setups)
+/// 2. `$HOME/.sakimori/iocs.yml` (macOS + traditional Unix)
+/// 3. `%LOCALAPPDATA%\sakimori\iocs.yml` (Windows, matches the
+///    convention already used by `deps verify-cache` for the npm
+///    cacache root)
+/// 4. `%USERPROFILE%\.sakimori\iocs.yml` (Windows last-resort —
+///    older shells / Cygwin-like envs where LOCALAPPDATA is unset)
+///
+/// Returns `None` only when every candidate env var is unset, in
+/// which case the CLI tells the operator to pass `--output`.
 pub fn default_override_path() -> Option<PathBuf> {
-    let base = std::env::var_os("XDG_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".sakimori")))?;
-    Some(base.join("iocs.yml"))
+    if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+        return Some(PathBuf::from(xdg).join("sakimori").join("iocs.yml"));
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(PathBuf::from(home).join(".sakimori").join("iocs.yml"));
+    }
+    if let Some(la) = std::env::var_os("LOCALAPPDATA") {
+        return Some(PathBuf::from(la).join("sakimori").join("iocs.yml"));
+    }
+    if let Some(up) = std::env::var_os("USERPROFILE") {
+        return Some(PathBuf::from(up).join(".sakimori").join("iocs.yml"));
+    }
+    None
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -756,6 +776,110 @@ mod tests {
         // Plenty-large cap → hashes fine.
         let h = hash_file_capped(&f, 1024).expect("hash should succeed under the cap");
         assert_eq!(h.len(), 64);
+    }
+
+    /// Drives `default_override_path` with a known env state to
+    /// exercise the resolution order without depending on the
+    /// developer machine's real env. Each candidate gets `var` (set
+    /// to a tmp value) or `remove`d for the test.
+    ///
+    /// `std::env::set_var` is process-global and `cargo test` runs
+    /// these in parallel, so we serialise via a mutex.
+    fn run_with_env(env: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let to_restore: Vec<(&str, Option<std::ffi::OsString>)> =
+            env.iter().map(|(k, _)| (*k, std::env::var_os(k))).collect();
+        for (k, v) in env {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+        f();
+        for (k, v) in to_restore {
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+
+    #[test]
+    fn default_override_path_resolution_order() {
+        // XDG wins when set.
+        run_with_env(
+            &[
+                ("XDG_DATA_HOME", Some("/xdg")),
+                ("HOME", Some("/home")),
+                ("LOCALAPPDATA", Some("C:/la")),
+                ("USERPROFILE", Some("C:/up")),
+            ],
+            || {
+                assert_eq!(
+                    default_override_path(),
+                    Some(PathBuf::from("/xdg/sakimori/iocs.yml"))
+                );
+            },
+        );
+        // HOME wins over Windows vars when XDG is unset.
+        run_with_env(
+            &[
+                ("XDG_DATA_HOME", None),
+                ("HOME", Some("/home")),
+                ("LOCALAPPDATA", Some("C:/la")),
+                ("USERPROFILE", Some("C:/up")),
+            ],
+            || {
+                assert_eq!(
+                    default_override_path(),
+                    Some(PathBuf::from("/home/.sakimori/iocs.yml"))
+                );
+            },
+        );
+        // Windows path: LOCALAPPDATA preferred over USERPROFILE.
+        run_with_env(
+            &[
+                ("XDG_DATA_HOME", None),
+                ("HOME", None),
+                ("LOCALAPPDATA", Some("C:/la")),
+                ("USERPROFILE", Some("C:/up")),
+            ],
+            || {
+                assert_eq!(
+                    default_override_path(),
+                    Some(PathBuf::from("C:/la/sakimori/iocs.yml"))
+                );
+            },
+        );
+        // USERPROFILE last-resort.
+        run_with_env(
+            &[
+                ("XDG_DATA_HOME", None),
+                ("HOME", None),
+                ("LOCALAPPDATA", None),
+                ("USERPROFILE", Some("C:/up")),
+            ],
+            || {
+                assert_eq!(
+                    default_override_path(),
+                    Some(PathBuf::from("C:/up/.sakimori/iocs.yml"))
+                );
+            },
+        );
+        // Nothing → None.
+        run_with_env(
+            &[
+                ("XDG_DATA_HOME", None),
+                ("HOME", None),
+                ("LOCALAPPDATA", None),
+                ("USERPROFILE", None),
+            ],
+            || {
+                assert_eq!(default_override_path(), None);
+            },
+        );
     }
 
     #[test]

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -30,10 +30,23 @@ use sha2::{Digest, Sha256};
 
 use crate::tamper::DEFAULT_SKIP_DIRS;
 
-/// Bundled IOC index. Refreshed by editing
-/// `crates/sakimori-core/iocs/coronarium-iocs.yml`; a future
-/// `sakimori iocs update` will do this from an upstream feed.
+/// Bundled IOC index. Always present in the binary as a fallback;
+/// `sakimori iocs update` writes a refreshed copy to
+/// [`default_override_path`] which the scanner prefers when present.
 pub const BUNDLED_CATALOG_YAML: &str = include_str!("../iocs/coronarium-iocs.yml");
+
+/// User-writable IOC override location. Honoured by
+/// [`Catalog::load_with_fallback`]: present + parseable = used;
+/// absent or unparseable = fall back to bundled. Resolved from
+/// `$HOME` (or `$XDG_DATA_HOME` if set) at call time, not at
+/// compile time, so a test running with a tmp `HOME` doesn't
+/// accidentally read the developer's real cache.
+pub fn default_override_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".sakimori")))?;
+    Some(base.join("iocs.yml"))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -110,6 +123,39 @@ impl Catalog {
         Self::from_yaml(&text)
     }
 
+    /// Production loader: tries `override_path` first (typically the
+    /// `~/.sakimori/iocs.yml` cache written by `sakimori iocs update`),
+    /// falls back to the bundled catalog on any error. Returns the
+    /// catalog plus a `loaded_from` enum so the CLI can tell the user
+    /// which one is in effect.
+    ///
+    /// Fall-through on parse error is deliberate: a corrupted cache
+    /// (truncated download, malformed feed) must not brick the
+    /// scanner. The error is surfaced through `loaded_from` so the
+    /// caller can warn loudly without aborting.
+    pub fn load_with_fallback(override_path: Option<&Path>) -> (Self, LoadedFrom) {
+        if let Some(path) = override_path
+            && path.exists()
+        {
+            match Self::from_file(path) {
+                Ok(cat) => return (cat, LoadedFrom::Override(path.to_path_buf())),
+                Err(err) => {
+                    return (
+                        Self::bundled().expect("bundled catalog parses"),
+                        LoadedFrom::BundledAfterOverrideError {
+                            path: path.to_path_buf(),
+                            error: err.to_string(),
+                        },
+                    );
+                }
+            }
+        }
+        (
+            Self::bundled().expect("bundled catalog parses"),
+            LoadedFrom::Bundled,
+        )
+    }
+
     fn validate(&self) -> Result<()> {
         let mut seen: BTreeSet<&str> = BTreeSet::new();
         for p in &self.patterns {
@@ -135,6 +181,78 @@ impl Catalog {
         }
         Ok(())
     }
+}
+
+/// Tells the CLI which on-disk source the catalog came from. Surfaced
+/// to the operator so a stale override that fails to parse can be
+/// noticed and fixed.
+#[derive(Debug, Clone)]
+pub enum LoadedFrom {
+    /// `BUNDLED_CATALOG_YAML` — the compile-time copy.
+    Bundled,
+    /// On-disk override (typically `~/.sakimori/iocs.yml`), parsed
+    /// cleanly.
+    Override(PathBuf),
+    /// On-disk override exists but failed to parse; the bundled
+    /// catalog was used as a fallback. Surface this loudly — the
+    /// override is silently stale until the operator fixes it.
+    BundledAfterOverrideError { path: PathBuf, error: String },
+}
+
+/// Fetcher abstraction so `update_from` can be unit-tested without a
+/// live HTTP request. Implementations: [`HttpFetcher`] for production,
+/// inline closures via [`FnFetcher`] for tests.
+pub trait Fetcher {
+    fn fetch(&self, url: &str) -> Result<String>;
+}
+
+pub struct HttpFetcher {
+    pub user_agent: String,
+}
+
+impl Fetcher for HttpFetcher {
+    fn fetch(&self, url: &str) -> Result<String> {
+        let resp = ureq::get(url)
+            .set("user-agent", &self.user_agent)
+            .call()
+            .with_context(|| format!("GET {url}"))?;
+        resp.into_string()
+            .with_context(|| format!("reading body from {url}"))
+    }
+}
+
+/// Test-friendly fetcher built from a closure.
+pub struct FnFetcher<F: Fn(&str) -> Result<String>>(pub F);
+impl<F: Fn(&str) -> Result<String>> Fetcher for FnFetcher<F> {
+    fn fetch(&self, url: &str) -> Result<String> {
+        (self.0)(url)
+    }
+}
+
+/// Fetch + validate + atomically write an IOC catalog. Returns the
+/// parsed catalog so the CLI can report the new version. The write is
+/// atomic (tempfile + rename) so a half-written cache can never leave
+/// a corrupted override on disk.
+///
+/// Validation happens *before* the write — a malformed upstream feed
+/// must not clobber a working local override.
+pub fn update_from(fetcher: &dyn Fetcher, url: &str, dest: &Path) -> Result<Catalog> {
+    let body = fetcher.fetch(url)?;
+    let cat = Catalog::from_yaml(&body)
+        .with_context(|| format!("fetched catalog from {url} did not validate"))?;
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating IOC cache dir {}", parent.display()))?;
+    }
+    // Atomic rename: write the validated bytes to a sibling tempfile
+    // first, then rename over the target. Rename is atomic within a
+    // filesystem on every platform we ship to.
+    let tmp = dest.with_extension("yml.tmp");
+    std::fs::write(&tmp, body.as_bytes())
+        .with_context(|| format!("writing temp {}", tmp.display()))?;
+    std::fs::rename(&tmp, dest)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), dest.display()))?;
+    Ok(cat)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -638,6 +756,97 @@ mod tests {
         // Plenty-large cap → hashes fine.
         let h = hash_file_capped(&f, 1024).expect("hash should succeed under the cap");
         assert_eq!(h.len(), 64);
+    }
+
+    #[test]
+    fn load_with_fallback_uses_bundled_when_no_override() {
+        let (cat, src) = Catalog::load_with_fallback(None);
+        assert!(!cat.patterns.is_empty());
+        assert!(matches!(src, LoadedFrom::Bundled));
+    }
+
+    #[test]
+    fn load_with_fallback_uses_override_when_present() {
+        let tmp = Tmp::new();
+        let path = tmp.0.join("iocs.yml");
+        fs::write(
+            &path,
+            "version: 42\npatterns:\n\
+             - id: just-one\n  description: t\n  severity: warn\n  \
+             match: {kind: basename, name: x}\n",
+        )
+        .unwrap();
+        let (cat, src) = Catalog::load_with_fallback(Some(&path));
+        assert_eq!(cat.version, 42);
+        assert_eq!(cat.patterns.len(), 1);
+        assert!(matches!(src, LoadedFrom::Override(p) if p == path));
+    }
+
+    #[test]
+    fn load_with_fallback_falls_back_on_parse_error_and_surfaces_it() {
+        // A corrupted override must not brick the scanner: bundled
+        // must still load, and the error has to be visible in
+        // LoadedFrom so the CLI can warn.
+        let tmp = Tmp::new();
+        let path = tmp.0.join("iocs.yml");
+        fs::write(&path, "this: [is, not: valid yaml at all").unwrap();
+        let (cat, src) = Catalog::load_with_fallback(Some(&path));
+        assert!(!cat.patterns.is_empty(), "bundled fallback must populate");
+        match src {
+            LoadedFrom::BundledAfterOverrideError { path: p, error } => {
+                assert_eq!(p, path);
+                assert!(!error.is_empty());
+            }
+            other => panic!("expected BundledAfterOverrideError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_from_writes_only_valid_upstream() {
+        let tmp = Tmp::new();
+        let dest = tmp.0.join("nested/iocs.yml"); // exercise mkdir
+        let upstream = "version: 7\npatterns:\n\
+                        - id: from-upstream\n  description: t\n  severity: error\n  \
+                        match: {kind: basename, name: y.js}\n";
+        let fetcher = FnFetcher(|_| Ok(upstream.to_string()));
+        let cat = update_from(&fetcher, "https://example.invalid/iocs.yml", &dest).unwrap();
+        assert_eq!(cat.version, 7);
+        // File on disk matches what we fetched.
+        let on_disk = fs::read_to_string(&dest).unwrap();
+        assert_eq!(on_disk, upstream);
+    }
+
+    #[test]
+    fn update_from_rejects_invalid_upstream_without_clobbering_existing() {
+        // Pre-existing good override + a bad upstream → the override
+        // is preserved untouched. This is the "don't trust the feed"
+        // safety we documented in update_from.
+        let tmp = Tmp::new();
+        let dest = tmp.0.join("iocs.yml");
+        let good = "version: 1\npatterns:\n\
+                    - id: keep-me\n  description: t\n  severity: warn\n  \
+                    match: {kind: basename, name: a}\n";
+        fs::write(&dest, good).unwrap();
+
+        let fetcher = FnFetcher(|_| Ok("this is not yaml: : :".to_string()));
+        let err = update_from(&fetcher, "https://example.invalid", &dest).unwrap_err();
+        // Either the YAML parser or the sha256 validator should refuse it.
+        assert!(format!("{err:#}").contains("validate") || format!("{err:#}").contains("parsing"));
+
+        // Original file is intact (atomic write means we never touched
+        // it because validation failed before the tempfile was renamed).
+        let after = fs::read_to_string(&dest).unwrap();
+        assert_eq!(after, good, "valid override must survive a failed update");
+    }
+
+    #[test]
+    fn update_from_surfaces_fetcher_errors() {
+        let tmp = Tmp::new();
+        let dest = tmp.0.join("iocs.yml");
+        let fetcher = FnFetcher(|_| Err(anyhow::anyhow!("network down")));
+        let err = update_from(&fetcher, "https://x", &dest).unwrap_err();
+        assert!(format!("{err:#}").contains("network down"));
+        assert!(!dest.exists(), "no file should be written on fetch failure");
     }
 
     #[test]

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -153,6 +153,40 @@ pub enum Command {
         #[command(subcommand)]
         cmd: AdvisoriesCommand,
     },
+    /// Manage the on-disk IOC catalog override used by
+    /// `workspace scan-iocs`. The bundled catalog ships in the
+    /// binary; `iocs update <url>` fetches a refreshed feed and
+    /// writes it to `~/.sakimori/iocs.yml`, where the scanner
+    /// picks it up automatically. A malformed feed never clobbers a
+    /// working override (validation runs before the atomic write).
+    Iocs {
+        #[command(subcommand)]
+        cmd: IocsCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum IocsCommand {
+    /// Fetch a YAML IOC catalog from `url`, validate it, and write
+    /// it to the local override path (defaults to
+    /// `~/.sakimori/iocs.yml`). Subsequent `workspace scan-iocs`
+    /// runs use the refreshed catalog automatically.
+    Update(IocsUpdateArgs),
+    /// Print which catalog the scanner will use right now (override
+    /// path, bundled, or override-failed-falling-back-to-bundled)
+    /// and the pattern count. Useful for confirming an `iocs update`
+    /// actually took effect.
+    Where,
+}
+
+#[derive(Debug, Parser)]
+pub struct IocsUpdateArgs {
+    /// URL to fetch. Anything `ureq` can GET — typically https.
+    pub url: String,
+    /// Destination file. Defaults to the same path
+    /// `workspace scan-iocs` reads (`~/.sakimori/iocs.yml`).
+    #[arg(long, short = 'o', value_name = "FILE")]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1081,6 +1115,12 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Advisories {
             cmd: AdvisoriesCommand::Scan(args),
         } => run_advisories_scan(args),
+        Command::Iocs {
+            cmd: IocsCommand::Update(args),
+        } => run_iocs_update(args),
+        Command::Iocs {
+            cmd: IocsCommand::Where,
+        } => run_iocs_where(),
     }
 }
 
@@ -1233,11 +1273,25 @@ fn run_workspace_diff(args: WorkspaceDiffArgs) -> Result<()> {
 }
 
 fn run_workspace_scan_iocs(args: WorkspaceScanIocsArgs) -> Result<()> {
+    use sakimori_core::iocs::{Catalog, LoadedFrom, default_override_path};
     use std::collections::BTreeSet;
-    let catalog = match &args.index {
-        Some(p) => sakimori_core::iocs::Catalog::from_file(p)?,
-        None => sakimori_core::iocs::Catalog::bundled()?,
+    let (catalog, loaded_from) = match &args.index {
+        // Explicit --index bypasses the override-fallback chain
+        // entirely: when the operator says "use this file," surfacing
+        // a silent bundled fallback would be wrong.
+        Some(p) => (Catalog::from_file(p)?, LoadedFrom::Override(p.clone())),
+        None => Catalog::load_with_fallback(default_override_path().as_deref()),
     };
+    // Loud one-line warning when an override exists but failed to
+    // parse — the operator must know they're getting bundled defaults
+    // instead of their fresh feed.
+    if let LoadedFrom::BundledAfterOverrideError { path, error } = &loaded_from {
+        eprintln!(
+            "sakimori: warning: IOC override at {} failed to parse ({}); using bundled catalog",
+            path.display(),
+            error,
+        );
+    }
     let allow: BTreeSet<String> = args.allow_id.into_iter().collect();
     let report = sakimori_core::iocs::scan(&args.dir, &catalog, &allow)?;
 
@@ -1269,6 +1323,66 @@ fn run_workspace_scan_iocs(args: WorkspaceScanIocsArgs) -> Result<()> {
 
     if report.has_error() {
         std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn run_iocs_update(args: IocsUpdateArgs) -> Result<()> {
+    use sakimori_core::iocs::{HttpFetcher, default_override_path, update_from};
+    let dest = match args.output {
+        Some(p) => p,
+        None => default_override_path().ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot resolve default IOC override path: neither $XDG_DATA_HOME nor $HOME is set. \
+                 Pass --output explicitly."
+            )
+        })?,
+    };
+    let fetcher = HttpFetcher {
+        user_agent: format!("sakimori/{}", env!("CARGO_PKG_VERSION")),
+    };
+    let cat = update_from(&fetcher, &args.url, &dest)?;
+    eprintln!(
+        "sakimori: wrote IOC catalog v{} ({} pattern(s)) to {}",
+        cat.version,
+        cat.patterns.len(),
+        dest.display(),
+    );
+    Ok(())
+}
+
+fn run_iocs_where() -> Result<()> {
+    use sakimori_core::iocs::{Catalog, LoadedFrom, default_override_path};
+    let override_path = default_override_path();
+    let (cat, src) = Catalog::load_with_fallback(override_path.as_deref());
+    match src {
+        LoadedFrom::Override(p) => {
+            println!(
+                "override (v{}, {} pattern(s)) — {}",
+                cat.version,
+                cat.patterns.len(),
+                p.display()
+            );
+        }
+        LoadedFrom::Bundled => {
+            println!(
+                "bundled (v{}, {} pattern(s)){}",
+                cat.version,
+                cat.patterns.len(),
+                override_path
+                    .map(|p| format!(" — no override at {}", p.display()))
+                    .unwrap_or_default(),
+            );
+        }
+        LoadedFrom::BundledAfterOverrideError { path, error } => {
+            println!(
+                "bundled (v{}, {} pattern(s)) — override at {} failed to parse: {}",
+                cat.version,
+                cat.patterns.len(),
+                path.display(),
+                error,
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
**Stacked on #73** — merge that one first; this PR only contains the 4 new commits on top of it.

## Summary

Completes the catalog-refresh half of roadmap item 18:

- **`sakimori iocs update <url>`** — fetch a YAML catalog from an
  upstream feed, validate it, and atomically write it to
  `~/.sakimori/iocs.yml` (override `--output`). Validation runs
  *before* the rename so a malformed feed cannot clobber a working
  override on disk; a fetcher error never writes a partial file.
- **`sakimori iocs where`** — report which catalog the scanner will
  use right now (override / bundled / bundled-after-override-error)
  plus version + pattern count.
- **`workspace scan-iocs`** now consults the override path by
  default; an unparseable override falls back to bundled with a
  loud `eprintln!` warning. Explicit `--index` still bypasses.
- Cross-platform default-path resolution:
  `$XDG_DATA_HOME` → `$HOME` → `%LOCALAPPDATA%` → `%USERPROFILE%`,
  first hit wins.
- Fetcher abstracted behind a trait (`HttpFetcher` for production,
  `FnFetcher` for tests) so `update_from` is unit-tested without
  live HTTP.

Codex review caught three real issues across the iterations, each
with its own follow-up commit:

- `525bf53` — `default_override_path` only knew `$HOME`/`$XDG_DATA_HOME`,
  leaving Windows users unable to use the default cache path.
- `88a9585` — first Windows fix used `std::env::set_var` under a
  mutex in tests; the mutex only serialised that one helper, not
  other tests in the same process reading env. Refactored to inject
  the env lookup; no more `unsafe` env mutation in tests.
- `2a67b67` — third codex round predicted clippy would flag
  `|k| std::env::var_os(k)` as redundant; verified locally that
  the closure is necessary (the bare path fails type inference
  because `var_os` is generic over `AsRef<OsStr>`). Added a
  comment so the next reviewer doesn't re-litigate.

## Test plan

- [x] `cargo test -p sakimori-core iocs` — 22 tests pass
  (15 prior + 6 new for update/load_with_fallback + 1 for the
  cross-platform path resolver)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Manual smoke: `sakimori iocs where` prints
  `bundled (v1, 2 pattern(s)) — no override at ~/.sakimori/iocs.yml`
- [x] Each commit independently reviewed by Codex; final state approved
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)