### PR TITLE
feat(sakimori-hub): self-hostable companion service (roadmap #6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +199,59 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -524,6 +589,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -614,6 +680,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "filetime"
@@ -791,8 +869,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -822,6 +902,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -838,10 +927,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
@@ -886,6 +990,15 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1280,6 +1393,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1444,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1385,10 +1524,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1645,6 +1796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1984,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +2147,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sakimori-hub"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64",
+ "chrono",
+ "clap",
+ "env_logger",
+ "hex",
+ "hmac",
+ "jsonwebtoken",
+ "log",
+ "rand",
+ "rusqlite",
+ "sakimori-core",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "ureq",
+ "urlencoding",
+]
+
+[[package]]
 name = "sakimori-proxy"
 version = "0.1.0"
 dependencies = [
@@ -2072,11 +2272,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2147,6 +2370,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2431,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -2439,6 +2680,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,6 +2855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +2894,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/sakimori",
     "crates/sakimori-common",
     "crates/sakimori-core",
+    "crates/sakimori-hub",
     "crates/sakimori-proxy",
 ]
 # NOTE: crates/sakimori-ebpf is built separately with a bpf target via xtask.

--- a/crates/sakimori-hub/Cargo.toml
+++ b/crates/sakimori-hub/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "sakimori-hub"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Optional self-hostable companion service: install inventory + retroactive advisory JOIN for sakimori-proxy."
+
+[lib]
+name = "sakimori_hub"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sakimori-hub"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "net"] }
+axum = { version = "0.7", default-features = false, features = ["http1", "json", "query", "tokio", "form"] }
+tower = "0.5"
+rusqlite = { version = "0.32", features = ["bundled"] }
+ureq = { workspace = true }
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+semver = "1"
+subtle = "2"
+rand = "0.8"
+base64 = "0.22"
+urlencoding = "2"
+jsonwebtoken = "9"
+
+sakimori-core = { path = "../sakimori-core" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/sakimori-hub/Dockerfile
+++ b/crates/sakimori-hub/Dockerfile
@@ -1,0 +1,73 @@
+# Multi-stage Dockerfile for sakimori-hub on Cloudflare Containers.
+#
+# Build with the *repository root* as the build context so the
+# whole workspace + Cargo.lock are visible:
+#
+#     docker build -f crates/sakimori-hub/Dockerfile -t sakimori-hub .
+#
+# The runtime image is debian:bookworm-slim rather than distroless
+# because rusqlite (bundled SQLite) links libc and a few libm
+# symbols at runtime, and a minimal Debian gets us the system
+# resolver + CA bundle for the webhook dispatcher's outbound
+# HTTPS without extra wrangling.
+#
+# Cloudflare Containers expects the entrypoint to:
+#   - bind on the port given by $PORT (defaults to 8080 there)
+#   - log to stdout/stderr
+#   - exit on SIGTERM
+# sakimori-hub already does all three. The shell wrapper just
+# threads $PORT into --bind.
+
+# -------- builder --------
+FROM rust:1.84-slim-bookworm AS builder
+WORKDIR /src
+
+# Build deps for rusqlite-bundled (uses cc to compile SQLite) and
+# ring/aws-lc-rs (used transitively by the proxy crate; the hub
+# build pulls it in via sakimori-core's ureq dep). Keep this list
+# minimal — each apt package is a release-process audit item.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        pkg-config build-essential ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy the workspace. We intentionally copy everything rather than
+# only `crates/sakimori-hub`; cargo can't resolve a workspace
+# member without the workspace manifest, and dropping unrelated
+# crates would force per-crate Cargo.lock files we don't want.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN cargo build --release -p sakimori-hub --bin sakimori-hub
+
+# -------- runtime --------
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --create-home --uid 10001 sakimori
+
+# Persistent state. On Cloudflare Containers attach a volume here
+# (e.g. `volumes: { hub_data: /var/lib/sakimori-hub }` in
+# wrangler.toml) so the SQLite file survives restarts. Without a
+# volume the inventory resets every cold start.
+ENV SAKIMORI_HUB_DB=/var/lib/sakimori-hub/hub.sqlite
+RUN install -d -o sakimori -g sakimori /var/lib/sakimori-hub
+
+COPY --from=builder /src/target/release/sakimori-hub /usr/local/bin/sakimori-hub
+
+USER sakimori
+EXPOSE 8080
+
+# Cloudflare Containers passes $PORT; default to 8080 locally.
+# `--allow-remote` is mandatory because we're binding 0.0.0.0;
+# the bearer token (SAKIMORI_HUB_INGEST_TOKEN) is the auth layer
+# and `main.rs` will hard-bail at startup if it's missing on a
+# non-loopback bind.
+ENV PORT=8080 \
+    RUST_LOG=info \
+    SAKIMORI_HUB_BIND=0.0.0.0:8080
+ENTRYPOINT ["/bin/sh", "-c", "exec sakimori-hub \
+    --bind 0.0.0.0:${PORT:-8080} \
+    --allow-remote --allow-public \
+    \"$@\"", "--"]

--- a/crates/sakimori-hub/cloudflare/package.json
+++ b/crates/sakimori-hub/cloudflare/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "sakimori-hub-worker",
+  "description": "Cloudflare Worker shim that fronts the sakimori-hub container.",
+  "type": "module",
+  "dependencies": {
+    "@cloudflare/containers": "^0.1"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/crates/sakimori-hub/cloudflare/worker.js
+++ b/crates/sakimori-hub/cloudflare/worker.js
@@ -1,0 +1,58 @@
+// Cloudflare Worker shim that fronts the sakimori-hub container.
+//
+// The class extends `Container` from `@cloudflare/containers`, which
+// owns the lifecycle (start, sleep, restart, port detection, request
+// streaming) so we only have to declare per-class config and a
+// dispatcher in `fetch`. See:
+//   https://developers.cloudflare.com/containers/
+//
+// Three responsibilities:
+//   1. Tell the runtime what port the container listens on.
+//   2. Forward the operator's Worker secrets (notably
+//      `SAKIMORI_HUB_INGEST_TOKEN`) into the container process
+//      env, since Worker `env` and container process env are
+//      otherwise separate worlds.
+//   3. Route every incoming Worker request to a singleton
+//      instance — sakimori-hub is single-writer by design.
+
+import { Container, getContainer } from "@cloudflare/containers";
+
+export class SakimoriHubContainer extends Container {
+  // Container listens on $PORT (defaults to 8080 in the Dockerfile).
+  defaultPort = 8080;
+  // Idle timeout. Containers cold-start when a request lands after
+  // sleep; the background dispatcher loop inside the hub does NOT
+  // count as "in use" once the Worker isn't being hit, so a long
+  // sleep means notifications stall. Keep short.
+  sleepAfter = "5m";
+
+  // Per-instance env. `this.env` is the Worker env (vars + secrets);
+  // `this.envVars` is what gets injected into the container process.
+  // Filtering explicitly avoids leaking unrelated Worker secrets
+  // into the container process — only the ones sakimori-hub knows
+  // how to consume should cross the boundary.
+  constructor(state, env) {
+    super(state, env);
+    this.envVars = {
+      RUST_LOG: env.RUST_LOG ?? "info",
+      SAKIMORI_HUB_INGEST_TOKEN: env.SAKIMORI_HUB_INGEST_TOKEN ?? "",
+    };
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    // Stable singleton id so every request hits the same container
+    // instance. When the hub eventually gains multi-instance
+    // support, switch to `getContainer(env.HUB, <tenant-id>)`.
+    const container = getContainer(env.HUB, "singleton");
+    try {
+      return await container.fetch(request);
+    } catch (err) {
+      return new Response(
+        JSON.stringify({ error: "container unavailable", detail: String(err) }),
+        { status: 502, headers: { "content-type": "application/json" } },
+      );
+    }
+  },
+};

--- a/crates/sakimori-hub/cloudflare/wrangler.toml
+++ b/crates/sakimori-hub/cloudflare/wrangler.toml
@@ -1,0 +1,60 @@
+# Cloudflare Containers + routing Worker for sakimori-hub.
+#
+# Deploy with:
+#
+#     cd crates/sakimori-hub/cloudflare
+#     npm install
+#     wrangler secret put SAKIMORI_HUB_INGEST_TOKEN
+#     wrangler deploy
+#
+# Cloudflare Containers is in beta; the schema fields below track
+# the documented `wrangler` Containers config + the
+# `@cloudflare/containers` JS helper as of 2026-05.
+
+name = "sakimori-hub"
+main = "worker.js"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Container image. `image` is resolved relative to
+# `image_build_context`; without an explicit context Cloudflare
+# defaults to the *directory of the image*, which would only see
+# the cloudflare/ subdir. Our Dockerfile copies the workspace root
+# (`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `crates/`)
+# so the build context HAS to be the repo root.
+[[containers]]
+class_name = "SakimoriHubContainer"
+image = "../Dockerfile"
+image_build_context = "../../.."
+# Single instance per region. sakimori-hub's dispatcher is
+# documented as single-process-only (slice 3 doc-comment on
+# `dispatch::run_once`); multi-instance needs a DB-level claim
+# pass we haven't built yet.
+max_instances = 1
+# Persistent SQLite file. Without this volume, every cold start
+# loses the install inventory.
+[[containers.volumes]]
+name = "hub_data"
+mount_path = "/var/lib/sakimori-hub"
+
+# Routing binding. The Worker dispatches incoming requests to
+# this Durable Object class via `env.HUB.getByName("singleton")`.
+[[durable_objects.bindings]]
+name = "HUB"
+class_name = "SakimoriHubContainer"
+
+# Cloudflare requires a `new_sqlite_classes` migration entry for
+# every Container/DO class on its first deploy. Missing this is
+# the most common "deploy returns a 500" symptom per Cloudflare's
+# Containers getting-started doc.
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["SakimoriHubContainer"]
+
+# Non-secret env vars are fine here. Secrets — including
+# `SAKIMORI_HUB_INGEST_TOKEN` — go via `wrangler secret put` so
+# they never enter source control. The Worker forwards the
+# secret into the container process via `envVars` on the
+# Container class (see worker.js).
+[vars]
+RUST_LOG = "info"

--- a/crates/sakimori-hub/src/advisories.rs
+++ b/crates/sakimori-hub/src/advisories.rs
@@ -1,0 +1,699 @@
+//! OSV advisory ingest + JOIN against the install inventory.
+//!
+//! This is the hub-side counterpart to the proxy's
+//! `sakimori_core::advisories` (which hits OSV.dev's live
+//! `/v1/querybatch` for a single laptop). Here we **store**
+//! advisories locally and JOIN them against the team-wide install
+//! inventory so the dispatcher slice can fire push notifications
+//! when a past install matches a newly-disclosed vulnerability.
+//!
+//! ## Matching modes
+//!
+//! Findings can come from two paths:
+//!
+//! 1. **Exact-version match** — `affected[].versions[]`. Every
+//!    listed string is recorded verbatim and JOINed against
+//!    `installs.version` literally. Cheap, no parser, no false
+//!    positives.
+//! 2. **SEMVER range match** — `affected[].ranges[]` entries of
+//!    `type: SEMVER` (and `type: ECOSYSTEM` for the npm/crates
+//!    ecosystems, which both use SemVer 2.0 semantics). Events
+//!    `introduced` and `fixed` are extracted into half-open
+//!    intervals `[introduced, fixed)`. An install is a match iff
+//!    its parsed version sits inside any such interval. PyPI's
+//!    PEP 440 and NuGet's variant of SemVer aren't standard
+//!    SemVer 2.0; ranges for those ecosystems are intentionally
+//!    skipped rather than mis-applied. (Their exact-version
+//!    `affected[].versions[]` entries still match.)
+//!
+//! The current matching mode is surfaced as the constant
+//! `crate::store::MATCHING_MODE`
+//! (`"exact_versions_and_semver_ranges"`) so subscribers can
+//! branch on what kind of "no match" they're looking at.
+//!
+//! ## Out of scope (next slice)
+//!
+//! - Automatic OSV mirror sync (download from
+//!   `gs://osv-vulnerabilities`). For now, advisories enter via
+//!   `POST /advisories`.
+//! - Email / Slack adapters on top of the existing webhook
+//!   substrate.
+//! - PEP 440 / NuGet range semantics.
+//! - KEV / known-exploited gating.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Coarse severity bucket. Driven by OSV's heterogenous severity
+/// shape (GHSA convention vs. CVSS v3 vector vs. nothing).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Critical,
+    High,
+    Moderate,
+    Low,
+    Unknown,
+}
+
+impl Severity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Severity::Critical => "critical",
+            Severity::High => "high",
+            Severity::Moderate => "moderate",
+            Severity::Low => "low",
+            Severity::Unknown => "unknown",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "critical" => Some(Severity::Critical),
+            "high" => Some(Severity::High),
+            "moderate" | "medium" => Some(Severity::Moderate),
+            "low" => Some(Severity::Low),
+            "unknown" | "" => Some(Severity::Unknown),
+            _ => None,
+        }
+    }
+
+    /// OSV's `database_specific.severity` is GHSA-shaped
+    /// (`"CRITICAL" | "HIGH" | "MODERATE" | "LOW"`). Be lenient
+    /// with case; fall back to `Unknown` if unrecognised.
+    fn from_database_specific(raw: &str) -> Self {
+        Self::parse(raw).unwrap_or(Severity::Unknown)
+    }
+
+    /// CVSS v3 base scores map to severity per the spec:
+    /// 0.0 None, 0.1-3.9 Low, 4.0-6.9 Medium, 7.0-8.9 High,
+    /// 9.0-10.0 Critical.
+    fn from_cvss_base_score(score: f64) -> Self {
+        if score >= 9.0 {
+            Severity::Critical
+        } else if score >= 7.0 {
+            Severity::High
+        } else if score >= 4.0 {
+            Severity::Moderate
+        } else if score > 0.0 {
+            Severity::Low
+        } else {
+            Severity::Unknown
+        }
+    }
+}
+
+/// Minimal subset of the OSV schema we deserialize. We use
+/// `serde(rename_all = "snake_case")` ergonomically but most
+/// OSV-shipped JSON uses lowerCamel/snake mixed — explicit
+/// `#[serde(rename)]` per field is more reliable.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvAdvisory {
+    pub id: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub published: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub affected: Vec<OsvAffected>,
+    #[serde(default)]
+    pub severity: Vec<OsvSeverityEntry>,
+    #[serde(default, rename = "database_specific")]
+    pub database_specific: Option<OsvDatabaseSpecific>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvAffected {
+    pub package: OsvPackage,
+    #[serde(default)]
+    pub versions: Vec<String>,
+    #[serde(default)]
+    pub ranges: Vec<OsvRange>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvRange {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub events: Vec<OsvRangeEvent>,
+}
+
+/// One entry inside `range.events`. OSV uses a "list of events"
+/// shape (`{introduced: "1.0.0"}`, `{fixed: "1.2.3"}`,
+/// `{last_affected: "1.2.2"}`, `{limit: "*"}`) which forms a
+/// half-open interval `[introduced, fixed)`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvRangeEvent {
+    #[serde(default)]
+    pub introduced: Option<String>,
+    #[serde(default)]
+    pub fixed: Option<String>,
+    #[serde(default)]
+    pub last_affected: Option<String>,
+    #[serde(default)]
+    pub limit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvPackage {
+    pub ecosystem: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvSeverityEntry {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub score: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsvDatabaseSpecific {
+    #[serde(default)]
+    pub severity: Option<String>,
+}
+
+impl OsvAdvisory {
+    /// Best-effort severity extraction. Prefer
+    /// `database_specific.severity` (GHSA's flavor and the easiest
+    /// to interpret deterministically); fall back to a CVSS v3
+    /// base score parsed out of the first `severity[]` entry of
+    /// type `CVSS_V3` or `CVSS_V4`.
+    pub fn severity(&self) -> Severity {
+        if let Some(ds) = &self.database_specific
+            && let Some(s) = &ds.severity
+        {
+            let parsed = Severity::from_database_specific(s);
+            if parsed != Severity::Unknown {
+                return parsed;
+            }
+        }
+        for entry in &self.severity {
+            let kind = entry.kind.to_ascii_uppercase();
+            if (kind == "CVSS_V3" || kind == "CVSS_V4")
+                && let Some(score) = extract_cvss_base_score(&entry.score)
+            {
+                return Severity::from_cvss_base_score(score);
+            }
+        }
+        Severity::Unknown
+    }
+
+    /// Normalise the affected list into one row per
+    /// `(ecosystem, name, version)` we should record from the
+    /// explicit `versions[]` entries. SEMVER `ranges[]` are
+    /// surfaced separately via [`affected_ranges`].
+    pub fn affected_versions(&self) -> Vec<AffectedVersion> {
+        let mut out = Vec::new();
+        for aff in &self.affected {
+            for v in &aff.versions {
+                out.push(AffectedVersion {
+                    ecosystem: osv_to_label(&aff.package.ecosystem)
+                        .unwrap_or(&aff.package.ecosystem)
+                        .to_string(),
+                    name: aff.package.name.clone(),
+                    version: v.clone(),
+                });
+            }
+        }
+        out
+    }
+
+    /// Normalise the affected list into half-open SemVer ranges.
+    ///
+    /// Only ranges whose ecosystem uses SemVer 2.0 semantics get
+    /// projected — npm and crates today. PyPI (PEP 440) and
+    /// NuGet (its own SemVer dialect) are left for a follow-up
+    /// slice rather than mis-matched here.
+    ///
+    /// A range is dropped if neither its `introduced` nor any
+    /// candidate upper bound (`fixed`, `last_affected`, `limit`)
+    /// parses as a [`semver::Version`]; we'd rather under-detect
+    /// than fabricate a match.
+    pub fn affected_ranges(&self) -> Vec<AffectedRange> {
+        let mut out = Vec::new();
+        for aff in &self.affected {
+            let Some(eco_label) = osv_to_label(&aff.package.ecosystem) else {
+                continue;
+            };
+            if !ecosystem_uses_semver(eco_label) {
+                continue;
+            }
+            for range in &aff.ranges {
+                if !range_kind_is_semver(&range.kind, eco_label) {
+                    continue;
+                }
+                // OSV's events list is sequence-sensitive: an
+                // `introduced` opens an interval, and a later
+                // `fixed`/`last_affected`/`limit` closes it.
+                // Many advisories ship at most one pair; rather
+                // than build a full segment tree, walk the events
+                // and emit one range per `introduced`, paired
+                // with the next closing event.
+                let mut introduced: Option<semver::Version> = None;
+                for ev in &range.events {
+                    if let Some(s) = &ev.introduced {
+                        if let Some(v) = parse_introduced(s) {
+                            introduced = Some(v);
+                        }
+                    } else if let Some(open) = introduced.take() {
+                        match classify_close(ev) {
+                            CloseEvent::Exclusive(upper) => out.push(AffectedRange {
+                                ecosystem: eco_label.to_string(),
+                                name: aff.package.name.clone(),
+                                introduced: open,
+                                upper: Some(upper),
+                                upper_inclusive: false,
+                            }),
+                            CloseEvent::Inclusive(upper) => out.push(AffectedRange {
+                                ecosystem: eco_label.to_string(),
+                                name: aff.package.name.clone(),
+                                introduced: open,
+                                upper: Some(upper),
+                                upper_inclusive: true,
+                            }),
+                            CloseEvent::Unbounded => out.push(AffectedRange {
+                                ecosystem: eco_label.to_string(),
+                                name: aff.package.name.clone(),
+                                introduced: open,
+                                upper: None,
+                                upper_inclusive: false,
+                            }),
+                            // A close event was present but its
+                            // payload failed to parse. Dropping
+                            // the open interval entirely is the
+                            // conservative choice: emitting an
+                            // unbounded range here would
+                            // *fabricate* a "matches every version
+                            // above introduced" claim that the
+                            // advisory never made.
+                            CloseEvent::Malformed => {}
+                        }
+                    }
+                }
+                // Trailing `introduced` with no closing event →
+                // unbounded affected range. This is OSV's
+                // shorthand for "no fix yet"; explicit.
+                if let Some(open) = introduced {
+                    out.push(AffectedRange {
+                        ecosystem: eco_label.to_string(),
+                        name: aff.package.name.clone(),
+                        introduced: open,
+                        upper: None,
+                        upper_inclusive: false,
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+fn ecosystem_uses_semver(label: &str) -> bool {
+    matches!(label, "npm" | "crates")
+}
+
+fn range_kind_is_semver(kind: &str, eco_label: &str) -> bool {
+    let upper = kind.to_ascii_uppercase();
+    if upper == "SEMVER" {
+        return true;
+    }
+    // OSV's `type: ECOSYSTEM` is "use the ecosystem's own
+    // ordering". For npm/crates that ordering *is* SemVer 2.0,
+    // so we accept it.
+    upper == "ECOSYSTEM" && ecosystem_uses_semver(eco_label)
+}
+
+fn parse_introduced(s: &str) -> Option<semver::Version> {
+    if s == "0" {
+        return Some(semver::Version::new(0, 0, 0));
+    }
+    parse_version_loose(s)
+}
+
+/// `semver::Version::parse` is strict about three-segment form.
+/// OSV in the wild ships shapes like `"1.0"` or `"1"`; pad them
+/// before parsing so the matcher's coverage stays useful.
+fn parse_version_loose(s: &str) -> Option<semver::Version> {
+    if let Ok(v) = semver::Version::parse(s) {
+        return Some(v);
+    }
+    let core = s.split(['+', '-']).next().unwrap_or(s);
+    let dots = core.chars().filter(|c| *c == '.').count();
+    let padded = match dots {
+        0 => format!("{s}.0.0"),
+        1 => format!("{s}.0"),
+        _ => return None,
+    };
+    semver::Version::parse(&padded).ok()
+}
+
+/// How a close event mapped to a range bound.
+enum CloseEvent {
+    /// `fixed` / `limit` — `[introduced, upper)`.
+    Exclusive(semver::Version),
+    /// `last_affected` — `[introduced, upper]`. Stored inclusive
+    /// so the scanner uses `<=` rather than fabricating an
+    /// exclusive bump (which would over-match around prereleases).
+    Inclusive(semver::Version),
+    /// `limit: "*"` — explicitly unbounded above.
+    Unbounded,
+    /// Close event present but no payload parsed: drop the open
+    /// rather than silently fabricating an unbounded range.
+    Malformed,
+}
+
+fn classify_close(ev: &OsvRangeEvent) -> CloseEvent {
+    if let Some(s) = ev.fixed.as_deref() {
+        return match parse_version_loose(s) {
+            Some(v) => CloseEvent::Exclusive(v),
+            None => CloseEvent::Malformed,
+        };
+    }
+    if let Some(s) = ev.last_affected.as_deref() {
+        return match parse_version_loose(s) {
+            Some(v) => CloseEvent::Inclusive(v),
+            None => CloseEvent::Malformed,
+        };
+    }
+    if let Some(s) = ev.limit.as_deref() {
+        if s == "*" {
+            return CloseEvent::Unbounded;
+        }
+        return match parse_version_loose(s) {
+            Some(v) => CloseEvent::Exclusive(v),
+            None => CloseEvent::Malformed,
+        };
+    }
+    // Truly empty close event (shouldn't happen per the OSV
+    // schema, but be defensive).
+    CloseEvent::Malformed
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AffectedVersion {
+    pub ecosystem: String,
+    pub name: String,
+    pub version: String,
+}
+
+/// SemVer 2.0 range projected out of an [`OsvRange`].
+/// `[introduced, upper)` when `inclusive_upper = false`,
+/// `[introduced, upper]` when `inclusive_upper = true`.
+/// `upper = None` means "unbounded above" (no patched release
+/// yet). `introduced = None` would mean "from the dawn of time"
+/// but we always materialise it as `0.0.0` so downstream
+/// comparisons stay total.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AffectedRange {
+    pub ecosystem: String,
+    pub name: String,
+    pub introduced: semver::Version,
+    pub upper: Option<semver::Version>,
+    /// `true` iff this range came from `last_affected` (inclusive
+    /// upper); `false` for `fixed` / `limit` and for unbounded.
+    pub upper_inclusive: bool,
+}
+
+/// A CVSS vector looks like `CVSS:3.1/AV:N/AC:L/...`. OSV stores
+/// the full vector; the *base score* is computed from it. Rather
+/// than vendor a CVSS calculator (heavy), we accept advisories
+/// that ship a base score inline as the score string. When the
+/// score string is a plain number, parse it directly.
+fn extract_cvss_base_score(raw: &str) -> Option<f64> {
+    // If it's a plain number, parse and use directly.
+    if let Ok(n) = raw.trim().parse::<f64>() {
+        return Some(n);
+    }
+    // Otherwise look for a trailing `/BASE/<num>` annotation OSV
+    // sometimes ships alongside the vector (non-standard but seen
+    // in the wild for older entries).
+    for part in raw.split('/') {
+        if let Some(rest) = part.strip_prefix("BASE:")
+            && let Ok(n) = rest.parse::<f64>()
+        {
+            return Some(n);
+        }
+    }
+    None
+}
+
+/// Map an OSV ecosystem label (e.g. `"npm"`, `"crates.io"`,
+/// `"PyPI"`, `"NuGet"`) to the [`sakimori_core::deps::Ecosystem`]
+/// label we use as the canonical storage form. Unknown OSV
+/// ecosystems pass through unchanged (we still want to record the
+/// advisory, even if no installs of that ecosystem could match
+/// today's enum).
+pub fn osv_to_label(osv: &str) -> Option<&'static str> {
+    match osv.to_ascii_lowercase().as_str() {
+        "npm" => Some("npm"),
+        "crates.io" | "crates" => Some("crates"),
+        "pypi" => Some("pypi"),
+        "nuget" => Some("nuget"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_buckets_from_database_specific() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-x",
+            "database_specific": {"severity": "HIGH"},
+        }))
+        .unwrap();
+        assert_eq!(adv.severity(), Severity::High);
+    }
+
+    #[test]
+    fn severity_falls_back_to_cvss_score() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-x",
+            "severity": [{"type": "CVSS_V3", "score": "9.8"}],
+        }))
+        .unwrap();
+        assert_eq!(adv.severity(), Severity::Critical);
+    }
+
+    #[test]
+    fn severity_unknown_when_nothing_parseable() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-x",
+            "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N"}],
+        }))
+        .unwrap();
+        assert_eq!(adv.severity(), Severity::Unknown);
+    }
+
+    #[test]
+    fn affected_versions_normalises_ecosystem_labels() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [
+                {"package": {"ecosystem": "crates.io", "name": "tokio"}, "versions": ["1.0.0"]},
+                {"package": {"ecosystem": "PyPI",      "name": "django"}, "versions": ["4.2.0", "4.2.1"]},
+                {"package": {"ecosystem": "Maven",     "name": "p"},      "versions": ["1"]},
+            ],
+        }))
+        .unwrap();
+        let av = adv.affected_versions();
+        assert_eq!(av.len(), 4);
+        assert!(
+            av.iter()
+                .any(|v| v.ecosystem == "crates" && v.version == "1.0.0")
+        );
+        assert!(
+            av.iter()
+                .any(|v| v.ecosystem == "pypi" && v.version == "4.2.1")
+        );
+        // Unknown ecosystem passes through verbatim.
+        assert!(av.iter().any(|v| v.ecosystem == "Maven"));
+    }
+
+    #[test]
+    fn affected_versions_does_not_include_range_only_entries() {
+        // No `versions` array → no row produced from
+        // affected_versions (ranges live in affected_ranges).
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "4.17.21"}]}]
+            }],
+        }))
+        .unwrap();
+        assert!(adv.affected_versions().is_empty());
+    }
+
+    #[test]
+    fn affected_ranges_extracts_introduced_fixed_pairs() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-1",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "0"}, {"fixed": "4.17.21"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        let ranges = adv.affected_ranges();
+        assert_eq!(ranges.len(), 1);
+        let r = &ranges[0];
+        assert_eq!(r.ecosystem, "npm");
+        assert_eq!(r.name, "lodash");
+        assert_eq!(r.introduced, semver::Version::new(0, 0, 0));
+        assert_eq!(r.upper.as_ref().unwrap(), &semver::Version::new(4, 17, 21));
+    }
+
+    #[test]
+    fn affected_ranges_handles_ecosystem_kind_for_npm_and_crates() {
+        for eco in ["npm", "crates.io"] {
+            let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+                "id": "x",
+                "affected": [{
+                    "package": {"ecosystem": eco, "name": "p"},
+                    "ranges": [{"type": "ECOSYSTEM", "events": [
+                        {"introduced": "1.0.0"}, {"fixed": "1.0.5"}
+                    ]}]
+                }],
+            }))
+            .unwrap();
+            let ranges = adv.affected_ranges();
+            assert_eq!(
+                ranges.len(),
+                1,
+                "{eco}: ECOSYSTEM kind should parse for SemVer ecosystems"
+            );
+        }
+    }
+
+    #[test]
+    fn affected_ranges_skips_pypi_and_nuget_for_now() {
+        for eco in ["PyPI", "NuGet"] {
+            let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+                "id": "x",
+                "affected": [{
+                    "package": {"ecosystem": eco, "name": "p"},
+                    "ranges": [{"type": "ECOSYSTEM", "events": [
+                        {"introduced": "1.0"}, {"fixed": "2.0"}
+                    ]}]
+                }],
+            }))
+            .unwrap();
+            assert!(
+                adv.affected_ranges().is_empty(),
+                "{eco}: ECOSYSTEM kind is not SemVer 2.0 — skip rather than mis-match"
+            );
+        }
+    }
+
+    #[test]
+    fn affected_ranges_last_affected_is_inclusive_upper() {
+        // last_affected = 1.2.3 ⇒ upper bound 1.2.3 INCLUSIVE
+        // (not bumped to 1.2.4, which would over-match prereleases
+        // of the patched release).
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"last_affected": "1.2.3"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        let r = &adv.affected_ranges()[0];
+        assert_eq!(r.upper.as_ref().unwrap(), &semver::Version::new(1, 2, 3));
+        assert!(r.upper_inclusive);
+    }
+
+    #[test]
+    fn affected_ranges_malformed_close_drops_the_open() {
+        // Regression: an unparseable `fixed` (or `last_affected`)
+        // must NOT silently turn into an unbounded "everything >=
+        // introduced" range — that fabricates findings.
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"fixed": "not-a-version"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        assert!(
+            adv.affected_ranges().is_empty(),
+            "malformed close => drop the open, not unbounded"
+        );
+    }
+
+    #[test]
+    fn affected_ranges_limit_star_is_explicit_unbounded() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"limit": "*"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        let r = &adv.affected_ranges()[0];
+        assert_eq!(r.introduced, semver::Version::new(1, 0, 0));
+        assert!(r.upper.is_none());
+        assert!(!r.upper_inclusive);
+    }
+
+    #[test]
+    fn affected_ranges_unbounded_when_no_close_event() {
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [{"introduced": "1.0.0"}]}]
+            }],
+        }))
+        .unwrap();
+        let r = &adv.affected_ranges()[0];
+        assert_eq!(r.introduced, semver::Version::new(1, 0, 0));
+        assert!(r.upper.is_none(), "no fix yet => unbounded upper");
+    }
+
+    #[test]
+    fn affected_ranges_tolerates_partial_versions() {
+        // `1` and `1.2` should pad to `1.0.0` / `1.2.0`.
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "x",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1"}, {"fixed": "1.2"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        let r = &adv.affected_ranges()[0];
+        assert_eq!(r.introduced, semver::Version::new(1, 0, 0));
+        assert_eq!(r.upper.as_ref().unwrap(), &semver::Version::new(1, 2, 0));
+    }
+
+    #[test]
+    fn severity_parse_accepts_medium_and_moderate() {
+        assert_eq!(Severity::parse("medium"), Some(Severity::Moderate));
+        assert_eq!(Severity::parse("MODERATE"), Some(Severity::Moderate));
+    }
+
+    #[test]
+    fn cvss_extract_handles_plain_number_and_base_annotation() {
+        assert_eq!(extract_cvss_base_score("9.8"), Some(9.8));
+        assert_eq!(extract_cvss_base_score("CVSS:3.1/AV:N/BASE:7.5"), Some(7.5));
+        assert_eq!(extract_cvss_base_score("CVSS:3.1/AV:N"), None);
+    }
+}

--- a/crates/sakimori-hub/src/auth/actions.rs
+++ b/crates/sakimori-hub/src/auth/actions.rs
@@ -1,0 +1,398 @@
+//! GitHub Actions OIDC exchange.
+//!
+//! GitHub gives every workflow with `permissions: id-token: write`
+//! a signed JWT via `$ACTIONS_ID_TOKEN_REQUEST_URL` /
+//! `$ACTIONS_ID_TOKEN_REQUEST_TOKEN`. The workflow POSTs that JWT
+//! to `/auth/actions/exchange`; the hub verifies it against
+//! GitHub's JWKS and mints a short-lived `sha_*` API token tied to
+//! the JWT's `repository` claim. Workflows then carry the
+//! `sha_*` token in `Authorization: Bearer` for the same write
+//! surface as the personal-token path.
+//!
+//! ## What we verify
+//!
+//! - **Signature** — RS256 against GitHub's published JWKS at
+//!   `https://token.actions.githubusercontent.com/.well-known/jwks`.
+//!   The verifier caches the JWKS for a small window so a flood
+//!   of exchanges doesn't beat up GitHub's endpoint.
+//! - **`iss` claim** — exact match against
+//!   `https://token.actions.githubusercontent.com`.
+//! - **`aud` claim** — exact match against the operator-configured
+//!   audience. GitHub lets the workflow set this when calling the
+//!   token endpoint (`?audience=<value>`); the operator must pick
+//!   a value they document for the workflow side. Defaults to
+//!   the hub's `external_base_url`.
+//! - **`exp` claim** — must be in the future.
+//! - **`repository` claim** — must match the operator's allowlist.
+//!
+//! We do NOT verify `nbf` (GitHub omits it), `iat`, or the rest
+//! of the schema beyond the fields above. The minted hub-side
+//! token gets its own TTL bounded by `min(jwt.exp - now,
+//! actions_token_ttl_secs)`.
+
+use serde::Deserialize;
+
+/// Claims we actually consume from the JWT. GitHub's tokens
+/// include many more (environment, run_id, job_workflow_ref,
+/// etc.); we keep the surface intentionally narrow because
+/// every field we read is a field we'd have to keep working
+/// across schema bumps on GitHub's side.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ActionsClaims {
+    pub iss: String,
+    /// `serde` accepts the OIDC `aud` claim as either string or
+    /// `[string]`. GitHub usually emits the string form; we
+    /// canonicalise to the first element for comparison.
+    #[serde(deserialize_with = "deserialize_aud")]
+    pub aud: String,
+    pub sub: String,
+    pub repository: String,
+    pub repository_owner: String,
+    #[serde(default)]
+    pub workflow: Option<String>,
+    #[serde(default)]
+    pub workflow_ref: Option<String>,
+    pub exp: i64,
+}
+
+fn deserialize_aud<'de, D: serde::Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    use serde::de::Error;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum AudShape {
+        One(String),
+        Many(Vec<String>),
+    }
+    match AudShape::deserialize(d)? {
+        AudShape::One(s) => Ok(s),
+        AudShape::Many(v) => v
+            .into_iter()
+            .next()
+            .ok_or_else(|| D::Error::custom("empty aud")),
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ActionsAuthError {
+    #[error("jwt malformed: {0}")]
+    Malformed(String),
+    #[error("jwt signature verification failed: {0}")]
+    Signature(String),
+    #[error("jwt issuer mismatch: got {0}")]
+    Issuer(String),
+    #[error("jwt audience mismatch: got {0}")]
+    Audience(String),
+    #[error("jwt expired at {0}")]
+    Expired(i64),
+    #[error("jwks fetch failed: {0}")]
+    Jwks(String),
+    #[error("no JWKS key matched kid {0}")]
+    UnknownKid(String),
+}
+
+/// Pluggable verifier so handler tests don't need real JWTs.
+pub trait ActionsOidcVerifier: Send + Sync {
+    fn verify(&self, jwt: &str) -> Result<ActionsClaims, ActionsAuthError>;
+}
+
+pub const GITHUB_ACTIONS_ISSUER: &str = "https://token.actions.githubusercontent.com";
+
+/// Match `repository` ("org/repo") against operator allowlist
+/// patterns. Two shapes:
+///
+/// - `org/repo` exact (case-insensitive on owner half — GitHub
+///   treats owner names case-insensitively).
+/// - `org/*` org-wide wildcard.
+///
+/// Anything else parses to a bad-pattern error; we'd rather
+/// hard-fail at config time than silently mismatch.
+pub fn repository_matches(allowed: &[String], repository: &str) -> bool {
+    let repo_lower = repository.to_ascii_lowercase();
+    for pat in allowed {
+        let pat_lower = pat.to_ascii_lowercase();
+        if let Some(owner) = pat_lower.strip_suffix("/*") {
+            // `org/*` — match if the repository starts with
+            // `org/` and has no further slashes (so `org/sub/x`
+            // doesn't slip through; GitHub repos are exactly
+            // `owner/name`).
+            if let Some(rest) = repo_lower.strip_prefix(&format!("{owner}/"))
+                && !rest.contains('/')
+                && !rest.is_empty()
+            {
+                return true;
+            }
+        } else if pat_lower == repo_lower {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn validate_repository_pattern(pat: &str) -> Result<(), String> {
+    if pat.is_empty() {
+        return Err("empty repository pattern".into());
+    }
+    let body = pat.strip_suffix("/*").unwrap_or(pat);
+    let slashes = body.matches('/').count();
+    let allows_wildcard = pat.ends_with("/*");
+    if allows_wildcard {
+        if slashes != 0 {
+            return Err(format!(
+                "wildcard pattern {pat:?} must be `<owner>/*`, not nested"
+            ));
+        }
+    } else if slashes != 1 {
+        return Err(format!(
+            "pattern {pat:?} must be `<owner>/<repo>` or `<owner>/*`"
+        ));
+    }
+    Ok(())
+}
+
+// ---------------- production verifier (jsonwebtoken + cached JWKS) ----------------
+
+pub use prod::GitHubActionsVerifier;
+pub use prod::GitHubActionsVerifier as DefaultVerifier;
+
+mod prod {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    /// Production verifier — hits `${issuer}/.well-known/jwks`,
+    /// caches the JWKS in-process, validates RS256.
+    pub struct GitHubActionsVerifier {
+        agent: ureq::Agent,
+        audience: String,
+        jwks_url: String,
+        cache: Mutex<JwksCache>,
+        ttl: Duration,
+    }
+
+    struct JwksCache {
+        keys: Vec<JwksKey>,
+        fetched_at: Option<Instant>,
+        /// Last "we tried to refresh because of a kid miss"
+        /// timestamp. Lets us throttle miss-driven refreshes
+        /// even inside the normal TTL window — `/auth/actions/
+        /// exchange` is unauthenticated, so a flood of attacker-
+        /// chosen `kid`s would otherwise pin a network call per
+        /// request.
+        last_miss_refresh: Option<Instant>,
+    }
+
+    #[derive(Clone, Deserialize)]
+    struct JwksKey {
+        kid: String,
+        n: String, // base64url modulus
+        e: String, // base64url exponent
+    }
+
+    #[derive(Deserialize)]
+    struct JwksResp {
+        keys: Vec<JwksKey>,
+    }
+
+    impl GitHubActionsVerifier {
+        pub fn new(audience: String) -> Self {
+            Self::with_issuer(audience, GITHUB_ACTIONS_ISSUER.to_string())
+        }
+
+        pub fn with_issuer(audience: String, issuer: String) -> Self {
+            Self {
+                agent: ureq::AgentBuilder::new()
+                    .timeout(Duration::from_secs(10))
+                    .user_agent(concat!("sakimori-hub/", env!("CARGO_PKG_VERSION")))
+                    .build(),
+                audience,
+                jwks_url: format!("{}/.well-known/jwks", issuer.trim_end_matches('/')),
+                cache: Mutex::new(JwksCache {
+                    keys: Vec::new(),
+                    fetched_at: None,
+                    last_miss_refresh: None,
+                }),
+                ttl: Duration::from_secs(300),
+            }
+        }
+
+        /// Min interval between two successive miss-driven JWKS
+        /// refreshes. 30s gives ~10s slack around realistic key
+        /// rotation propagation while keeping the per-call worst
+        /// case at one network round-trip per 30s, not per
+        /// request.
+        const MISS_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
+        fn refresh_jwks(&self) -> Result<Vec<JwksKey>, ActionsAuthError> {
+            let resp = self
+                .agent
+                .get(&self.jwks_url)
+                .set("accept", "application/json")
+                .call()
+                .map_err(|e| ActionsAuthError::Jwks(e.to_string()))?;
+            let parsed: JwksResp = resp
+                .into_json()
+                .map_err(|e| ActionsAuthError::Jwks(e.to_string()))?;
+            Ok(parsed.keys)
+        }
+
+        fn key_for_kid(&self, kid: &str) -> Result<JwksKey, ActionsAuthError> {
+            let now = Instant::now();
+            // Decide what to do based solely on cache state.
+            #[derive(Clone)]
+            enum Action {
+                UseCachedHit(JwksKey),
+                ReturnUnknownKid,
+                Refresh,
+            }
+            let action = {
+                let cache = self.cache.lock().expect("jwks cache mutex poisoned");
+                let fresh = cache
+                    .fetched_at
+                    .map(|t| now.duration_since(t) < self.ttl)
+                    .unwrap_or(false);
+                let hit = cache.keys.iter().find(|k| k.kid == kid).cloned();
+                match (fresh, hit) {
+                    // Fresh hit: serve from cache (fast path).
+                    (true, Some(k)) => Action::UseCachedHit(k),
+                    // Stale hit OR stale miss: refresh so a
+                    // rotated-out key can't keep validating
+                    // tokens past the TTL.
+                    (false, _) => Action::Refresh,
+                    // Fresh miss: throttle refresh —
+                    // /auth/actions/exchange is unauthenticated,
+                    // so a stream of attacker-chosen kids would
+                    // otherwise force a network call per request.
+                    (true, None) => {
+                        let throttled = cache
+                            .last_miss_refresh
+                            .map(|t| now.duration_since(t) < Self::MISS_REFRESH_INTERVAL)
+                            .unwrap_or(false);
+                        if throttled {
+                            Action::ReturnUnknownKid
+                        } else {
+                            Action::Refresh
+                        }
+                    }
+                }
+            };
+            match action {
+                Action::UseCachedHit(k) => Ok(k),
+                Action::ReturnUnknownKid => Err(ActionsAuthError::UnknownKid(kid.to_string())),
+                Action::Refresh => {
+                    let keys = self.refresh_jwks()?;
+                    {
+                        let mut cache = self.cache.lock().expect("jwks cache mutex poisoned");
+                        cache.keys = keys.clone();
+                        cache.fetched_at = Some(now);
+                        cache.last_miss_refresh = Some(now);
+                    }
+                    keys.into_iter()
+                        .find(|k| k.kid == kid)
+                        .ok_or_else(|| ActionsAuthError::UnknownKid(kid.to_string()))
+                }
+            }
+        }
+    }
+
+    impl ActionsOidcVerifier for GitHubActionsVerifier {
+        fn verify(&self, jwt: &str) -> Result<ActionsClaims, ActionsAuthError> {
+            let header = jsonwebtoken::decode_header(jwt)
+                .map_err(|e| ActionsAuthError::Malformed(e.to_string()))?;
+            let kid = header
+                .kid
+                .as_deref()
+                .ok_or_else(|| ActionsAuthError::Malformed("missing `kid`".into()))?;
+            let key_meta = self.key_for_kid(kid)?;
+            let decoding = jsonwebtoken::DecodingKey::from_rsa_components(&key_meta.n, &key_meta.e)
+                .map_err(|e| ActionsAuthError::Signature(e.to_string()))?;
+            let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+            validation.set_audience(&[&self.audience]);
+            validation.set_issuer(&[GITHUB_ACTIONS_ISSUER]);
+            // `exp` validation is on by default; leave the rest
+            // disabled — claim shape varies between GHA env types.
+            validation.required_spec_claims = ["exp", "iss", "aud"]
+                .into_iter()
+                .map(String::from)
+                .collect();
+            let data = jsonwebtoken::decode::<ActionsClaims>(jwt, &decoding, &validation).map_err(
+                |e| match e.kind() {
+                    jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                        ActionsAuthError::Expired(0)
+                    }
+                    jsonwebtoken::errors::ErrorKind::InvalidIssuer => {
+                        ActionsAuthError::Issuer(String::new())
+                    }
+                    jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+                        ActionsAuthError::Audience(String::new())
+                    }
+                    _ => ActionsAuthError::Signature(e.to_string()),
+                },
+            )?;
+            Ok(data.claims)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_matches_exact() {
+        assert!(repository_matches(&["org/repo".into()], "org/repo"));
+        assert!(!repository_matches(&["org/repo".into()], "org/other"));
+    }
+
+    #[test]
+    fn repository_matches_org_wildcard() {
+        let allow = vec!["org/*".into()];
+        assert!(repository_matches(&allow, "org/repo"));
+        assert!(repository_matches(&allow, "org/other-repo"));
+        assert!(!repository_matches(&allow, "other-org/repo"));
+        // `/*` doesn't cross slashes — paranoia.
+        assert!(!repository_matches(&allow, "org/sub/x"));
+        // No trailing empty
+        assert!(!repository_matches(&allow, "org/"));
+    }
+
+    #[test]
+    fn repository_matches_case_insensitive_owner() {
+        // GitHub normalises owner case.
+        assert!(repository_matches(&["Org/Repo".into()], "org/repo"));
+        assert!(repository_matches(&["ORG/*".into()], "Org/Whatever"));
+    }
+
+    #[test]
+    fn validate_repository_pattern_rejects_garbage() {
+        assert!(validate_repository_pattern("org/repo").is_ok());
+        assert!(validate_repository_pattern("org/*").is_ok());
+        assert!(validate_repository_pattern("").is_err());
+        assert!(validate_repository_pattern("just-an-owner").is_err());
+        assert!(validate_repository_pattern("org/repo/extra").is_err());
+        assert!(validate_repository_pattern("org/sub/*").is_err());
+    }
+
+    #[test]
+    fn aud_deserialize_accepts_string_and_array() {
+        let v: ActionsClaims = serde_json::from_value(serde_json::json!({
+            "iss": "x",
+            "aud": "hub",
+            "sub": "s",
+            "repository": "org/repo",
+            "repository_owner": "org",
+            "exp": 99999,
+        }))
+        .unwrap();
+        assert_eq!(v.aud, "hub");
+        let v: ActionsClaims = serde_json::from_value(serde_json::json!({
+            "iss": "x",
+            "aud": ["hub"],
+            "sub": "s",
+            "repository": "org/repo",
+            "repository_owner": "org",
+            "exp": 99999,
+        }))
+        .unwrap();
+        assert_eq!(v.aud, "hub");
+    }
+}

--- a/crates/sakimori-hub/src/auth/github.rs
+++ b/crates/sakimori-hub/src/auth/github.rs
@@ -1,0 +1,226 @@
+//! GitHub OAuth Authorization Code Flow.
+//!
+//! Two responsibilities live here:
+//!
+//! 1. Build the `authorize` redirect URL given a freshly-minted
+//!    CSRF `state` token.
+//! 2. Exchange the callback `code` for an access token and pull
+//!    the authenticated user's profile out of `GET /user`.
+//!
+//! Both surfaces are gated behind the [`OAuthExchange`] trait so
+//! the handler tests don't need real network access — the test
+//! suite injects a stub that returns canned responses.
+
+use serde::Deserialize;
+
+/// Identity returned by the GitHub `/user` endpoint that we
+/// actually consume. GitHub returns *much* more than this; we
+/// deliberately project to a small surface so we don't accumulate
+/// fields we have no use for (privacy minimum-collection).
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GitHubUser {
+    pub id: i64,
+    pub login: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GitHubAuthError {
+    #[error("OAuth token exchange failed: HTTP {status}: {body}")]
+    TokenExchange { status: u16, body: String },
+    #[error("OAuth token exchange transport error: {0}")]
+    Transport(String),
+    #[error("user lookup failed: HTTP {status}: {body}")]
+    UserLookup { status: u16, body: String },
+    #[error("user response decode: {0}")]
+    Decode(String),
+}
+
+/// Pluggable shim so tests can avoid the real GitHub endpoints.
+/// `code` is the value GitHub redirected with on
+/// `/auth/github/callback`; the impl is responsible for hitting
+/// the GitHub token endpoint, then `/user`, and returning the
+/// profile.
+pub trait OAuthExchange: Send + Sync {
+    fn exchange_code(&self, code: &str) -> std::result::Result<GitHubUser, GitHubAuthError>;
+}
+
+/// Production [`OAuthExchange`] backed by `ureq`. Mirrors the
+/// `dispatch::UreqClient` pattern (10-second timeout, explicit
+/// User-Agent — GitHub's API rejects requests without one).
+pub struct GitHubOAuthClient {
+    pub client_id: String,
+    pub client_secret: String,
+    pub agent: ureq::Agent,
+}
+
+impl GitHubOAuthClient {
+    pub fn new(client_id: String, client_secret: String) -> Self {
+        Self {
+            client_id,
+            client_secret,
+            agent: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(10))
+                .user_agent(concat!("sakimori-hub/", env!("CARGO_PKG_VERSION")))
+                .build(),
+        }
+    }
+}
+
+impl OAuthExchange for GitHubOAuthClient {
+    fn exchange_code(&self, code: &str) -> std::result::Result<GitHubUser, GitHubAuthError> {
+        // Step 1: code -> access_token.
+        let body = format!(
+            "client_id={}&client_secret={}&code={}",
+            urlencoding::encode(&self.client_id),
+            urlencoding::encode(&self.client_secret),
+            urlencoding::encode(code),
+        );
+        let resp = self
+            .agent
+            .post("https://github.com/login/oauth/access_token")
+            .set("accept", "application/json")
+            .set("content-type", "application/x-www-form-urlencoded")
+            .send_string(&body);
+        let resp = match resp {
+            Ok(r) => r,
+            Err(ureq::Error::Status(status, r)) => {
+                return Err(GitHubAuthError::TokenExchange {
+                    status,
+                    body: r.into_string().unwrap_or_default(),
+                });
+            }
+            Err(e) => return Err(GitHubAuthError::Transport(e.to_string())),
+        };
+        #[derive(Deserialize)]
+        struct TokenResp {
+            access_token: Option<String>,
+            error: Option<String>,
+            error_description: Option<String>,
+        }
+        let token: TokenResp = resp
+            .into_json()
+            .map_err(|e| GitHubAuthError::Decode(e.to_string()))?;
+        let access = match (token.access_token, token.error) {
+            (Some(t), _) => t,
+            (None, Some(err)) => {
+                return Err(GitHubAuthError::TokenExchange {
+                    status: 200,
+                    body: format!("{err}: {}", token.error_description.unwrap_or_default()),
+                });
+            }
+            _ => {
+                return Err(GitHubAuthError::Decode(
+                    "token response had neither access_token nor error".into(),
+                ));
+            }
+        };
+        // Step 2: access_token -> /user. Bearer auth with the user
+        // access token; we never persist this token — only the
+        // profile fields below.
+        let resp = self
+            .agent
+            .get("https://api.github.com/user")
+            .set("accept", "application/vnd.github+json")
+            .set("authorization", &format!("Bearer {access}"))
+            .call();
+        let resp = match resp {
+            Ok(r) => r,
+            Err(ureq::Error::Status(status, r)) => {
+                return Err(GitHubAuthError::UserLookup {
+                    status,
+                    body: r.into_string().unwrap_or_default(),
+                });
+            }
+            Err(e) => return Err(GitHubAuthError::Transport(e.to_string())),
+        };
+        resp.into_json::<GitHubUser>()
+            .map_err(|e| GitHubAuthError::Decode(e.to_string()))
+    }
+}
+
+/// Build the URL we redirect the browser to for step 1 of the
+/// flow. `state` is the CSRF token the caller generated and
+/// stashed in a short-lived signed cookie / server-side store.
+/// `scopes` is the OAuth scope set; for read-only profile a
+/// blank scope is enough (the default `read:user` is implicit on
+/// /user lookup).
+pub fn authorize_url(client_id: &str, redirect_uri: &str, state: &str, scopes: &[&str]) -> String {
+    let mut url = format!(
+        "https://github.com/login/oauth/authorize?client_id={}&redirect_uri={}&state={}",
+        urlencoding::encode(client_id),
+        urlencoding::encode(redirect_uri),
+        urlencoding::encode(state),
+    );
+    if !scopes.is_empty() {
+        url.push_str(&format!(
+            "&scope={}",
+            urlencoding::encode(&scopes.join(" "))
+        ));
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_includes_required_params() {
+        let url = authorize_url(
+            "abcd1234",
+            "https://hub.example.com/auth/github/callback",
+            "csrf-state-token",
+            &["read:user"],
+        );
+        assert!(url.starts_with("https://github.com/login/oauth/authorize?"));
+        assert!(url.contains("client_id=abcd1234"));
+        assert!(
+            url.contains("redirect_uri=https%3A%2F%2Fhub.example.com%2Fauth%2Fgithub%2Fcallback")
+        );
+        assert!(url.contains("state=csrf-state-token"));
+        assert!(url.contains("scope=read%3Auser"));
+    }
+
+    #[test]
+    fn authorize_url_omits_scope_when_empty() {
+        let url = authorize_url("c", "https://x/cb", "s", &[]);
+        assert!(!url.contains("scope="));
+    }
+
+    #[test]
+    fn authorize_url_url_encodes_unsafe_characters() {
+        let url = authorize_url("a&b=c", "https://x/cb?x=1", "s/t", &["a b"]);
+        assert!(url.contains("client_id=a%26b%3Dc"));
+        assert!(url.contains("redirect_uri=https%3A%2F%2Fx%2Fcb%3Fx%3D1"));
+        assert!(url.contains("state=s%2Ft"));
+        assert!(url.contains("scope=a%20b"));
+    }
+
+    #[test]
+    fn github_user_decodes_minimum_shape() {
+        let v: GitHubUser = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "login": "ada",
+        }))
+        .unwrap();
+        assert_eq!(v.login, "ada");
+        assert!(v.name.is_none());
+    }
+
+    #[test]
+    fn github_user_ignores_unmodelled_fields() {
+        let v: GitHubUser = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "login": "x",
+            "email": "ignored@example.com",
+            "company": "ignored",
+            "twitter_username": "ignored",
+        }))
+        .unwrap();
+        assert_eq!(v.id, 1);
+    }
+}

--- a/crates/sakimori-hub/src/auth/mod.rs
+++ b/crates/sakimori-hub/src/auth/mod.rs
@@ -1,0 +1,31 @@
+//! Identity for sakimori-hub.
+//!
+//! Three auth paths are planned (see the slice-7 design note in
+//! conversation history). This module implements path 1:
+//!
+//! 1. **Browser login** — GitHub OAuth Authorization Code Flow.
+//!    Returns an HMAC-signed session cookie. *This slice.*
+//! 2. **GitHub Actions** — `id-token: write` OIDC JWT, exchanged
+//!    for a short-lived team-scoped API token. (slice 9)
+//! 3. **Personal laptop CLI** — OAuth Device Authorization Flow,
+//!    returns a long-lived per-user API token. (slice 10)
+//!
+//! The bearer-token middleware from slice 6 stays for legacy CI
+//! that doesn't (yet) want to wire OAuth — it just becomes one of
+//! several accepted credentials, not the only one.
+
+pub mod actions;
+pub mod github;
+pub mod session;
+
+pub use actions::{
+    ActionsAuthError, ActionsClaims, ActionsOidcVerifier,
+    DefaultVerifier as DefaultActionsVerifier, GITHUB_ACTIONS_ISSUER, repository_matches,
+    validate_repository_pattern,
+};
+
+pub use github::{GitHubAuthError, GitHubOAuthClient, GitHubUser, OAuthExchange};
+pub use session::{
+    SESSION_COOKIE_NAME, SessionCookie, SessionToken, hash_session_token, mint_session_token,
+    verify_cookie,
+};

--- a/crates/sakimori-hub/src/auth/session.rs
+++ b/crates/sakimori-hub/src/auth/session.rs
@@ -1,0 +1,253 @@
+//! Session cookies for browser-authenticated users.
+//!
+//! ## Wire shape
+//!
+//! ```text
+//! Set-Cookie: sakimori_hub_session=<base64url(token)>.<base64url(hmac)>;
+//!     HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=<seconds>
+//! ```
+//!
+//! The cookie value is `<token>.<hmac>` where:
+//!
+//! - `token` is 32 random bytes, base64url-encoded (43 chars).
+//!   The DB row stores SHA-256 of `token`, never the cleartext —
+//!   so a DB dump can't impersonate a live user, only revoke them.
+//! - `hmac` is HMAC-SHA256(server_secret, token) truncated to
+//!   16 bytes (128 bits), base64url-encoded. A forged or modified
+//!   cookie fails the signature check before any DB lookup, so the
+//!   token-hash index never sees attacker-controlled values.
+//!
+//! Why HMAC on top of the random-token-with-DB-hash pattern? Two
+//! reasons:
+//!
+//! 1. Rejects garbage at the edge — typo'd cookies, expired
+//!    `Secure` flag transitions, etc. — without one DB round-trip
+//!    per request.
+//! 2. Lets us rotate the server secret to invalidate every live
+//!    session instantly (e.g. after a suspected compromise),
+//!    without a `DELETE FROM sessions`.
+
+use anyhow::Result;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+pub const SESSION_COOKIE_NAME: &str = "sakimori_hub_session";
+const TOKEN_LEN: usize = 32;
+const HMAC_TRUNC_LEN: usize = 16;
+
+/// A freshly-minted session token. The `cookie_value` is what
+/// gets sent in `Set-Cookie`; the `token_hash` is what gets
+/// inserted into `sessions.token_hash`. They never leave this
+/// struct together except via the matching pair returned by
+/// [`mint_session_token`].
+#[derive(Debug)]
+pub struct SessionToken {
+    pub cookie_value: String,
+    pub token_hash: [u8; 32],
+}
+
+/// A cookie value that's been signature-checked and split back
+/// into its components.
+#[derive(Debug)]
+pub struct SessionCookie {
+    pub token_hash: [u8; 32],
+}
+
+/// Generate 32 random bytes, base64url-encode them, sign with
+/// the server secret, and return both the cookie value (token +
+/// signature, joined with `.`) and the SHA-256 of the token for
+/// the DB row.
+pub fn mint_session_token(server_secret: &[u8]) -> SessionToken {
+    let mut raw = [0u8; TOKEN_LEN];
+    rand::thread_rng().fill_bytes(&mut raw);
+    let token_b64 = URL_SAFE_NO_PAD.encode(raw);
+    let sig = sign(server_secret, token_b64.as_bytes());
+    let cookie_value = format!("{token_b64}.{sig}");
+    let mut h = Sha256::new();
+    h.update(token_b64.as_bytes());
+    let token_hash: [u8; 32] = h.finalize().into();
+    SessionToken {
+        cookie_value,
+        token_hash,
+    }
+}
+
+/// Verify the HMAC, then return the SHA-256 token hash so the
+/// caller can look the session up. `None` for any
+/// shape/signature failure — the caller treats every failure
+/// uniformly as "no session", so an attacker can't distinguish
+/// "bad signature" from "expired" from "revoked" via response
+/// timing/wording.
+pub fn verify_cookie(server_secret: &[u8], cookie_value: &str) -> Option<SessionCookie> {
+    let (token, sig) = cookie_value.split_once('.')?;
+    // Length-check before constant-time compare so a stupendously
+    // wrong cookie shape doesn't drag in a 64-byte CT loop.
+    let expected_sig = sign(server_secret, token.as_bytes());
+    if sig.len() != expected_sig.len() {
+        return None;
+    }
+    if !bool::from(sig.as_bytes().ct_eq(expected_sig.as_bytes())) {
+        return None;
+    }
+    let mut h = Sha256::new();
+    h.update(token.as_bytes());
+    let token_hash: [u8; 32] = h.finalize().into();
+    Some(SessionCookie { token_hash })
+}
+
+/// Standalone helper for callers that already have the cleartext
+/// token (e.g. the freshly-minted one) and want to recompute the
+/// row hash without going through cookie parsing.
+pub fn hash_session_token(cookie_token_part: &str) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(cookie_token_part.as_bytes());
+    h.finalize().into()
+}
+
+/// HMAC-SHA256 truncated to [`HMAC_TRUNC_LEN`] bytes,
+/// base64url-encoded. 128 bits is enough to make forgery
+/// infeasible at the per-request budget while keeping the cookie
+/// compact.
+pub fn sign(server_secret: &[u8], body: &[u8]) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(server_secret).expect("hmac accepts any key length");
+    mac.update(body);
+    let tag = mac.finalize().into_bytes();
+    URL_SAFE_NO_PAD.encode(&tag[..HMAC_TRUNC_LEN])
+}
+
+/// Build the `Set-Cookie` value for [`SESSION_COOKIE_NAME`].
+/// `secure` flips the `Secure` flag — set `false` only for local
+/// loopback testing, every production deploy must keep it `true`.
+pub fn build_set_cookie(value: &str, max_age_secs: i64, secure: bool) -> Result<String> {
+    if value.contains([';', '\r', '\n']) {
+        anyhow::bail!("session cookie value contained a control character");
+    }
+    let mut s = format!(
+        "{SESSION_COOKIE_NAME}={value}; Path=/; HttpOnly; SameSite=Lax; Max-Age={max_age_secs}"
+    );
+    if secure {
+        s.push_str("; Secure");
+    }
+    Ok(s)
+}
+
+/// `Set-Cookie` value that clears the session client-side. The
+/// server should also revoke the DB row in the same handler.
+pub fn build_clear_cookie(secure: bool) -> String {
+    let mut s = format!("{SESSION_COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0");
+    if secure {
+        s.push_str("; Secure");
+    }
+    s
+}
+
+/// Pull `SESSION_COOKIE_NAME` out of a `Cookie:` header value.
+/// We do the parsing ourselves rather than pulling in
+/// `tower-cookies` because the surface is one cookie and the
+/// `Cookie` header is just `;`-separated `name=value` pairs.
+pub fn extract_session_cookie(cookie_header: &str) -> Option<&str> {
+    for part in cookie_header.split(';') {
+        let part = part.trim();
+        if let Some(value) = part.strip_prefix(&format!("{SESSION_COOKIE_NAME}=")) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_minted_cookie_verifies() {
+        let secret = b"server-secret-1234567890abcdef";
+        let t = mint_session_token(secret);
+        let parsed = verify_cookie(secret, &t.cookie_value).expect("must verify");
+        assert_eq!(parsed.token_hash, t.token_hash);
+    }
+
+    #[test]
+    fn cookie_with_wrong_secret_rejects() {
+        let t = mint_session_token(b"server-secret-1234567890abcdef");
+        assert!(verify_cookie(b"wrong-secret-doesntmatch", &t.cookie_value).is_none());
+    }
+
+    #[test]
+    fn tampered_token_rejects() {
+        let secret = b"server-secret-1234567890abcdef";
+        let t = mint_session_token(secret);
+        // Flip one char of the token portion; signature should fail.
+        let (token, sig) = t.cookie_value.split_once('.').unwrap();
+        let mut chars: Vec<char> = token.chars().collect();
+        chars[0] = if chars[0] == 'A' { 'B' } else { 'A' };
+        let tampered = format!("{}.{}", chars.into_iter().collect::<String>(), sig);
+        assert!(verify_cookie(secret, &tampered).is_none());
+    }
+
+    #[test]
+    fn tampered_signature_rejects() {
+        let secret = b"server-secret-1234567890abcdef";
+        let t = mint_session_token(secret);
+        let (token, sig) = t.cookie_value.split_once('.').unwrap();
+        let mut sig_chars: Vec<char> = sig.chars().collect();
+        sig_chars[0] = if sig_chars[0] == 'A' { 'B' } else { 'A' };
+        let tampered = format!("{}.{}", token, sig_chars.into_iter().collect::<String>());
+        assert!(verify_cookie(secret, &tampered).is_none());
+    }
+
+    #[test]
+    fn cookie_without_dot_rejects() {
+        assert!(verify_cookie(b"k1234567890abcdef", "no-dot-anywhere").is_none());
+    }
+
+    #[test]
+    fn extract_finds_named_cookie_among_many() {
+        let h = "foo=bar; sakimori_hub_session=abc.def; baz=qux";
+        assert_eq!(extract_session_cookie(h), Some("abc.def"));
+    }
+
+    #[test]
+    fn extract_returns_none_when_missing() {
+        assert!(extract_session_cookie("foo=bar; baz=qux").is_none());
+    }
+
+    #[test]
+    fn build_set_cookie_rejects_control_chars() {
+        // Defence in depth — every caller should be passing a
+        // value from `mint_session_token`, but if a buggy caller
+        // ever passes user-controlled bytes we must not let CRLF
+        // through (header injection).
+        assert!(build_set_cookie("evil\r\nLocation: http://x/", 60, true).is_err());
+        // `;` in value would prematurely close the cookie and let an
+        // attacker append attributes like `Domain=evil.example`.
+        assert!(build_set_cookie("ok;Domain=evil", 60, true).is_err());
+        let v = mint_session_token(b"secret-1234567890abcdef").cookie_value;
+        assert!(build_set_cookie(&v, 60, true).is_ok());
+    }
+
+    #[test]
+    fn set_cookie_includes_secure_only_when_requested() {
+        let v = "abc.def";
+        assert!(build_set_cookie(v, 60, true).unwrap().contains("; Secure"));
+        assert!(!build_set_cookie(v, 60, false).unwrap().contains("; Secure"));
+    }
+
+    #[test]
+    fn clear_cookie_uses_max_age_zero() {
+        assert!(build_clear_cookie(true).contains("Max-Age=0"));
+    }
+
+    #[test]
+    fn hash_helper_matches_mint() {
+        let secret = b"server-secret-1234567890abcdef";
+        let t = mint_session_token(secret);
+        let token_part = t.cookie_value.split_once('.').unwrap().0;
+        assert_eq!(hash_session_token(token_part), t.token_hash);
+    }
+}

--- a/crates/sakimori-hub/src/classify.rs
+++ b/crates/sakimori-hub/src/classify.rs
@@ -1,0 +1,223 @@
+//! Hub-side classification of *where* an InstallEvent originated.
+//!
+//! The proxy already records `execution_mode` (persistent vs ephemeral
+//! — see [`sakimori_core::installs::ExecutionMode`]). That's the
+//! "what shape of install" axis. This module adds the orthogonal
+//! "what shape of machine" axis: a CI runner or a developer's laptop?
+//!
+//! The two answers together drive different inventory views ("who on
+//! the team has `<pkg>@<ver>` checked in" vs. "did any CI job pull
+//! `<pkg>@<ver>` last week") and, eventually, different advisory
+//! notification routing.
+//!
+//! The classifier is intentionally conservative: when neither a
+//! User-Agent nor a project-path gives a confident answer we return
+//! [`Source::Unknown`] rather than guess.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Source {
+    /// GitHub Actions runner (and, by reasonable extension, other
+    /// hosted CI we haven't fingerprinted yet — for now this variant
+    /// is GHA-shaped).
+    Actions,
+    /// Developer endpoint — laptop / workstation.
+    Desktop,
+    /// Couldn't classify confidently. Surface as "unknown" rather
+    /// than mis-attribute.
+    Unknown,
+}
+
+impl Source {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Source::Actions => "actions",
+            Source::Desktop => "desktop",
+            Source::Unknown => "unknown",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "actions" => Some(Source::Actions),
+            "desktop" => Some(Source::Desktop),
+            "unknown" => Some(Source::Unknown),
+            _ => None,
+        }
+    }
+}
+
+/// Decide where an event came from.
+///
+/// Order of precedence:
+///
+/// 1. **`project_path`** — GitHub-hosted runners always check the
+///    repo out under `/home/runner/work/<repo>/<repo>/` (Linux) or
+///    `D:\a\<repo>\<repo>\` / `C:\actions-runner\_work\...` (Windows
+///    self-hosted). Anything matching is a CI runner.
+/// 2. **`user_agent`** — the GHA-shipped tooling sets distinctive
+///    UAs (e.g. `actions/setup-node`, `GitHubActions`). Less reliable
+///    than path because package managers themselves don't advertise
+///    "I'm on a runner", but useful when `project_path` is absent.
+/// 3. **Otherwise** — if we have *some* signal that suggests a
+///    developer machine (`/Users/...`, `/home/<non-runner>/...`,
+///    `C:\Users\...`) we say `Desktop`. If we have nothing, `Unknown`.
+pub fn classify(project_path: Option<&str>, user_agent: Option<&str>) -> Source {
+    if let Some(path) = project_path {
+        if looks_like_runner_path(path) {
+            return Source::Actions;
+        }
+        if looks_like_desktop_path(path) {
+            return Source::Desktop;
+        }
+    }
+    if let Some(ua) = user_agent
+        && looks_like_actions_ua(ua)
+    {
+        return Source::Actions;
+    }
+    Source::Unknown
+}
+
+fn looks_like_runner_path(path: &str) -> bool {
+    // GitHub-hosted (Linux, macOS): /home/runner/work/<repo>/<repo>/
+    // GitHub-hosted (Linux runners post-2024 also expose /Users/runner on macOS)
+    // Self-hosted: typically `_work` directory under the runner home.
+    let normalised = path.replace('\\', "/");
+    normalised.contains("/home/runner/work/")
+        || normalised.contains("/Users/runner/work/")
+        || normalised.contains("/actions-runner/_work/")
+        || normalised.contains(":/a/")
+        // Windows GitHub-hosted: D:\a\<repo>\<repo>\
+        || normalised.starts_with("D:/a/")
+        || normalised.starts_with("C:/a/")
+}
+
+fn looks_like_desktop_path(path: &str) -> bool {
+    let normalised = path.replace('\\', "/");
+    // POSIX user homes that aren't `runner`. Match prefix + path
+    // separator to avoid `/Users/runnerfoo/...` collisions.
+    if let Some(rest) = normalised.strip_prefix("/Users/")
+        && !rest.starts_with("runner/")
+    {
+        return true;
+    }
+    if let Some(rest) = normalised.strip_prefix("/home/")
+        && !rest.starts_with("runner/")
+    {
+        return true;
+    }
+    // Windows user profile dir.
+    let lower = normalised.to_ascii_lowercase();
+    lower.starts_with("c:/users/") && !lower.starts_with("c:/users/runneradmin/")
+}
+
+fn looks_like_actions_ua(ua: &str) -> bool {
+    // GHA-shipped tooling and the runner itself set distinctive UAs.
+    // The list is deliberately small — we'd rather mis-classify as
+    // Unknown than mis-attribute a developer's `npm install` to CI.
+    let lower = ua.to_ascii_lowercase();
+    lower.contains("githubactions")
+        || lower.contains("github-actions")
+        || lower.contains("actions/setup-")
+        || lower.contains("actions/runner")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_hosted_linux_path_is_actions() {
+        assert_eq!(
+            classify(Some("/home/runner/work/myrepo/myrepo"), None),
+            Source::Actions
+        );
+    }
+
+    #[test]
+    fn github_hosted_windows_path_is_actions() {
+        assert_eq!(classify(Some(r"D:\a\myrepo\myrepo"), None), Source::Actions);
+    }
+
+    #[test]
+    fn self_hosted_runner_path_is_actions() {
+        assert_eq!(
+            classify(Some("/opt/actions-runner/_work/myrepo/myrepo"), None),
+            Source::Actions
+        );
+    }
+
+    #[test]
+    fn macos_user_home_is_desktop() {
+        assert_eq!(
+            classify(Some("/Users/alice/code/proj"), None),
+            Source::Desktop
+        );
+    }
+
+    #[test]
+    fn linux_user_home_is_desktop() {
+        assert_eq!(
+            classify(Some("/home/alice/src/proj"), None),
+            Source::Desktop
+        );
+    }
+
+    #[test]
+    fn similar_but_not_runner_user_is_desktop() {
+        // The startswith check must not be tricked by usernames
+        // starting with "runner".
+        assert_eq!(
+            classify(Some("/home/runnerfoo/proj"), None),
+            Source::Desktop
+        );
+    }
+
+    #[test]
+    fn windows_user_profile_is_desktop() {
+        assert_eq!(
+            classify(Some(r"C:\Users\alice\proj"), None),
+            Source::Desktop
+        );
+    }
+
+    #[test]
+    fn actions_ua_without_path_classifies() {
+        assert_eq!(
+            classify(None, Some("actions/setup-node@4.0.0")),
+            Source::Actions
+        );
+    }
+
+    #[test]
+    fn nothing_known_is_unknown() {
+        assert_eq!(classify(None, None), Source::Unknown);
+        assert_eq!(
+            classify(None, Some("npm/10.0.0 node/20.0.0")),
+            Source::Unknown
+        );
+        // Path that matches neither bucket.
+        assert_eq!(classify(Some("/srv/build/proj"), None), Source::Unknown);
+    }
+
+    #[test]
+    fn path_beats_ambiguous_ua() {
+        // Path is the higher-confidence signal — even if UA looks
+        // CI-ish, a clearly-desktop path wins.
+        assert_eq!(
+            classify(Some("/Users/alice/proj"), Some("actions/setup-node")),
+            Source::Desktop
+        );
+    }
+
+    #[test]
+    fn source_string_roundtrip() {
+        for s in [Source::Actions, Source::Desktop, Source::Unknown] {
+            assert_eq!(Source::parse(s.as_str()), Some(s));
+        }
+        assert_eq!(Source::parse("nonsense"), None);
+    }
+}

--- a/crates/sakimori-hub/src/dispatch.rs
+++ b/crates/sakimori-hub/src/dispatch.rs
@@ -1,0 +1,990 @@
+//! Webhook dispatcher: convert `findings` rows into HTTP POSTs to
+//! operator-registered targets.
+//!
+//! This is the "push notifications" half of CLAUDE.md roadmap #6.
+//! The previous slices built the install inventory and the
+//! advisory-vs-install JOIN; this one turns each new finding into a
+//! delivery against every target whose `(min_severity, source_filter)`
+//! the finding satisfies.
+//!
+//! ## Delivery contract
+//!
+//! For each pending `(finding, target)` pair the dispatcher
+//! constructs a [`DeliveryPayload`] (JSON), signs the body with
+//! HMAC-SHA256 keyed on the target's secret, and POSTs:
+//!
+//! ```text
+//! POST <target.url>
+//! Content-Type: application/json
+//! X-Sakimori-Event: finding.created
+//! X-Sakimori-Signature: sha256=<hex>
+//! X-Sakimori-Target: <target.label>
+//! User-Agent: sakimori-hub/<version>
+//! ```
+//!
+//! Subscribers re-compute HMAC-SHA256 of the raw body with the
+//! shared secret and compare to the header to prove authenticity.
+//!
+//! ## Replay protection
+//!
+//! The HMAC only proves the message was produced by someone
+//! holding the shared secret — it does not prove freshness. The
+//! signed body carries `dispatched_at` (RFC 3339, UTC), and
+//! subscribers should:
+//!
+//! 1. Reject deliveries whose `dispatched_at` is more than ~5
+//!    minutes in the past or future, to bound the replay window.
+//! 2. Track `finding_id` as a dedupe key — the hub guarantees a
+//!    given finding is delivered at most once per target
+//!    successfully (the `dispatch_attempts` unique partial index
+//!    on `(finding_id, target_id) WHERE success = 1` enforces
+//!    this server-side), so any duplicate the subscriber sees was
+//!    either a network retry or an active replay.
+//!
+//! Each attempt is durably recorded in `dispatch_attempts` —
+//! `(finding_id, target_id, success)` is the per-attempt outcome.
+//! Re-running `run_once` is idempotent: pairs that already have a
+//! successful attempt are skipped, pairs that have hit the failure
+//! cap are skipped, everything else is retried.
+//!
+//! ## What's not in this slice
+//!
+//! - **Exponential backoff.** The retry policy is "up to N
+//!   attempts" with no inter-attempt delay enforced by the
+//!   dispatcher itself. Operators who want backoff can re-run
+//!   `/dispatch/run` from cron with whatever cadence they want;
+//!   the failure cap stops a permanently-broken target from
+//!   silently filling the attempts table.
+//! - **Email and Slack adapters.** Both deliver as HTTP webhooks
+//!   in practice (Slack incoming-webhook is `POST <slack-url>`;
+//!   email-via-API is `POST <SES/etc>` with auth). The signed
+//!   webhook is the substrate; named adapters can layer on top
+//!   when there's a real user asking for them.
+
+use std::net::ToSocketAddrs;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+use crate::Source;
+use crate::advisories::Severity;
+use crate::store::{
+    PendingDelivery, Store, StoredAdvisory, StoredEvent, StoredFinding, TargetSpec,
+};
+
+/// Per-call result so the operator can see what fired and what
+/// stayed pending. `considered` is the number of pending pairs
+/// this run examined; `delivered` and `failed` partition it.
+/// `over_cap_at_scan` is the count of `(finding, target)` pairs
+/// that were excluded because they had already hit
+/// `attempt_cap` *at the moment the JOIN ran* — operators
+/// notice this as "we have N targets that are permanently stuck;
+/// fix the target or bump the cap".
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DispatchReport {
+    pub considered: i64,
+    pub delivered: i64,
+    pub failed: i64,
+    pub over_cap_at_scan: i64,
+}
+
+/// Default cap on the number of attempts per `(finding, target)`
+/// pair. Keeps a permanently-broken target from filling the
+/// attempts table. Operators can override per-call.
+pub const DEFAULT_ATTEMPT_CAP: i64 = 5;
+
+/// Wire shape of every POST body. Stable so subscriber code can
+/// rely on the field names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliveryPayload {
+    pub event: &'static str,
+    pub dispatched_at: DateTime<Utc>,
+    pub finding_id: i64,
+    pub finding_created_at: DateTime<Utc>,
+    pub advisory: AdvisorySummary,
+    pub install: InstallSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdvisorySummary {
+    pub osv_id: String,
+    pub severity: Severity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstallSummary {
+    pub ecosystem: String,
+    pub name: String,
+    pub version: String,
+    pub source: Source,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    pub resolved_at: DateTime<Utc>,
+}
+
+impl DeliveryPayload {
+    pub fn from_parts(f: &StoredFinding) -> Self {
+        Self {
+            event: "finding.created",
+            dispatched_at: Utc::now(),
+            finding_id: f.id,
+            finding_created_at: f.created_at,
+            advisory: summarise_adv(&f.advisory),
+            install: summarise_install(&f.install),
+        }
+    }
+
+    pub fn for_pending(p: &PendingDelivery) -> Self {
+        Self {
+            event: "finding.created",
+            dispatched_at: Utc::now(),
+            finding_id: p.finding_id,
+            finding_created_at: p.finding_created_at,
+            advisory: AdvisorySummary {
+                osv_id: p.advisory_osv_id.clone(),
+                severity: p.advisory_severity,
+                summary: p.advisory_summary.clone(),
+                published_at: p.advisory_published_at,
+            },
+            install: InstallSummary {
+                ecosystem: p.install_ecosystem.clone(),
+                name: p.install_name.clone(),
+                version: p.install_version.clone(),
+                source: p.install_source,
+                project_path: p.install_project_path.clone(),
+                resolved_at: p.install_resolved_at,
+            },
+        }
+    }
+}
+
+fn summarise_adv(a: &StoredAdvisory) -> AdvisorySummary {
+    AdvisorySummary {
+        osv_id: a.osv_id.clone(),
+        severity: a.severity,
+        summary: a.summary.clone(),
+        published_at: a.published_at,
+    }
+}
+
+fn summarise_install(i: &StoredEvent) -> InstallSummary {
+    InstallSummary {
+        ecosystem: i.ecosystem.clone(),
+        name: i.name.clone(),
+        version: i.version.clone(),
+        source: i.source,
+        project_path: i.project_path.clone(),
+        resolved_at: i.resolved_at,
+    }
+}
+
+/// Pluggable HTTP client. Production uses [`UreqClient`]; tests
+/// inject a stub so the dispatcher can be exercised offline.
+pub trait WebhookClient: Send + Sync {
+    /// POST `body` with the supplied headers and return the
+    /// response status code, or a transport-level error string
+    /// (e.g. DNS, TLS, connect refused).
+    fn post(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> std::result::Result<u16, String>;
+}
+
+/// Default [`WebhookClient`] backed by `ureq`. Honours a 10-second
+/// timeout so a hung target can't pin the dispatcher worker.
+///
+/// The client also enforces the SSRF policy at *connect* time
+/// — not via a separate preflight, but by installing a custom
+/// `ureq::Resolver` on the `Agent`. The agent calls the resolver
+/// exactly once per connection, and the resolver returns only the
+/// public addresses; ureq then dials one of those addresses, so
+/// the address that was *checked* is the address that's
+/// *connected to*. This closes the TOCTOU between a preflight
+/// lookup and ureq's own resolution that a DNS-rebinding or
+/// split-DNS target could otherwise exploit.
+pub struct UreqClient {
+    agent: ureq::Agent,
+}
+
+impl Default for UreqClient {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+impl UreqClient {
+    pub fn new(allow_private: bool) -> Self {
+        let resolver = SafeResolver { allow_private };
+        Self {
+            agent: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(10))
+                .user_agent(concat!("sakimori-hub/", env!("CARGO_PKG_VERSION")))
+                .resolver(resolver)
+                .build(),
+        }
+    }
+}
+
+/// Resolver shim. Delegates DNS to `ToSocketAddrs` (libstd's
+/// system resolver — same one `ureq` uses by default), filters the
+/// result through [`ip_is_private`], and returns only the
+/// surviving addresses. ureq picks one of those to dial, so the
+/// connection lands on an address we explicitly approved.
+struct SafeResolver {
+    allow_private: bool,
+}
+
+impl ureq::Resolver for SafeResolver {
+    fn resolve(&self, netloc: &str) -> std::io::Result<Vec<std::net::SocketAddr>> {
+        let addrs: Vec<std::net::SocketAddr> = netloc.to_socket_addrs()?.collect();
+        if self.allow_private {
+            return Ok(addrs);
+        }
+        let filtered: Vec<_> = addrs
+            .iter()
+            .copied()
+            .filter(|sa| !ip_is_private(sa.ip()))
+            .collect();
+        if filtered.is_empty() && !addrs.is_empty() {
+            return Err(std::io::Error::other(format!(
+                "refusing to connect to {netloc}: all resolved addresses are private \
+                 (set allow_private_webhooks to override)"
+            )));
+        }
+        Ok(filtered)
+    }
+}
+
+impl WebhookClient for UreqClient {
+    fn post(
+        &self,
+        url: &str,
+        headers: &[(String, String)],
+        body: &[u8],
+    ) -> std::result::Result<u16, String> {
+        let mut req = self.agent.post(url).set("content-type", "application/json");
+        for (k, v) in headers {
+            req = req.set(k, v);
+        }
+        match req.send_bytes(body) {
+            Ok(resp) => Ok(resp.status()),
+            // ureq's `Error::Status` carries the HTTP code even
+            // though it's >=400 — that is *not* a transport error;
+            // record it as a real status.
+            Err(ureq::Error::Status(code, _)) => Ok(code),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+/// Compute the `X-Sakimori-Signature` value for `body` keyed on
+/// `secret`. Exposed so the subscriber side of integration tests
+/// can re-derive it.
+pub fn sign(secret: &[u8], body: &[u8]) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(secret).expect("hmac accepts any key length");
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Run a single dispatch pass.
+///
+/// Pulls up to `batch` pending deliveries from `store`, serializes
+/// each payload, signs it with the target's secret, posts via
+/// `client`, and records the outcome. Returns a per-call summary.
+///
+/// Concurrency: callers MUST serialize calls to `run_once` against
+/// the same `store` so two parallel runs can't both claim the same
+/// `(finding, target)` pair before either has recorded success.
+/// The `AppState` in `crate::server` holds a `tokio::sync::Mutex`
+/// for exactly this purpose; if you call `run_once` from elsewhere,
+/// wrap it in your own equivalent.
+///
+/// **Deploy model is one hub process per team.** The mutex is
+/// in-process only. Two `sakimori-hub` processes pointing at the
+/// same SQLite file could both pull the same `(finding, target)`
+/// pair, both POST, then race on the unique partial index — one
+/// success-attempt insert wins, the other returns a UNIQUE
+/// constraint error and is recorded as a failure, but the
+/// subscriber has already received both POSTs. Operators who
+/// genuinely need multi-process need to add a DB-level lease
+/// (e.g. an `UPDATE … WHERE claimed_at IS NULL RETURNING …`
+/// claim pass) before this scales out — out of scope here.
+pub async fn run_once(
+    store: Arc<Store>,
+    client: Arc<dyn WebhookClient>,
+    batch: u32,
+    attempt_cap: i64,
+) -> Result<DispatchReport> {
+    let (pending, over_cap_at_scan) = store
+        .pending_deliveries_with_stats(batch, attempt_cap)
+        .await
+        .context("listing pending deliveries")?;
+    let considered = pending.len() as i64;
+    let mut delivered = 0i64;
+    let mut failed = 0i64;
+    for p in &pending {
+        let payload = DeliveryPayload::for_pending(p);
+        let body = serde_json::to_vec(&payload).context("serializing dispatch payload")?;
+        let sig = sign(p.target_secret.as_bytes(), &body);
+        let headers = vec![
+            ("X-Sakimori-Event".into(), payload.event.into()),
+            ("X-Sakimori-Signature".into(), sig),
+            ("X-Sakimori-Target".into(), p.target_label.clone()),
+        ];
+        match client.post(&p.target_url, &headers, &body) {
+            Ok(status) if (200..300).contains(&status) => {
+                store
+                    .record_attempt(p.finding_id, p.target_id, true, Some(status as i64), None)
+                    .await?;
+                delivered += 1;
+            }
+            Ok(status) => {
+                store
+                    .record_attempt(
+                        p.finding_id,
+                        p.target_id,
+                        false,
+                        Some(status as i64),
+                        Some(format!("non-2xx status {status}")),
+                    )
+                    .await?;
+                failed += 1;
+            }
+            Err(transport) => {
+                store
+                    .record_attempt(p.finding_id, p.target_id, false, None, Some(transport))
+                    .await?;
+                failed += 1;
+            }
+        }
+    }
+    Ok(DispatchReport {
+        considered,
+        delivered,
+        failed,
+        over_cap_at_scan,
+    })
+}
+
+/// Handle for a background dispatcher loop started with
+/// [`spawn_loop`]. Drop the handle to keep the loop running for
+/// the lifetime of the process; call [`DispatcherHandle::shutdown`]
+/// to ask it to stop cleanly (it finishes whatever pass is in
+/// flight and then exits).
+///
+/// The loop is intentionally simple: every `interval`, take the
+/// shared `dispatch_lock`, call [`run_once`], release the lock.
+/// Sharing the lock with the HTTP handler means a `POST
+/// /dispatch/run` racing the timer can't double-fire — whichever
+/// gets the lock first goes; the other waits and then either
+/// runs (if there are still pending pairs) or no-ops.
+pub struct DispatcherHandle {
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    join: tokio::task::JoinHandle<()>,
+}
+
+impl DispatcherHandle {
+    /// Ask the loop to stop and wait for it to finish the
+    /// current pass (if any) and exit. Idempotent.
+    pub async fn shutdown(self) {
+        // Best-effort: the receiver may already have dropped if
+        // the loop crashed; that's fine, the join below tells us.
+        let _ = self.shutdown_tx.send(());
+        let _ = self.join.await;
+    }
+}
+
+/// Spawn a background task that calls [`run_once`] every
+/// `interval`. Errors from any single pass are `log::warn!`ed
+/// (e.g. transient DB lock, malformed advisory) so the loop
+/// keeps running rather than wedging the hub on the first hiccup.
+///
+/// `dispatch_lock` MUST be the same `Arc<tokio::sync::Mutex>` the
+/// HTTP `/dispatch/run` handler uses, so the two paths can't
+/// claim the same `(finding, target)` pair simultaneously.
+pub fn spawn_loop(
+    store: Arc<Store>,
+    client: Arc<dyn WebhookClient>,
+    dispatch_lock: Arc<tokio::sync::Mutex<()>>,
+    interval: std::time::Duration,
+    batch: u32,
+    attempt_cap: i64,
+) -> DispatcherHandle {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+    let join = tokio::spawn(async move {
+        // `MissedTickBehavior::Delay` keeps the cadence smooth
+        // when a single pass takes longer than `interval`
+        // (e.g. one slow target); otherwise tokio's default
+        // would fire back-to-back ticks to catch up, which is
+        // exactly the wrong behaviour for a network worker.
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = ticker.tick() => {
+                    // A pass that the HTTP `/dispatch/run` handler
+                    // is currently holding could otherwise pin
+                    // shutdown until both passes finish; this
+                    // inner select lets shutdown win the race for
+                    // the lock and exit straight away.
+                    let _guard = tokio::select! {
+                        g = dispatch_lock.lock() => g,
+                        _ = &mut shutdown_rx => break,
+                    };
+                    // Phase 1: derive any new (advisory, install)
+                    // matches. Without this the background loop
+                    // would only re-deliver findings someone else
+                    // produced via `POST /scan` — which is exactly
+                    // *not* "set and forget". Errors are logged
+                    // but don't skip the dispatch phase (a partial
+                    // scan + dispatch is still useful).
+                    match store.scan_findings().await {
+                        Ok(report) if report.new_findings > 0 => log::info!(
+                            target: "sakimori_hub::dispatch",
+                            "background scan: {} new finding(s) (total {})",
+                            report.new_findings, report.total_findings,
+                        ),
+                        Ok(_) => {}
+                        Err(e) => log::warn!(
+                            target: "sakimori_hub::dispatch",
+                            "background scan errored: {e:#}",
+                        ),
+                    }
+                    // Phase 2: deliver everything pending.
+                    match run_once(store.clone(), client.clone(), batch, attempt_cap).await {
+                        Ok(report) => {
+                            if report.delivered + report.failed > 0 {
+                                log::info!(
+                                    target: "sakimori_hub::dispatch",
+                                    "background pass: delivered={} failed={} over_cap={}",
+                                    report.delivered, report.failed, report.over_cap_at_scan,
+                                );
+                            }
+                        }
+                        Err(e) => log::warn!(
+                            target: "sakimori_hub::dispatch",
+                            "background dispatcher pass errored: {e:#}",
+                        ),
+                    }
+                }
+                _ = &mut shutdown_rx => break,
+            }
+        }
+    });
+    DispatcherHandle { shutdown_tx, join }
+}
+
+/// Validate operator-supplied target fields before they hit the
+/// store. Mirrors the advisory validator pattern.
+#[derive(Debug, thiserror::Error)]
+pub enum TargetValidationError {
+    #[error("label is empty")]
+    EmptyLabel,
+    #[error("label exceeds 128 chars")]
+    LabelTooLong,
+    #[error("url is empty")]
+    EmptyUrl,
+    #[error("url must start with http:// or https://")]
+    UrlScheme,
+    #[error("url host is missing")]
+    UrlHostMissing,
+    #[error(
+        "url host {0} resolves to a private / loopback / link-local address; \
+         pass allow_private_webhooks if this is intentional (e.g. a localhost test receiver)"
+    )]
+    UrlHostPrivate(String),
+    #[error("secret must be at least 16 chars")]
+    SecretTooShort,
+}
+
+pub fn validate_target(
+    spec: &TargetSpec,
+    allow_private: bool,
+) -> std::result::Result<(), TargetValidationError> {
+    if spec.label.is_empty() {
+        return Err(TargetValidationError::EmptyLabel);
+    }
+    if spec.label.len() > 128 {
+        return Err(TargetValidationError::LabelTooLong);
+    }
+    if spec.url.is_empty() {
+        return Err(TargetValidationError::EmptyUrl);
+    }
+    if !(spec.url.starts_with("http://") || spec.url.starts_with("https://")) {
+        return Err(TargetValidationError::UrlScheme);
+    }
+    if !allow_private {
+        let host = extract_host(&spec.url).ok_or(TargetValidationError::UrlHostMissing)?;
+        if host_looks_private(host) {
+            return Err(TargetValidationError::UrlHostPrivate(host.to_string()));
+        }
+    }
+    if spec.secret.len() < 16 {
+        return Err(TargetValidationError::SecretTooShort);
+    }
+    Ok(())
+}
+
+/// Pull the host part out of a URL without depending on a full URL
+/// parser. Recognises `scheme://[user[:pass]@]host[:port]/...`.
+/// Returns `None` for shapes that don't match.
+fn extract_host(url: &str) -> Option<&str> {
+    let after_scheme = url.split_once("://")?.1;
+    let after_authority = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
+    let after_userinfo = match after_authority.rsplit_once('@') {
+        Some((_, rest)) => rest,
+        None => after_authority,
+    };
+    if after_userinfo.is_empty() {
+        return None;
+    }
+    // Strip port. IPv6 hosts are bracketed: `[::1]:8080`.
+    if let Some(rest) = after_userinfo.strip_prefix('[') {
+        let (host, _) = rest.split_once(']')?;
+        Some(host)
+    } else {
+        Some(after_userinfo.split(':').next().unwrap_or(after_userinfo))
+    }
+}
+
+pub(crate) fn host_looks_private(host: &str) -> bool {
+    // String matches first — covers the cases that don't parse as
+    // an IP literal (DNS names) cheaply.
+    let lower = host.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "localhost" | "ip6-localhost" | "ip6-loopback"
+    ) {
+        return true;
+    }
+    if lower.ends_with(".localhost") || lower.ends_with(".internal") {
+        return true;
+    }
+    if lower == "metadata.google.internal" {
+        return true;
+    }
+    if let Ok(addr) = host.parse::<std::net::IpAddr>() {
+        return ip_is_private(addr);
+    }
+    false
+}
+
+pub(crate) fn ip_is_private(addr: std::net::IpAddr) -> bool {
+    match addr {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                // 169.254.169.254 is the cloud metadata IP
+                || v4.octets() == [169, 254, 169, 254]
+                // Carrier-grade NAT (RFC6598)
+                || (v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1]))
+        }
+        std::net::IpAddr::V6(v6) => {
+            // IPv4-mapped IPv6 (`::ffff:10.0.0.1`,
+            // `::ffff:127.0.0.1`, `::ffff:169.254.169.254`) are
+            // really IPv4 — apply the v4 blocker to the unwrapped
+            // form, otherwise an attacker bypasses the v4 checks
+            // by writing the same address as `[::ffff:...]`.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return ip_is_private(std::net::IpAddr::V4(v4));
+            }
+            v6.is_loopback() || v6.is_unspecified() || {
+                let s = v6.segments()[0];
+                // fc00::/7 ULA (fc00..fdff) or fe80::/10 link-local
+                (s & 0xfe00) == 0xfc00 || (s & 0xffc0) == 0xfe80
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::TargetSpec;
+    use sakimori_core::deps::Ecosystem;
+    use sakimori_core::installs::{ExecutionMode, InstallEvent};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct CountingClient {
+        calls: AtomicU32,
+    }
+    impl WebhookClient for CountingClient {
+        fn post(
+            &self,
+            _url: &str,
+            _headers: &[(String, String)],
+            _body: &[u8],
+        ) -> std::result::Result<u16, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(200)
+        }
+    }
+
+    async fn seed_finding_and_target(store: &Store, label: &str) -> i64 {
+        store
+            .insert(
+                InstallEvent::new(Ecosystem::Npm, "p", "1.0.0")
+                    .with_mode(ExecutionMode::Persistent)
+                    .into(),
+            )
+            .await
+            .unwrap();
+        let adv: crate::advisories::OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": format!("ADV-{label}"),
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "p"}, "versions": ["1.0.0"]}],
+        }))
+        .unwrap();
+        store.upsert_advisory(adv, None).await.unwrap();
+        store.scan_findings().await.unwrap();
+        store
+            .register_target(TargetSpec {
+                label: label.into(),
+                url: "https://t.example.com/".into(),
+                secret: "0123456789abcdef0123".into(),
+                min_severity: Severity::Low,
+                source_filter: None,
+            })
+            .await
+            .unwrap()
+    }
+
+    /// Variant that skips `scan_findings` so we can assert the
+    /// loop itself drives the scan phase.
+    async fn seed_install_and_advisory_only(store: &Store, label: &str) -> i64 {
+        store
+            .insert(
+                InstallEvent::new(Ecosystem::Npm, "p", "1.0.0")
+                    .with_mode(ExecutionMode::Persistent)
+                    .into(),
+            )
+            .await
+            .unwrap();
+        let adv: crate::advisories::OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": format!("ADV-{label}"),
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "p"}, "versions": ["1.0.0"]}],
+        }))
+        .unwrap();
+        store.upsert_advisory(adv, None).await.unwrap();
+        // Deliberately NOT calling scan_findings — the loop must.
+        store
+            .register_target(TargetSpec {
+                label: label.into(),
+                url: "https://t.example.com/".into(),
+                secret: "0123456789abcdef0123".into(),
+                min_severity: Severity::Low,
+                source_filter: None,
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn spawn_loop_runs_scan_then_dispatch() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        seed_install_and_advisory_only(&store, "ops").await;
+        // Pre-condition: no findings yet.
+        assert!(
+            store
+                .list_findings(Default::default())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let client = Arc::new(CountingClient {
+            calls: AtomicU32::new(0),
+        });
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let handle = spawn_loop(
+            store.clone(),
+            client.clone(),
+            lock.clone(),
+            std::time::Duration::from_millis(20),
+            100,
+            DEFAULT_ATTEMPT_CAP,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        handle.shutdown().await;
+        assert_eq!(
+            client.calls.load(Ordering::SeqCst),
+            1,
+            "loop must scan then dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_loop_delivers_pending_then_idles() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        seed_finding_and_target(&store, "ops").await;
+        let client = Arc::new(CountingClient {
+            calls: AtomicU32::new(0),
+        });
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let handle = spawn_loop(
+            store.clone(),
+            client.clone(),
+            lock.clone(),
+            std::time::Duration::from_millis(20),
+            100,
+            DEFAULT_ATTEMPT_CAP,
+        );
+        // Give the loop several ticks to fire. The pending pair
+        // should deliver on the first tick; subsequent ticks see
+        // an empty queue and do nothing.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        handle.shutdown().await;
+        let n = client.calls.load(Ordering::SeqCst);
+        assert_eq!(
+            n, 1,
+            "exactly one delivery expected; got {n} (loop should idle after the queue drains)"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_loop_shares_dispatch_lock_with_caller() {
+        // Hold the lock outside the loop; the loop must not be
+        // able to fire while it's held.
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        seed_finding_and_target(&store, "ops").await;
+        let client = Arc::new(CountingClient {
+            calls: AtomicU32::new(0),
+        });
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = lock.clone().lock_owned().await;
+        let handle = spawn_loop(
+            store.clone(),
+            client.clone(),
+            lock.clone(),
+            std::time::Duration::from_millis(20),
+            100,
+            DEFAULT_ATTEMPT_CAP,
+        );
+        // Several ticks elapse while we hold the lock — no deliveries.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(
+            client.calls.load(Ordering::SeqCst),
+            0,
+            "loop must wait for the dispatch_lock"
+        );
+        drop(held);
+        // Give the loop a moment to acquire and deliver.
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+        handle.shutdown().await;
+        assert_eq!(
+            client.calls.load(Ordering::SeqCst),
+            1,
+            "delivery should land after the external holder drops"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_promptly_while_external_holds_lock() {
+        // Regression: previously the loop awaited the dispatch
+        // lock outside the shutdown `select!`, so shutdown was
+        // pinned until whoever held the lock released it.
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let client = Arc::new(CountingClient {
+            calls: AtomicU32::new(0),
+        });
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let handle = spawn_loop(
+            store,
+            client,
+            lock.clone(),
+            std::time::Duration::from_millis(10),
+            100,
+            DEFAULT_ATTEMPT_CAP,
+        );
+        // Hold the lock so any tick that fires can't get past
+        // the lock acquisition.
+        let _held = lock.lock_owned().await;
+        // Let at least one tick fire and block on the lock.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let start = std::time::Instant::now();
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown should not be pinned by a held dispatch_lock");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(1),
+            "shutdown took {:?}",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_returns_promptly_even_with_long_interval() {
+        let store = Arc::new(Store::open_in_memory().unwrap());
+        let client = Arc::new(CountingClient {
+            calls: AtomicU32::new(0),
+        });
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        let handle = spawn_loop(
+            store,
+            client,
+            lock,
+            std::time::Duration::from_secs(60), // long enough that we'd notice
+            100,
+            DEFAULT_ATTEMPT_CAP,
+        );
+        let start = std::time::Instant::now();
+        // Wrap shutdown in a timeout to surface a regression
+        // loudly rather than hanging the test runner.
+        tokio::time::timeout(std::time::Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown should return well within the test timeout");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "shutdown took {:?}",
+            start.elapsed()
+        );
+    }
+
+    // Silence "unused import" when the tests above are the only
+    // consumers of these — keeps the test module compiling without
+    // hand-tracking every helper.
+    #[allow(dead_code)]
+    fn _ensure_mutex_used(_: Mutex<()>) {}
+
+    #[test]
+    fn signature_is_stable_and_keyed() {
+        let a = sign(b"secret-1234567890abc", b"hello");
+        let b = sign(b"secret-1234567890abc", b"hello");
+        let c = sign(b"different-1234567890", b"hello");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a.starts_with("sha256="));
+    }
+
+    #[test]
+    fn validate_rejects_obviously_bad_targets() {
+        let base = TargetSpec {
+            label: "ops".into(),
+            url: "https://ops.example.com/hook".into(),
+            secret: "0123456789abcdef".into(),
+            min_severity: Severity::High,
+            source_filter: None,
+        };
+        validate_target(&base, false).unwrap();
+        let bad = TargetSpec {
+            url: "ftp://nope/".into(),
+            ..base.clone()
+        };
+        assert!(matches!(
+            validate_target(&bad, false),
+            Err(TargetValidationError::UrlScheme)
+        ));
+        let short_secret = TargetSpec {
+            secret: "tiny".into(),
+            ..base.clone()
+        };
+        assert!(matches!(
+            validate_target(&short_secret, false),
+            Err(TargetValidationError::SecretTooShort)
+        ));
+    }
+
+    #[test]
+    fn private_hosts_blocked_unless_opted_in() {
+        let mk = |url: &str| TargetSpec {
+            label: "t".into(),
+            url: url.into(),
+            secret: "0123456789abcdef".into(),
+            min_severity: Severity::High,
+            source_filter: None,
+        };
+        for url in [
+            "http://127.0.0.1/hook",
+            "http://localhost:9000/hook",
+            "http://10.0.0.5/hook",
+            "http://192.168.1.1/hook",
+            "http://[::1]/hook",
+            "http://169.254.169.254/latest/meta-data",
+            "http://metadata.google.internal/",
+            "http://internal-ops.internal/x",
+        ] {
+            assert!(
+                matches!(
+                    validate_target(&mk(url), false),
+                    Err(TargetValidationError::UrlHostPrivate(_))
+                ),
+                "{url} should be blocked without allow_private_webhooks"
+            );
+            // Same URL accepted when operator opts in.
+            validate_target(&mk(url), true).expect(url);
+        }
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_does_not_bypass_private_check() {
+        for url in [
+            "http://[::ffff:127.0.0.1]/hook",
+            "http://[::ffff:10.0.0.1]/hook",
+            "http://[::ffff:169.254.169.254]/latest/meta-data",
+        ] {
+            let spec = TargetSpec {
+                label: "t".into(),
+                url: url.into(),
+                secret: "0123456789abcdef".into(),
+                min_severity: Severity::High,
+                source_filter: None,
+            };
+            assert!(
+                matches!(
+                    validate_target(&spec, false),
+                    Err(TargetValidationError::UrlHostPrivate(_))
+                ),
+                "{url} must be blocked: IPv4-mapped IPv6 unwraps to a private v4"
+            );
+        }
+    }
+
+    #[test]
+    fn ureq_client_refuses_dns_resolved_to_private() {
+        // localhost resolves to 127.0.0.1 on every supported
+        // platform; the client must refuse to POST even though
+        // `localhost` was never literally registered as a target
+        // URL string (this is the rebinding-style bypass).
+        let client = UreqClient::new(false);
+        let err = client
+            .post("http://localhost:1/hook", &[], b"{}")
+            .expect_err("must refuse");
+        assert!(err.contains("private") || err.contains("resolved address"));
+    }
+
+    #[test]
+    fn public_hosts_pass_validation() {
+        for url in [
+            "https://ops.example.com/hook",
+            // Public IPv6 literal (Cloudflare 1.1.1.1's v6 sibling).
+            // extract_host strips brackets; the validator only checks
+            // whether the resulting IP is private — `2606:4700::1111`
+            // is not, so this should pass.
+            "https://[2606:4700::1111]/hook",
+        ] {
+            let spec = TargetSpec {
+                label: "t".into(),
+                url: url.into(),
+                secret: "0123456789abcdef".into(),
+                min_severity: Severity::High,
+                source_filter: None,
+            };
+            validate_target(&spec, false).expect(url);
+        }
+    }
+}

--- a/crates/sakimori-hub/src/lib.rs
+++ b/crates/sakimori-hub/src/lib.rs
@@ -1,0 +1,77 @@
+//! sakimori-hub — optional self-hostable companion service.
+//!
+//! This crate is the foundation for the **team-wide install inventory**
+//! described in roadmap item #6 of CLAUDE.md. It accepts
+//! `InstallEvent`s posted by every `sakimori proxy` on a developer
+//! laptop or CI runner, stores them durably, and exposes a small read
+//! API so operators can answer:
+//!
+//! > "Who installed `<pkg>@<ver>`, and when, across CI and developer
+//! > laptops?"
+//!
+//! ## Authentication
+//!
+//! Three independent credentials are accepted by write endpoints
+//! (`/ingest`, `/advisories`, `/scan`, `/dispatch-targets`,
+//! `/dispatch/run`):
+//!
+//! 1. **Browser session cookie** — minted by the GitHub OAuth
+//!    Authorization Code Flow at `/auth/github/login` →
+//!    `/auth/github/callback`. HMAC-signed (`subtle::ConstantTimeEq`),
+//!    HttpOnly+Secure+SameSite=Lax. Cookie-authenticated writes
+//!    also pass an Origin/Referer CSRF check against
+//!    `external_base_url`.
+//! 2. **Personal API token** — minted via `POST /api/tokens`
+//!    while session-authenticated, returned as cleartext exactly
+//!    once. Carry as `Authorization: Bearer shp_<43chars>`.
+//!    Per-user, revocable, allowlist-gated on every request
+//!    (offboarding via `SAKIMORI_HUB_ALLOWED_GITHUB_LOGINS` takes
+//!    effect immediately).
+//! 3. **Legacy shared-secret bearer** — `--ingest-token` /
+//!    `SAKIMORI_HUB_INGEST_TOKEN`. Useful for CI bootstrapping
+//!    before any user has logged in to mint a personal token.
+//!    Cannot start with `shp_` (reserved for personal tokens).
+//!
+//! Read endpoints (`GET /installs` / `/findings` / `/advisories`
+//! / `/dispatch-targets` / `/`) are gated identically by default;
+//! `--public-reads` opts out (for deployments with an upstream
+//! auth proxy in front of reads). `/healthz` is always open.
+//!
+//! ## What it does **not** do yet
+//!
+//! - **Team / RBAC.** Every authenticated user currently has
+//!   full operator powers on a single shared dataset. The
+//!   team/`team_id`/invite slice (#11 in the slice plan) carves
+//!   the data tables by team and introduces owner/member roles.
+//! - **GitHub Actions OIDC exchange** (#9) — short-lived
+//!   per-Actions tokens via `id-token: write` JWT exchange.
+//! - **Device Authorization Flow** (#10) — `sakimori login` CLI
+//!   for the personal-laptop path so developers don't have to
+//!   paste tokens manually.
+//! - **R2 backup per team** (#12).
+//! - **Stripe billing** (#13, design only).
+//!
+//! ## Schema
+//!
+//! Stored shape mirrors [`sakimori_core::installs::InstallEvent`] plus
+//! a hub-side derived [`Source`] classifier (CI runner vs developer
+//! laptop) so the read API can split CI and desktop activity without
+//! re-deriving from User-Agent at every query.
+
+pub mod advisories;
+pub mod auth;
+pub mod classify;
+pub mod dispatch;
+pub mod server;
+pub mod store;
+
+pub use advisories::{OsvAdvisory, Severity};
+pub use classify::Source;
+pub use dispatch::{DispatchReport, DispatcherHandle, UreqClient, WebhookClient, spawn_loop};
+pub use store::{
+    ACTIONS_TOKEN_PREFIX, API_TOKEN_PREFIX, ActionsPrincipal, ActionsTokenSpec, DeviceCodeStatus,
+    DevicePollOutcome, MintedActionsToken, MintedApiToken, MintedDeviceCode, ScanReport, Store,
+    StoredActionsToken, StoredAdvisory, StoredApiToken, StoredDeviceCode, StoredEvent,
+    StoredFinding, StoredTarget, StoredUser, TargetSpec, UpsertUserSpec, hash_actions_token,
+    hash_api_token,
+};

--- a/crates/sakimori-hub/src/main.rs
+++ b/crates/sakimori-hub/src/main.rs
@@ -1,0 +1,486 @@
+//! `sakimori-hub` — bind a TCP listener and serve the inventory API.
+//!
+//! See [`sakimori_hub`] for the protocol shape. Defaults are
+//! deliberately conservative: bind to localhost (`127.0.0.1:8787`)
+//! and store the SQLite file in the user's home, so a fresh
+//! `sakimori-hub` run on a workstation never accidentally exposes
+//! data on a LAN interface.
+//!
+//! ## Security
+//!
+//! Three independent credentials are accepted on write endpoints:
+//!
+//! 1. **GitHub OAuth session cookie** — minted by
+//!    `/auth/github/login` → `/auth/github/callback` when
+//!    `--github-client-id` + `--github-client-secret` +
+//!    `--external-base-url` + `--session-secret` +
+//!    `--allowed-github-logins` are all set.
+//! 2. **Personal API token** — minted by a logged-in user via
+//!    `POST /api/tokens`, sent as `Authorization: Bearer shp_…`.
+//!    Allowlist-gated on every request so offboarding is
+//!    immediate.
+//! 3. **Actions OIDC token** — workflows POST their `id-token:
+//!    write` JWT to `/auth/actions/exchange` and receive a
+//!    short-lived `sha_…` bearer token. Enabled by
+//!    `--allowed-actions-repositories` + an OIDC audience
+//!    (defaults to `--external-base-url`).
+//! 4. **Legacy shared bearer** (`--ingest-token` /
+//!    `SAKIMORI_HUB_INGEST_TOKEN`) — CI bootstrap before any
+//!    user logs in to mint a personal token.
+//!
+//! Read endpoints default to ALSO requiring the bearer/session
+//! (secure-by-default for a public Cloudflare Containers
+//! deploy); `--public-reads` opts out when an upstream auth
+//! proxy is in front. `/healthz` is always open for liveness
+//! probes.
+//!
+//! To make accidental exposure hard, binding to anything other
+//! than the loopback interface is refused unless `--allow-remote`
+//! is set. `--allow-public` is additionally required for the
+//! unrestricted `0.0.0.0` / `::` shapes. Non-loopback binds
+//! also require AT LEAST ONE of the four auth paths above —
+//! otherwise the hub would put a wide-open write API on the
+//! network.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use sakimori_hub::server::{AppState, ServerConfig, router};
+use sakimori_hub::store::Store;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "sakimori-hub",
+    about = "Self-hostable inventory + advisory-JOIN companion for sakimori-proxy",
+    version
+)]
+struct Cli {
+    /// Address to bind. Defaults to loopback — change explicitly to
+    /// expose the service on a LAN/VPN interface, and pair with
+    /// `--allow-remote` to acknowledge there is no built-in authn.
+    #[arg(long, default_value = "127.0.0.1:8787", env = "SAKIMORI_HUB_BIND")]
+    bind: SocketAddr,
+    /// Where to persist the SQLite inventory. Use `:memory:` for a
+    /// throwaway test instance.
+    #[arg(long, env = "SAKIMORI_HUB_DB")]
+    db: Option<PathBuf>,
+    /// Maximum allowed body size for any request, in bytes.
+    /// Defaults to 1 MiB.
+    #[arg(long, default_value_t = 1024 * 1024)]
+    body_limit_bytes: usize,
+    /// Maximum events accepted in a single `/ingest` batch.
+    #[arg(long, default_value_t = 1000)]
+    max_batch: usize,
+    /// Acknowledge that binding to a non-loopback interface exposes
+    /// the unauthenticated API to the LAN/VPN. Without this flag,
+    /// non-loopback `--bind` values are refused.
+    #[arg(long)]
+    allow_remote: bool,
+    /// Acknowledge that binding to the unrestricted `0.0.0.0` /
+    /// `::` exposes the API to every interface. Requires
+    /// `--allow-remote`.
+    #[arg(long)]
+    allow_public: bool,
+    /// Allow registering webhook targets whose URL host is a
+    /// loopback / private / link-local address. Off by default to
+    /// block the common SSRF pivot. Flip on for localhost test
+    /// receivers.
+    #[arg(long)]
+    allow_private_webhooks: bool,
+    /// Shared bearer token required on every endpoint except
+    /// `/healthz`. Clients send it as
+    /// `Authorization: Bearer <token>`. Mandatory when binding
+    /// non-loopback in production — without it the hub would
+    /// have no authentication between the bind address and the
+    /// public internet.
+    ///
+    /// Writes (`POST /ingest`, `POST /advisories`, `POST /scan`,
+    /// `POST /dispatch-targets`, `DELETE /dispatch-targets/:id`,
+    /// `POST /dispatch/run`) are ALWAYS gated when a token is
+    /// set. Reads (`GET /installs` / `/findings` / `/advisories`
+    /// / `/dispatch-targets` / `/`) are gated by default too;
+    /// opt out with `--public-reads` when an upstream auth proxy
+    /// covers them.
+    #[arg(long, env = "SAKIMORI_HUB_INGEST_TOKEN")]
+    ingest_token: Option<String>,
+    /// Acknowledge that an *upstream* auth proxy (Cloudflare
+    /// Access, oauth2-proxy, mTLS, etc.) is handling
+    /// authentication for the read endpoints, and leave them open
+    /// at the hub layer. Without this flag, reads also require
+    /// the bearer token when one is configured.
+    #[arg(long, env = "SAKIMORI_HUB_PUBLIC_READS")]
+    public_reads: bool,
+    /// GitHub OAuth App client_id. Required for browser login;
+    /// pairs with `--github-client-secret`. Enables
+    /// `/auth/github/login` and `/auth/github/callback`.
+    #[arg(long, env = "SAKIMORI_HUB_GITHUB_CLIENT_ID")]
+    github_client_id: Option<String>,
+    /// GitHub OAuth App client_secret (env-only — never accept
+    /// secrets on the command line where they'd land in shell
+    /// history and `ps aux`).
+    #[arg(long, env = "SAKIMORI_HUB_GITHUB_CLIENT_SECRET", hide = true)]
+    github_client_secret: Option<String>,
+    /// Public URL the hub is reachable at. Used to build the
+    /// OAuth `redirect_uri` (must match the value registered on
+    /// the GitHub OAuth App). e.g. `https://hub.example.com`.
+    #[arg(long, env = "SAKIMORI_HUB_EXTERNAL_BASE_URL")]
+    external_base_url: Option<String>,
+    /// Server secret (32+ bytes) used to HMAC-sign session
+    /// cookies. Generate with `openssl rand -base64 48`. Rotate
+    /// to invalidate every live session instantly.
+    #[arg(long, env = "SAKIMORI_HUB_SESSION_SECRET", hide = true)]
+    session_secret: Option<String>,
+    /// Drop the `Secure` flag from `Set-Cookie`. Useful for
+    /// local loopback testing over plain HTTP; **NEVER** flip on
+    /// in production — a man-in-the-middle on an http endpoint
+    /// can steal the session cookie.
+    #[arg(long)]
+    insecure_cookies: bool,
+    /// Comma-separated GitHub logins permitted to sign in via
+    /// OAuth. Required when `--github-client-id` is set —
+    /// otherwise *any* GitHub account could log in and operate
+    /// the hub. Case-insensitive. Example:
+    /// `--allowed-github-logins ada,linus`.
+    #[arg(
+        long,
+        env = "SAKIMORI_HUB_ALLOWED_GITHUB_LOGINS",
+        value_delimiter = ','
+    )]
+    allowed_github_logins: Vec<String>,
+    /// Comma-separated repository patterns permitted to call
+    /// `POST /auth/actions/exchange`. Patterns are `org/repo`
+    /// (exact) or `org/*` (org-wide). Enables Actions OIDC
+    /// exchange — leave empty to disable the endpoint.
+    #[arg(
+        long,
+        env = "SAKIMORI_HUB_ALLOWED_ACTIONS_REPOSITORIES",
+        value_delimiter = ','
+    )]
+    allowed_actions_repositories: Vec<String>,
+    /// Required `aud` claim on Actions OIDC JWTs. Workflows
+    /// must request the token with `?audience=<value>` matching
+    /// this. Defaults to `--external-base-url` when unset.
+    #[arg(long, env = "SAKIMORI_HUB_ACTIONS_OIDC_AUDIENCE")]
+    actions_oidc_audience: Option<String>,
+    /// Max lifetime of `sha_` tokens minted by the exchange
+    /// endpoint. Capped against the inbound JWT's `exp`.
+    #[arg(long, default_value_t = 15 * 60)]
+    actions_token_ttl_secs: i64,
+    /// Background dispatcher cadence in seconds. The hub runs a
+    /// dispatch pass every `N` seconds (sharing the same mutex
+    /// as `POST /dispatch/run`, so the two paths can't race).
+    /// Set to `0` to disable the loop and require
+    /// operator/cron-triggered runs.
+    #[arg(long, default_value_t = 60)]
+    dispatch_interval_secs: u64,
+    /// Per-pass batch size for the background dispatcher.
+    #[arg(long, default_value_t = 100)]
+    dispatch_batch: u32,
+    /// Attempt cap for the background dispatcher. A `(finding,
+    /// target)` pair stops being retried after this many attempts
+    /// to keep a permanently-broken target from filling the
+    /// attempts table.
+    #[arg(long, default_value_t = sakimori_hub::dispatch::DEFAULT_ATTEMPT_CAP)]
+    dispatch_attempt_cap: i64,
+}
+
+fn default_db_path() -> PathBuf {
+    match std::env::var_os("HOME") {
+        Some(h) => PathBuf::from(h).join(".sakimori").join("hub.sqlite"),
+        None => PathBuf::from("hub.sqlite"),
+    }
+}
+
+fn check_bind_safety(bind: &SocketAddr, allow_remote: bool, allow_public: bool) -> Result<()> {
+    let ip = bind.ip();
+    if is_unspecified(&ip) {
+        if !(allow_remote && allow_public) {
+            anyhow::bail!(
+                "refusing to bind to {ip} without both --allow-remote and --allow-public; \
+                 the bearer-token gate alone is not enough — the operator must \
+                 explicitly opt into exposing every interface"
+            );
+        }
+        return Ok(());
+    }
+    if !is_loopback(&ip) && !allow_remote {
+        anyhow::bail!(
+            "refusing to bind to non-loopback address {ip} without --allow-remote; \
+             non-loopback also requires --ingest-token (the bearer-token gate is \
+             the only auth between this address and the public internet)"
+        );
+    }
+    Ok(())
+}
+
+fn is_loopback(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_loopback(),
+        IpAddr::V6(v6) => v6.is_loopback(),
+    }
+}
+
+fn is_unspecified(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4 == &Ipv4Addr::UNSPECIFIED,
+        IpAddr::V6(v6) => v6 == &Ipv6Addr::UNSPECIFIED,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let cli = Cli::parse();
+    check_bind_safety(&cli.bind, cli.allow_remote, cli.allow_public)?;
+    let db = cli.db.unwrap_or_else(default_db_path);
+    let store = if db.to_string_lossy() == ":memory:" {
+        Store::open_in_memory()
+    } else {
+        Store::open(&db)
+    }
+    .with_context(|| format!("opening store at {}", db.display()))?;
+    let non_loopback = !cli.bind.ip().is_loopback();
+    if let Some(t) = &cli.ingest_token {
+        if t.len() < 16 {
+            anyhow::bail!("--ingest-token must be at least 16 chars");
+        }
+        // `shp_` is reserved for personal API tokens. A legacy
+        // ingest token using that prefix would be misrouted to
+        // the personal-token DB lookup, fail there, and never
+        // get a chance to match the constant-time compare. Reject
+        // at config time so the failure is loud, not silent.
+        for reserved in [
+            sakimori_hub::API_TOKEN_PREFIX,
+            sakimori_hub::ACTIONS_TOKEN_PREFIX,
+        ] {
+            if t.starts_with(reserved) {
+                anyhow::bail!(
+                    "--ingest-token must not start with `{}` (that prefix is reserved \
+                     for sakimori-issued tokens — personal via POST /api/tokens or \
+                     Actions via POST /auth/actions/exchange)",
+                    reserved,
+                );
+            }
+        }
+    }
+    // Validate the OAuth flag set as a group: either all three
+    // are present (login enabled) or none are (login disabled).
+    // Partial config is the worst kind — looks right, silently
+    // 404s on /auth/github/login.
+    let oauth_fields = [
+        cli.github_client_id.is_some(),
+        cli.github_client_secret.is_some(),
+        cli.external_base_url.is_some(),
+    ];
+    let oauth_enabled = match oauth_fields.iter().filter(|b| **b).count() {
+        0 => false,
+        3 => {
+            if cli.session_secret.is_none() {
+                anyhow::bail!(
+                    "GitHub OAuth flags set but --session-secret / \
+                     SAKIMORI_HUB_SESSION_SECRET is missing; sessions can't be signed"
+                );
+            }
+            if cli.allowed_github_logins.is_empty() {
+                anyhow::bail!(
+                    "GitHub OAuth enabled but --allowed-github-logins is empty; \
+                     anyone with a GitHub account would be able to sign in. \
+                     Set SAKIMORI_HUB_ALLOWED_GITHUB_LOGINS=ada,linus,..."
+                );
+            }
+            true
+        }
+        _ => anyhow::bail!(
+            "GitHub OAuth requires all of --github-client-id, \
+             --github-client-secret, --external-base-url to be set together"
+        ),
+    };
+    let session_secret = cli.session_secret.as_ref().map(|s| s.as_bytes().to_vec());
+    if let Some(s) = &session_secret
+        && s.len() < 32
+    {
+        anyhow::bail!("--session-secret must be at least 32 bytes");
+    }
+    // Auth-layer guard: a non-loopback bind must have SOMETHING
+    // gating writes — either the legacy shared-secret bearer
+    // token, or the full OAuth/session/allowlist bundle. Without
+    // either, every write endpoint would be wide open.
+    let actions_enabled = !cli.allowed_actions_repositories.is_empty();
+    if non_loopback && cli.ingest_token.is_none() && !oauth_enabled && !actions_enabled {
+        anyhow::bail!(
+            "refusing to bind {} without an auth path: pass any of: \
+             --ingest-token (shared secret), \
+             the full --github-client-id / --github-client-secret / \
+             --external-base-url / --session-secret / --allowed-github-logins bundle (browser OAuth), \
+             or --allowed-actions-repositories with an audience (Actions OIDC).",
+            cli.bind
+        );
+    }
+    // Validate Actions OIDC patterns up front so a typo doesn't
+    // silently let nothing through.
+    for pat in &cli.allowed_actions_repositories {
+        if let Err(e) = sakimori_hub::auth::validate_repository_pattern(pat) {
+            anyhow::bail!("--allowed-actions-repositories: {e}");
+        }
+    }
+    let actions_oidc_audience = cli
+        .actions_oidc_audience
+        .clone()
+        .or_else(|| cli.external_base_url.clone());
+    if !cli.allowed_actions_repositories.is_empty() && actions_oidc_audience.is_none() {
+        anyhow::bail!(
+            "--allowed-actions-repositories set but neither \
+             --actions-oidc-audience nor --external-base-url is configured; \
+             can't validate the JWT `aud` claim"
+        );
+    }
+    if cli.actions_token_ttl_secs < 1 {
+        anyhow::bail!("--actions-token-ttl-secs must be >= 1");
+    }
+    let config = ServerConfig {
+        body_limit_bytes: cli.body_limit_bytes,
+        max_batch: cli.max_batch,
+        allow_private_webhooks: cli.allow_private_webhooks,
+        ingest_token: cli.ingest_token.clone(),
+        public_reads: cli.public_reads,
+        session_secret,
+        cookie_secure: !cli.insecure_cookies,
+        external_base_url: cli.external_base_url.clone(),
+        github_client_id: cli.github_client_id.clone(),
+        allowed_github_logins: cli
+            .allowed_github_logins
+            .iter()
+            .map(|s| s.to_ascii_lowercase())
+            .collect(),
+        allowed_actions_repositories: cli.allowed_actions_repositories.clone(),
+        actions_oidc_audience: actions_oidc_audience.clone(),
+        actions_token_ttl_secs: cli.actions_token_ttl_secs,
+        session_ttl_secs: 60 * 60 * 24 * 7,
+    };
+    let mut state = AppState::new(Arc::new(store), config);
+    if oauth_enabled {
+        state.oauth = Some(Arc::new(sakimori_hub::auth::GitHubOAuthClient::new(
+            cli.github_client_id.clone().unwrap(),
+            cli.github_client_secret.clone().unwrap(),
+        )));
+        log::info!(
+            "GitHub OAuth login enabled (client_id={}, redirect={})",
+            cli.github_client_id.as_deref().unwrap_or(""),
+            cli.external_base_url.as_deref().unwrap_or(""),
+        );
+    } else {
+        log::info!("GitHub OAuth login disabled (--github-client-id not set)");
+    }
+    if !cli.allowed_actions_repositories.is_empty() {
+        state.actions_verifier = Some(Arc::new(sakimori_hub::auth::DefaultActionsVerifier::new(
+            actions_oidc_audience.clone().unwrap(),
+        )));
+        log::info!(
+            "Actions OIDC exchange enabled (audience={}, repositories={})",
+            actions_oidc_audience.as_deref().unwrap_or(""),
+            cli.allowed_actions_repositories.join(","),
+        );
+    } else {
+        log::info!("Actions OIDC exchange disabled (--allowed-actions-repositories empty)");
+    }
+    let dispatcher = if cli.dispatch_interval_secs > 0 {
+        // Clamp footguns: a batch of 0 silently does nothing
+        // every tick; a negative attempt cap classifies every
+        // pending pair as over-cap and never dispatches. Surface
+        // both as errors so a typo in the CLI is loud, not silent.
+        if cli.dispatch_batch == 0 {
+            anyhow::bail!("--dispatch-batch must be >= 1");
+        }
+        if cli.dispatch_attempt_cap < 1 {
+            anyhow::bail!("--dispatch-attempt-cap must be >= 1");
+        }
+        log::info!(
+            "background dispatcher every {}s (batch={}, attempt_cap={})",
+            cli.dispatch_interval_secs,
+            cli.dispatch_batch,
+            cli.dispatch_attempt_cap,
+        );
+        Some(sakimori_hub::dispatch::spawn_loop(
+            state.store.clone(),
+            state.webhook.clone(),
+            state.dispatch_lock.clone(),
+            std::time::Duration::from_secs(cli.dispatch_interval_secs),
+            cli.dispatch_batch,
+            cli.dispatch_attempt_cap,
+        ))
+    } else {
+        log::info!("background dispatcher disabled (--dispatch-interval-secs=0)");
+        None
+    };
+    let app = router(state);
+    log::info!(
+        "sakimori-hub listening on http://{} (db={})",
+        cli.bind,
+        db.display()
+    );
+    let listener = tokio::net::TcpListener::bind(cli.bind)
+        .await
+        .with_context(|| format!("binding {}", cli.bind))?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("server error")?;
+    if let Some(d) = dispatcher {
+        d.shutdown().await;
+    }
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let term = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut s) = signal(SignalKind::terminate()) {
+            s.recv().await;
+        }
+    };
+    #[cfg(not(unix))]
+    let term = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = term => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sa(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn loopback_bind_is_always_ok() {
+        check_bind_safety(&sa("127.0.0.1:8787"), false, false).unwrap();
+        check_bind_safety(&sa("[::1]:8787"), false, false).unwrap();
+    }
+
+    #[test]
+    fn non_loopback_requires_allow_remote() {
+        let r = check_bind_safety(&sa("10.0.0.5:8787"), false, false);
+        assert!(r.is_err(), "should require --allow-remote");
+        check_bind_safety(&sa("10.0.0.5:8787"), true, false).unwrap();
+    }
+
+    #[test]
+    fn unspecified_requires_both_flags() {
+        assert!(check_bind_safety(&sa("0.0.0.0:8787"), false, false).is_err());
+        assert!(check_bind_safety(&sa("0.0.0.0:8787"), true, false).is_err());
+        assert!(check_bind_safety(&sa("0.0.0.0:8787"), false, true).is_err());
+        check_bind_safety(&sa("0.0.0.0:8787"), true, true).unwrap();
+        check_bind_safety(&sa("[::]:8787"), true, true).unwrap();
+    }
+}

--- a/crates/sakimori-hub/src/server.rs
+++ b/crates/sakimori-hub/src/server.rs
@@ -1,0 +1,3934 @@
+//! HTTP surface — the actual ingest + read API.
+//!
+//! Endpoints:
+//!
+//! - `POST /ingest` — accepts either a single ingest record JSON
+//!   object or an array of them. Each record is an
+//!   [`sakimori_core::installs::InstallEvent`] plus an optional
+//!   explicit `source` override the proxy can set when it knows its
+//!   runtime context with more certainty than the hub's heuristics
+//!   could infer. The whole batch commits atomically inside one
+//!   SQLite transaction.
+//! - `GET /installs` — JSON list, filtered by `?ecosystem=&name=&
+//!   version=&source=&since=&limit=`.
+//! - `GET /healthz` — liveness probe; returns `"ok"` and an integer
+//!   `count` of stored events so a simple curl confirms the DB works.
+//! - `GET /` — minimal server-rendered HTML inventory view: the
+//!   single-page "what's in our supply chain?" answer described in
+//!   roadmap item #6.
+//!
+//! Request body size is capped (default 1 MiB, overridable via
+//! [`ServerConfig::body_limit_bytes`]) and ingest batches are capped
+//! (default 1000 records, overridable via [`ServerConfig::max_batch`])
+//! to keep a single malicious / runaway client from exhausting
+//! memory.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::{DefaultBodyLimit, Query, State};
+use axum::http::{self, StatusCode, header};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use sakimori_core::installs::InstallEvent;
+
+use crate::Source;
+use crate::advisories::{OsvAdvisory, Severity};
+use crate::dispatch::{
+    DEFAULT_ATTEMPT_CAP, DispatchReport, UreqClient, WebhookClient, run_once, validate_target,
+};
+use crate::store::{
+    DeviceCodeStatus, DevicePollOutcome, FindingFilter, IngestRecord, ListFilter, MATCHING_MODE,
+    ScanReport, Store, StoredAdvisory, StoredApiToken, StoredEvent, StoredFinding, StoredTarget,
+    StoredUser, TargetSpec, UpsertUserSpec, validate_advisory,
+};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub store: Arc<Store>,
+    pub config: ServerConfig,
+    /// The webhook client used by `/dispatch/run`. Pluggable so
+    /// tests can swap in a stub; default is [`UreqClient`].
+    pub webhook: Arc<dyn WebhookClient>,
+    /// Process-wide mutex serializing `/dispatch/run` calls so
+    /// two concurrent requests can't both claim the same
+    /// `(finding, target)` and double-fire. See
+    /// `dispatch::run_once` doc-comment for the contract.
+    pub dispatch_lock: Arc<tokio::sync::Mutex<()>>,
+    /// GitHub OAuth exchange backend. `None` disables browser
+    /// login (and the `/auth/github/*` routes 404). Production
+    /// uses [`crate::auth::GitHubOAuthClient`]; tests inject a
+    /// stub that returns canned `GitHubUser` values.
+    pub oauth: Option<Arc<dyn crate::auth::OAuthExchange>>,
+    /// GitHub Actions OIDC verifier. `None` disables the
+    /// exchange endpoint. Production uses
+    /// [`crate::auth::actions::DefaultVerifier`]; tests inject
+    /// a stub.
+    pub actions_verifier: Option<Arc<dyn crate::auth::ActionsOidcVerifier>>,
+}
+
+impl AppState {
+    pub fn new(store: Arc<Store>, config: ServerConfig) -> Self {
+        let allow_private = config.allow_private_webhooks;
+        Self {
+            store,
+            config,
+            webhook: Arc::new(UreqClient::new(allow_private)),
+            dispatch_lock: Arc::new(tokio::sync::Mutex::new(())),
+            oauth: None,
+            actions_verifier: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    /// Maximum allowed JSON body size for any endpoint, in bytes.
+    /// Axum returns 413 on overflow.
+    pub body_limit_bytes: usize,
+    /// Maximum events accepted in a single `/ingest` batch.
+    /// Excess returns 400 with a clear message.
+    pub max_batch: usize,
+    /// Allow `POST /dispatch-targets` to accept URLs whose host
+    /// resolves to a private / loopback / link-local address.
+    /// Off by default — blocks the most common SSRF pivot
+    /// (`http://169.254.169.254/...`, `http://10.0.0.5/...`).
+    /// Operators running a localhost receiver in tests can flip
+    /// this on explicitly.
+    pub allow_private_webhooks: bool,
+    /// Shared secret required on protected endpoints when set.
+    /// Clients prove possession with
+    /// `Authorization: Bearer <token>`. `None` disables the
+    /// check entirely — fine for loopback dev, but mandatory
+    /// once the hub is exposed on a non-loopback bind.
+    pub ingest_token: Option<String>,
+    /// Leave the **read** endpoints (`GET /`, `/installs`,
+    /// `/findings`, `/advisories`, `/dispatch-targets`) outside
+    /// the bearer-token gate so an upstream auth proxy
+    /// (Cloudflare Access, oauth2-proxy, etc.) can authenticate
+    /// browsers separately from API clients.
+    ///
+    /// **Default `false`** — secure by default: when
+    /// `ingest_token` is set, every endpoint except `/healthz`
+    /// requires the bearer token, so a default `wrangler deploy`
+    /// to Cloudflare Containers does NOT leak inventory.
+    /// Operators who explicitly want to layer Access in front of
+    /// reads opt in with `--public-reads`.
+    pub public_reads: bool,
+    /// Server-side HMAC key for session cookies (32+ random
+    /// bytes). When `None`, browser-login endpoints reject every
+    /// request with 500 — the bin sets one before serving.
+    pub session_secret: Option<Vec<u8>>,
+    /// `Secure;` flag on `Set-Cookie`. `true` for production
+    /// (https), `false` only for local loopback testing.
+    pub cookie_secure: bool,
+    /// External base URL the hub is served at, used to build the
+    /// `redirect_uri` for the GitHub OAuth callback. e.g.
+    /// `https://hub.example.com`. `None` disables browser login.
+    pub external_base_url: Option<String>,
+    /// GitHub OAuth App client_id. Required for browser login.
+    /// Paired with the OAuth client on `AppState.oauth` which
+    /// owns the matching client_secret (kept off `ServerConfig`
+    /// so secrets don't accidentally land in debug-printed
+    /// config dumps).
+    pub github_client_id: Option<String>,
+    /// Lower-cased GitHub login allowlist. An empty Vec means
+    /// "nobody allowed in" — when OAuth is enabled, `main.rs`
+    /// hard-bails if the operator didn't set this, so a public
+    /// deploy can't accidentally accept arbitrary GitHub accounts
+    /// as operators. (Slice-7 design: until the team/RBAC slice
+    /// lands, every authenticated user gets full operator
+    /// powers; the allowlist is the only thing standing between a
+    /// public OAuth App and an attacker registering a free
+    /// GitHub account.)
+    pub allowed_github_logins: Vec<String>,
+    /// Repository allowlist for the Actions OIDC exchange.
+    /// Patterns are either `org/repo` (exact) or `org/*`
+    /// (org-wide). Empty Vec disables `/auth/actions/exchange`
+    /// entirely (returns 404) rather than accepting anything —
+    /// same secure-by-default posture as `allowed_github_logins`.
+    pub allowed_actions_repositories: Vec<String>,
+    /// Required `aud` claim on incoming GitHub Actions OIDC
+    /// JWTs. Workflows pass this via `audience=<value>` when
+    /// requesting the token; operators typically use the hub's
+    /// external URL. Required when Actions OIDC is enabled.
+    pub actions_oidc_audience: Option<String>,
+    /// Max lifetime of the minted `sha_` token from
+    /// `/auth/actions/exchange`. Capped against the inbound
+    /// JWT's own `exp` — whichever is sooner wins. Defaults
+    /// to 15 minutes.
+    pub actions_token_ttl_secs: i64,
+    /// Session lifetime in seconds. Defaults to 7 days.
+    pub session_ttl_secs: i64,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            body_limit_bytes: 1024 * 1024,
+            max_batch: 1000,
+            allow_private_webhooks: false,
+            ingest_token: None,
+            public_reads: false,
+            session_secret: None,
+            cookie_secure: true,
+            external_base_url: None,
+            github_client_id: None,
+            allowed_github_logins: Vec::new(),
+            allowed_actions_repositories: Vec::new(),
+            actions_oidc_audience: None,
+            actions_token_ttl_secs: 15 * 60,    // 15min
+            session_ttl_secs: 60 * 60 * 24 * 7, // 7d
+        }
+    }
+}
+
+pub fn router(state: AppState) -> Router {
+    let limit = state.config.body_limit_bytes;
+    // Writes are always behind the bearer-token gate (when a
+    // token is configured).
+    let writes = Router::new()
+        .route("/ingest", post(ingest))
+        .route("/advisories", post(advisories_import))
+        .route("/scan", post(scan))
+        .route("/dispatch-targets", post(targets_create))
+        .route(
+            "/dispatch-targets/{id}",
+            axum::routing::delete(targets_delete),
+        )
+        .route("/dispatch/run", post(dispatch_run));
+    // Reads default to gated too (secure-by-default for a public
+    // Containers deploy). Operators who put an auth proxy in
+    // front of reads opt into the open behaviour with
+    // `--public-reads`, which moves these routes out of the
+    // bearer-token layer.
+    let reads = Router::new()
+        .route("/installs", get(list))
+        .route("/advisories", get(advisories_list))
+        .route("/findings", get(findings_list))
+        .route("/dispatch-targets", get(targets_list))
+        .route("/", get(index_html));
+    let (protected, public_extras) = if state.config.public_reads {
+        (writes, reads)
+    } else {
+        (writes.merge(reads), Router::new())
+    };
+    let protected = protected.layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        require_bearer_token,
+    ));
+    // `/healthz` is always open — liveness/readiness probes can't
+    // carry a bearer token and would otherwise force operators
+    // into ugly cf-access shenanigans.
+    // Browser auth endpoints. `/auth/github/login` + `callback`
+    // run the OAuth dance; `/auth/logout` clears the session;
+    // `/auth/me` returns the logged-in user (handy for the
+    // browser to discover whether to show a "Log in" link).
+    // None of these are gated by the bearer-token middleware —
+    // the login endpoints can't be (chicken-and-egg) and
+    // `/auth/me` is intentionally non-sensitive (it returns 401
+    // when there's no session).
+    let auth = Router::new()
+        .route("/auth/github/login", get(auth_github_login))
+        .route("/auth/github/callback", get(auth_github_callback))
+        .route("/auth/logout", post(auth_logout))
+        .route("/auth/me", get(auth_me))
+        .route("/auth/actions/exchange", post(auth_actions_exchange))
+        .route("/auth/device/code", post(auth_device_code))
+        .route("/auth/device/token", post(auth_device_token));
+    // Personal API tokens — list/mint/revoke. Always gated by a
+    // valid session cookie (not the legacy shared-secret bearer:
+    // tokens are per-user, so a session that can't be tied to
+    // one user has no business minting them). The
+    // `require_session_user` middleware is *separate* from
+    // `require_bearer_token` because it always demands a session
+    // and never accepts the legacy bearer.
+    // Nest under `/api` so the token routes' `{id}` placeholder
+    // doesn't collide with `/dispatch-targets/{id}` at axum's
+    // matchit layer when merging routers with overlapping
+    // parameter shapes.
+    // POST-based revoke instead of DELETE on a parameterized
+    // path. axum 0.7's router has a quirk where merging a router
+    // that registers `DELETE /a/{id}` alongside another router
+    // that also has `{id}` placeholders (e.g. our existing
+    // `/dispatch-targets/{id}`) silently swallows the second one
+    // — both routes return 404 at runtime. POST/body keeps the
+    // matchit tree single-segment-deep here and side-steps the
+    // bug entirely.
+    let tokens = Router::new()
+        .route("/api/tokens", post(tokens_create).get(tokens_list))
+        .route("/api/tokens/revoke", post(tokens_revoke))
+        // Device-flow approve UI + action endpoint share the
+        // `require_session_user` layer: only a browser-
+        // authenticated operator can confirm a device login
+        // request, and CSRF is checked via the same Origin/
+        // Referer rule as the rest of the session-cookie surface.
+        .route("/auth/device", get(auth_device_page))
+        .route("/auth/device/approve", post(auth_device_approve))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_session_user,
+        ));
+    let public = Router::new()
+        .route("/healthz", get(healthz))
+        .merge(public_extras)
+        .merge(auth);
+    public
+        .merge(tokens)
+        .merge(protected)
+        .layer(DefaultBodyLimit::max(limit))
+        .with_state(state)
+}
+
+/// Middleware that gates write endpoints with **either** a valid
+/// `Authorization: Bearer <token>` matching
+/// `ServerConfig.ingest_token` **or** a valid signed session
+/// cookie pointing at a live `users` row. Browser users get in
+/// via the cookie (plus an Origin/Referer CSRF check); CI /
+/// `sakimori-proxy` keeps using bearer.
+///
+/// The middleware is a no-op only when **both** `ingest_token`
+/// and `session_secret` are unset — the loopback-default
+/// `main.rs` posture. With only one of them set, the other
+/// path is explicitly rejected (e.g. an OAuth-only deploy
+/// returns 401 on `Authorization: Bearer ...`, never 200).
+async fn require_bearer_token(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<Response, ApiError> {
+    let bearer_configured = state.config.ingest_token.is_some();
+    let session_configured = state.config.session_secret.is_some();
+    // Use the config alone (not the live verifier) as the
+    // source of truth for "Actions auth is configured". A caller
+    // that sets `allowed_actions_repositories` but forgets to
+    // attach `actions_verifier` would otherwise turn the middleware
+    // into a no-op and silently open every write — instead, writes
+    // stay locked (no sha_ token could have been minted, so they
+    // can't pass) and the `/auth/actions/exchange` endpoint 404s
+    // for being unwired.
+    let actions_configured = !state.config.allowed_actions_repositories.is_empty();
+    if !bearer_configured && !session_configured && !actions_configured {
+        return Ok(next.run(req).await);
+    }
+    // Cookie path first. A valid session is sufficient on its own
+    // (that's how a browser user POSTs `/dispatch/run` from the
+    // inventory page without ever holding the shared secret), but
+    // cookie-authenticated requests ALSO need a CSRF origin check:
+    // SameSite=Lax does NOT prevent top-level form POSTs from
+    // cross-site pages. Bearer-authenticated requests skip the
+    // check — an attacker can't set custom headers from cross-site
+    // browser contexts.
+    if let Some(secret) = state.config.session_secret.as_deref()
+        && cookie_session_user(&state, secret, req.headers())
+            .await?
+            .is_some()
+    {
+        if !cookie_origin_ok(&state, req.headers()) {
+            return Err(ApiError::unauthorized(
+                "cookie-authenticated request without matching Origin/Referer",
+            ));
+        }
+        return Ok(next.run(req).await);
+    }
+    let header = req
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim());
+    let Some(presented) = header else {
+        return Err(ApiError::unauthorized(
+            "missing `Authorization: Bearer <token>` or session cookie",
+        ));
+    };
+    // Personal API tokens are recognisable by the `shp_` prefix
+    // — a fast-fail so noise traffic doesn't hit the DB hash
+    // lookup. Anything else falls through to the legacy
+    // shared-secret comparison.
+    if presented.starts_with(crate::store::ACTIONS_TOKEN_PREFIX) {
+        // Actions OIDC-exchanged token. No GitHub-login allowlist
+        // re-check here: the repository allowlist was already
+        // enforced at mint time, and the underlying GitHub
+        // identity (the workflow itself) has no
+        // `allowed_github_logins` analogue. Operators revoke by
+        // either (a) flipping the repository off
+        // `allowed_actions_repositories` (no new tokens) or
+        // (b) waiting out the short TTL. The latter is why TTLs
+        // default to 15 minutes.
+        let token_hash = crate::store::hash_actions_token(presented);
+        let principal = state
+            .store
+            .actions_token_principal(token_hash)
+            .await
+            .map_err(ApiError::internal)?;
+        if let Some(p) = principal {
+            let store = state.store.clone();
+            let tid = p.token_id;
+            tokio::spawn(async move {
+                if let Err(e) = store.touch_actions_token(tid).await {
+                    log::warn!(
+                        target: "sakimori_hub::auth",
+                        "touch_actions_token({tid}) failed: {e:#}",
+                    );
+                }
+            });
+            return Ok(next.run(req).await);
+        }
+        return Err(ApiError::unauthorized(
+            "invalid, revoked, or expired actions token",
+        ));
+    }
+    if presented.starts_with(crate::store::API_TOKEN_PREFIX) {
+        let token_hash = crate::store::hash_api_token(presented);
+        let row = state
+            .store
+            .api_token_user(token_hash)
+            .await
+            .map_err(ApiError::internal)?;
+        if let Some((user, token_id)) = row {
+            // Re-check the GitHub allowlist on every request, not
+            // just at OAuth callback time. Otherwise an offboarded
+            // user's long-lived `shp_` tokens (default no expiry)
+            // would keep working until each one was individually
+            // revoked. With this check, removing the login from
+            // `SAKIMORI_HUB_ALLOWED_GITHUB_LOGINS` immediately
+            // disables every token they hold.
+            if !state.config.allowed_github_logins.is_empty()
+                && !state
+                    .config
+                    .allowed_github_logins
+                    .contains(&user.github_login.to_ascii_lowercase())
+            {
+                return Err(ApiError::unauthorized(
+                    "owning github user is no longer on the allowlist",
+                ));
+            }
+            // Best-effort `last_used_at` update — spawn so a slow
+            // DB write can't drag out the request path.
+            let store = state.store.clone();
+            tokio::spawn(async move {
+                if let Err(e) = store.touch_api_token(token_id).await {
+                    log::warn!(
+                        target: "sakimori_hub::auth",
+                        "touch_api_token({token_id}) failed: {e:#}",
+                    );
+                }
+            });
+            return Ok(next.run(req).await);
+        }
+        return Err(ApiError::unauthorized("invalid or revoked api token"));
+    }
+    let Some(expected) = state.config.ingest_token.as_deref() else {
+        // Bearer presented but no shared secret configured — this
+        // is an OAuth-only deploy. Don't pretend the token might
+        // be right.
+        return Err(ApiError::unauthorized(
+            "bearer auth disabled on this deploy; use a session cookie",
+        ));
+    };
+    use subtle::ConstantTimeEq;
+    let ok =
+        presented.len() == expected.len() && presented.as_bytes().ct_eq(expected.as_bytes()).into();
+    if !ok {
+        return Err(ApiError::unauthorized("invalid bearer token"));
+    }
+    Ok(next.run(req).await)
+}
+
+/// Stricter middleware for `/api/tokens` routes — requires a
+/// live session cookie + matching CSRF origin. Personal-token
+/// auth is deliberately NOT accepted here: a long-lived token
+/// shouldn't be able to mint new long-lived tokens (would let a
+/// leaked token persist past revoke). The session cookie is the
+/// only thing that proves "a human is at the keyboard".
+async fn require_session_user(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<Response, ApiError> {
+    let secret = state
+        .config
+        .session_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::not_found("personal tokens require GitHub OAuth login"))?;
+    let user = cookie_session_user(&state, secret, req.headers())
+        .await?
+        .ok_or_else(|| ApiError::unauthorized("session required"))?;
+    // CSRF origin check ONLY for unsafe methods. GETs of e.g.
+    // `/auth/device?code=...` are linkable / bookmarkable / typed
+    // into a fresh tab, so requiring an Origin/Referer match
+    // would 401 the operator before they ever see the confirm
+    // form. Reads are non-mutating, so the SameSite=Lax cookie
+    // contract is enough.
+    if is_unsafe_method(req.method()) && !cookie_origin_ok(&state, req.headers()) {
+        return Err(ApiError::unauthorized(
+            "cookie-authenticated request without matching Origin/Referer",
+        ));
+    }
+    // Hand the user object down to the handler via request
+    // extensions so it doesn't have to re-do the lookup.
+    let mut req = req;
+    req.extensions_mut().insert(user);
+    Ok(next.run(req).await)
+}
+
+fn is_unsafe_method(m: &axum::http::Method) -> bool {
+    !matches!(
+        *m,
+        axum::http::Method::GET | axum::http::Method::HEAD | axum::http::Method::OPTIONS
+    )
+}
+
+/// CSRF origin check for cookie-authenticated mutating requests.
+/// Returns `true` iff `Origin` (preferred) or `Referer` (fallback)
+/// matches `external_base_url`. When `external_base_url` is unset
+/// we accept everything — the loopback dev posture; production
+/// deploys MUST set it (and `main.rs` does, in tandem with the
+/// OAuth flag bundle).
+fn cookie_origin_ok(state: &AppState, headers: &axum::http::HeaderMap) -> bool {
+    let Some(base) = state.config.external_base_url.as_deref() else {
+        return true;
+    };
+    let base = base.trim_end_matches('/');
+    if let Some(origin) = headers
+        .get(http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    {
+        return origin.trim_end_matches('/') == base;
+    }
+    if let Some(referer) = headers
+        .get(http::header::REFERER)
+        .and_then(|v| v.to_str().ok())
+    {
+        // A naïve `referer.starts_with(base)` would accept
+        // `https://hub.example.com.attacker.tld/x` for
+        // `base = https://hub.example.com`. Require either an
+        // exact match or a `base/...` prefix so an attacker
+        // can't append more characters to the host portion.
+        let with_slash = format!("{base}/");
+        return referer == base || referer.starts_with(&with_slash);
+    }
+    // Neither header — refuse. A legitimate browser request
+    // always sets at least one; an intentional `curl --cookie ...`
+    // would too. Lacking both is the shape of a clickjacked /
+    // form-action CSRF attempt.
+    false
+}
+
+/// Extract the session cookie from request headers, verify the
+/// signature, and resolve it to a [`StoredUser`]. Returns
+/// `Ok(None)` for "no cookie, bad cookie, expired, or revoked"
+/// — every failure mode is indistinguishable to the caller so
+/// timing/wording can't differentiate them.
+async fn cookie_session_user(
+    state: &AppState,
+    secret: &[u8],
+    headers: &axum::http::HeaderMap,
+) -> Result<Option<StoredUser>, ApiError> {
+    let Some(cookie_header) = headers
+        .get(http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return Ok(None);
+    };
+    let Some(cookie_value) = crate::auth::session::extract_session_cookie(cookie_header) else {
+        return Ok(None);
+    };
+    let Some(parsed) = crate::auth::verify_cookie(secret, cookie_value) else {
+        return Ok(None);
+    };
+    state
+        .store
+        .session_user(parsed.token_hash)
+        .await
+        .map_err(ApiError::internal)
+}
+
+/// Wire shape of a single ingest record. Flattens the full
+/// `InstallEvent` JSON and adds an optional `source` override that
+/// the proxy can set when it knows the runtime context for sure.
+/// When `source` is omitted the hub falls back to its heuristic
+/// classifier — see [`crate::classify::classify`].
+#[derive(Debug, Deserialize)]
+pub struct IngestItem {
+    #[serde(flatten)]
+    pub event: InstallEvent,
+    pub source: Option<Source>,
+}
+
+impl From<IngestItem> for IngestRecord {
+    fn from(it: IngestItem) -> Self {
+        IngestRecord {
+            event: it.event,
+            source: it.source,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum IngestPayload {
+    One(Box<IngestItem>),
+    Many(Vec<IngestItem>),
+}
+
+#[derive(Serialize)]
+struct IngestResp {
+    accepted: usize,
+}
+
+async fn ingest(
+    State(state): State<AppState>,
+    Json(payload): Json<IngestPayload>,
+) -> Result<Json<IngestResp>, ApiError> {
+    let items: Vec<IngestItem> = match payload {
+        IngestPayload::One(e) => vec![*e],
+        IngestPayload::Many(v) => v,
+    };
+    if items.len() > state.config.max_batch {
+        return Err(ApiError::bad_request(format!(
+            "batch size {} exceeds max_batch={}",
+            items.len(),
+            state.config.max_batch
+        )));
+    }
+    let records: Vec<IngestRecord> = items.into_iter().map(Into::into).collect();
+    let accepted = records.len();
+    state
+        .store
+        .insert_many(records)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(IngestResp { accepted }))
+}
+
+#[derive(Deserialize)]
+struct ListQuery {
+    ecosystem: Option<String>,
+    name: Option<String>,
+    version: Option<String>,
+    source: Option<String>,
+    since: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct ListResp {
+    events: Vec<StoredEvent>,
+}
+
+async fn list(
+    State(state): State<AppState>,
+    Query(q): Query<ListQuery>,
+) -> Result<Json<ListResp>, ApiError> {
+    let filter = build_filter(q)?;
+    let events = state.store.list(filter).await.map_err(ApiError::internal)?;
+    Ok(Json(ListResp { events }))
+}
+
+fn build_filter(q: ListQuery) -> Result<ListFilter, ApiError> {
+    let source = match q.source.as_deref() {
+        Some(s) => Some(Source::parse(s).ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "invalid `source`: {s}; expected one of actions|desktop|unknown"
+            ))
+        })?),
+        None => None,
+    };
+    let since = match q.since.as_deref() {
+        Some(s) => Some(parse_since(s)?),
+        None => None,
+    };
+    Ok(ListFilter {
+        ecosystem: q.ecosystem,
+        name: q.name,
+        version: q.version,
+        source,
+        since,
+        limit: q.limit,
+    })
+}
+
+fn parse_since(s: &str) -> Result<DateTime<Utc>, ApiError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|d| d.with_timezone(&Utc))
+        .map_err(|e| ApiError::bad_request(format!("invalid `since` (need RFC3339): {e}")))
+}
+
+#[derive(Serialize)]
+struct Healthz {
+    status: &'static str,
+    count: i64,
+    schema_version: i32,
+    matching_mode: &'static str,
+}
+
+async fn healthz(State(state): State<AppState>) -> Result<Json<Healthz>, ApiError> {
+    let count = state.store.count().await.map_err(ApiError::internal)?;
+    let schema_version = state
+        .store
+        .schema_version()
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(Healthz {
+        status: "ok",
+        count,
+        schema_version,
+        matching_mode: MATCHING_MODE,
+    }))
+}
+
+async fn index_html(State(state): State<AppState>) -> Result<Html<String>, ApiError> {
+    let events = state
+        .store
+        .list(ListFilter {
+            limit: Some(200),
+            ..Default::default()
+        })
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Html(render_index(&events)))
+}
+
+fn render_index(events: &[StoredEvent]) -> String {
+    let mut rows = String::new();
+    for e in events {
+        rows.push_str(&format!(
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td>{}</td><td>{}</td></tr>",
+            html_escape(&e.resolved_at.to_rfc3339()),
+            html_escape(&e.ecosystem),
+            html_escape(&e.name),
+            html_escape(&e.version),
+            html_escape(e.source.as_str()),
+            html_escape(execution_mode_label(e)),
+            html_escape(e.project_path.as_deref().unwrap_or("")),
+        ));
+    }
+    format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\">\
+         <title>sakimori-hub — install inventory</title>\
+         <style>\
+           body{{font-family:system-ui,sans-serif;margin:1.5rem}}\
+           table{{border-collapse:collapse;font-size:.85rem;width:100%}}\
+           th,td{{border:1px solid #ccc;padding:.3rem .5rem;text-align:left}}\
+           th{{background:#f4f4f4}}\
+           caption{{caption-side:top;text-align:left;font-weight:600;padding:.4rem 0}}\
+         </style></head><body>\
+         <h1>sakimori-hub</h1>\
+         <p>Showing the {n} most recent install events. Use \
+         <code>GET /installs</code> for filtered JSON.</p>\
+         <table><caption>Recent installs</caption>\
+         <thead><tr><th>resolved_at</th><th>ecosystem</th><th>name</th>\
+         <th>version</th><th>source</th><th>execution</th><th>project_path</th></tr></thead>\
+         <tbody>{rows}</tbody></table></body></html>",
+        n = events.len(),
+        rows = rows,
+    )
+}
+
+fn execution_mode_label(e: &StoredEvent) -> &'static str {
+    use sakimori_core::installs::ExecutionMode::*;
+    match e.execution_mode {
+        Persistent => "persistent",
+        Ephemeral => "ephemeral",
+        Unknown => "unknown",
+    }
+}
+
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+// ---------------- advisories / scan / findings ----------------
+
+#[derive(Serialize)]
+struct AdvisoryImportResp {
+    created: usize,
+    refreshed: usize,
+    matching_mode: &'static str,
+}
+
+/// Accept the advisory body as a raw `serde_json::Value` so the
+/// original JSON value (including fields the typed `OsvAdvisory`
+/// view doesn't model) is what we durably store. The shape may
+/// be either a single advisory object or an array.
+async fn advisories_import(
+    State(state): State<AppState>,
+    Json(payload): Json<serde_json::Value>,
+) -> Result<Json<AdvisoryImportResp>, ApiError> {
+    let raw_items: Vec<serde_json::Value> = match payload {
+        serde_json::Value::Array(arr) => arr,
+        v => vec![v],
+    };
+    if raw_items.len() > state.config.max_batch {
+        return Err(ApiError::bad_request(format!(
+            "batch size {} exceeds max_batch={}",
+            raw_items.len(),
+            state.config.max_batch
+        )));
+    }
+    let mut typed = Vec::with_capacity(raw_items.len());
+    for (idx, raw) in raw_items.into_iter().enumerate() {
+        let adv: OsvAdvisory = serde_json::from_value(raw.clone())
+            .map_err(|e| ApiError::bad_request(format!("advisory[{idx}]: invalid OSV: {e}")))?;
+        validate_advisory(&adv)
+            .map_err(|e| ApiError::bad_request(format!("advisory[{idx}]: {e}")))?;
+        typed.push((adv, Some(raw)));
+    }
+    let (created, refreshed) = state
+        .store
+        .upsert_advisories(typed)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(AdvisoryImportResp {
+        created,
+        refreshed,
+        matching_mode: MATCHING_MODE,
+    }))
+}
+
+#[derive(Deserialize)]
+struct AdvisoryListQuery {
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct AdvisoryListResp {
+    advisories: Vec<StoredAdvisory>,
+}
+
+async fn advisories_list(
+    State(state): State<AppState>,
+    Query(q): Query<AdvisoryListQuery>,
+) -> Result<Json<AdvisoryListResp>, ApiError> {
+    let advisories = state
+        .store
+        .list_advisories(q.limit)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(AdvisoryListResp { advisories }))
+}
+
+async fn scan(State(state): State<AppState>) -> Result<Json<ScanReport>, ApiError> {
+    let report = state
+        .store
+        .scan_findings()
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(report))
+}
+
+#[derive(Deserialize)]
+struct FindingListQuery {
+    min_severity: Option<String>,
+    source: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct FindingListResp {
+    findings: Vec<StoredFinding>,
+}
+
+async fn findings_list(
+    State(state): State<AppState>,
+    Query(q): Query<FindingListQuery>,
+) -> Result<Json<FindingListResp>, ApiError> {
+    let min_severity = match q.min_severity.as_deref() {
+        Some(s) => Some(Severity::parse(s).ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "invalid `min_severity`: {s}; expected critical|high|moderate|low|unknown"
+            ))
+        })?),
+        None => None,
+    };
+    let source = match q.source.as_deref() {
+        Some(s) => Some(Source::parse(s).ok_or_else(|| {
+            ApiError::bad_request(format!(
+                "invalid `source`: {s}; expected actions|desktop|unknown"
+            ))
+        })?),
+        None => None,
+    };
+    let findings = state
+        .store
+        .list_findings(FindingFilter {
+            min_severity,
+            source,
+            limit: q.limit,
+        })
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(FindingListResp { findings }))
+}
+
+// ---------------- dispatch targets / run ----------------
+
+/// Wire shape for `POST /dispatch-targets`. We accept the secret
+/// from the operator (rather than generating one) because the
+/// receiver also needs to know it — anything we generate would
+/// just have to be displayed back, and round-tripping the secret
+/// through our response body is exactly what we want to avoid.
+#[derive(Debug, Deserialize)]
+pub struct TargetCreateBody {
+    pub label: String,
+    pub url: String,
+    pub secret: String,
+    pub min_severity: Severity,
+    #[serde(default)]
+    pub source_filter: Option<Source>,
+}
+
+#[derive(Serialize)]
+struct TargetCreateResp {
+    id: i64,
+    label: String,
+}
+
+async fn targets_create(
+    State(state): State<AppState>,
+    Json(body): Json<TargetCreateBody>,
+) -> Result<Json<TargetCreateResp>, ApiError> {
+    let spec = TargetSpec {
+        label: body.label,
+        url: body.url,
+        secret: body.secret,
+        min_severity: body.min_severity,
+        source_filter: body.source_filter,
+    };
+    validate_target(&spec, state.config.allow_private_webhooks)
+        .map_err(|e| ApiError::bad_request(format!("invalid target: {e}")))?;
+    let label = spec.label.clone();
+    let id = state
+        .store
+        .register_target(spec)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(TargetCreateResp { id, label }))
+}
+
+#[derive(Serialize)]
+struct TargetListResp {
+    targets: Vec<StoredTarget>,
+}
+
+async fn targets_list(State(state): State<AppState>) -> Result<Json<TargetListResp>, ApiError> {
+    let targets = state
+        .store
+        .list_targets()
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(TargetListResp { targets }))
+}
+
+async fn targets_delete(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<i64>,
+) -> Result<StatusCode, ApiError> {
+    let removed = state
+        .store
+        .delete_target(id)
+        .await
+        .map_err(ApiError::internal)?;
+    if removed {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError::not_found(format!("no target with id {id}")))
+    }
+}
+
+#[derive(Deserialize)]
+struct DispatchRunQuery {
+    batch: Option<u32>,
+    attempt_cap: Option<i64>,
+}
+
+async fn dispatch_run(
+    State(state): State<AppState>,
+    Query(q): Query<DispatchRunQuery>,
+) -> Result<Json<DispatchReport>, ApiError> {
+    let batch = q.batch.unwrap_or(100).min(10_000);
+    let cap = q.attempt_cap.unwrap_or(DEFAULT_ATTEMPT_CAP).max(1);
+    // Hold the lock for the whole pass so two concurrent
+    // `POST /dispatch/run` calls can't both pull the same pending
+    // rows. The lock is process-local; the deploy model is one
+    // hub per team, so process-local is sufficient.
+    let _guard = state.dispatch_lock.lock().await;
+    let report = run_once(state.store.clone(), state.webhook.clone(), batch, cap)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(report))
+}
+
+// ---------------- browser auth (GitHub OAuth) ----------------
+
+const OAUTH_STATE_COOKIE: &str = "sakimori_hub_oauth_state";
+
+#[derive(Deserialize)]
+struct OAuthCallbackQuery {
+    code: String,
+    state: String,
+}
+
+async fn auth_github_login(State(state): State<AppState>) -> Result<Response, ApiError> {
+    let oauth = state
+        .oauth
+        .as_ref()
+        .ok_or_else(|| ApiError::not_found("github oauth not configured"))?;
+    let _ = oauth; // we only need the existence check at this layer
+    let client_id = require_oauth_client_id(&state)?;
+    let base = state
+        .config
+        .external_base_url
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("external_base_url not configured"))?;
+    let secret = state
+        .config
+        .session_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("session_secret not configured"))?;
+    // CSRF state: random 32 bytes, base64url, dropped on the
+    // browser as a short-lived signed cookie. The callback
+    // verifies the value GitHub echoes back matches the cookie
+    // value bit-for-bit.
+    let state_token = crate::auth::session::mint_session_token(secret);
+    let redirect_uri = format!("{}/auth/github/callback", base.trim_end_matches('/'));
+    let url = crate::auth::github::authorize_url(
+        client_id,
+        &redirect_uri,
+        // The browser-visible part of the cookie value is the
+        // signed token; the callback only needs the *cookie* to
+        // match, so we send that string as the OAuth `state`.
+        &state_token.cookie_value,
+        &["read:user"],
+    );
+    let cookie = state_oauth_set_cookie(&state_token.cookie_value, state.config.cookie_secure)
+        .map_err(ApiError::internal)?;
+    let mut resp = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(http::header::LOCATION, url)
+        .header(http::header::SET_COOKIE, cookie)
+        .body(axum::body::Body::empty())
+        .map_err(ApiError::internal)?;
+    // Don't cache the redirect — GitHub clamps state to the
+    // login attempt that minted it.
+    resp.headers_mut().insert(
+        http::header::CACHE_CONTROL,
+        "no-store".parse().expect("static header value"),
+    );
+    Ok(resp)
+}
+
+async fn auth_github_callback(
+    State(state): State<AppState>,
+    Query(q): Query<OAuthCallbackQuery>,
+    headers: axum::http::HeaderMap,
+) -> Result<Response, ApiError> {
+    let oauth = state
+        .oauth
+        .as_ref()
+        .ok_or_else(|| ApiError::not_found("github oauth not configured"))?
+        .clone();
+    let secret = state
+        .config
+        .session_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("session_secret not configured"))?;
+    // CSRF check: the `state` query param must equal the value
+    // we stashed in OAUTH_STATE_COOKIE on /login. Mismatch ⇒
+    // 400 — every flow without the matching cookie is an
+    // attacker drive-by.
+    let cookie_state = headers
+        .get(http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| extract_named_cookie(h, OAUTH_STATE_COOKIE))
+        .ok_or_else(|| ApiError::bad_request("missing oauth state cookie"))?;
+    if cookie_state.len() != q.state.len()
+        || !bool::from(subtle::ConstantTimeEq::ct_eq(
+            cookie_state.as_bytes(),
+            q.state.as_bytes(),
+        ))
+    {
+        return Err(ApiError::bad_request("oauth state mismatch"));
+    }
+    // Also verify the cookie's own HMAC — even though we don't
+    // *use* the inner token, validating the signature shuts down
+    // an attacker who could otherwise paste a same-length string
+    // they made up.
+    if crate::auth::verify_cookie(secret, cookie_state).is_none() {
+        return Err(ApiError::bad_request("oauth state failed signature check"));
+    }
+    let user_agent = headers
+        .get(http::header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let code = q.code.clone();
+    let gh_user = tokio::task::spawn_blocking(move || oauth.exchange_code(&code))
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(|e| ApiError::bad_request(format!("oauth exchange: {e}")))?;
+    // Authorization gate: the operator's `allowed_github_logins`
+    // determines who can hold a session. Until the team/RBAC
+    // slice lands, "logged in" == "operator", so an empty
+    // allowlist would let anyone with a GitHub account take
+    // over the hub. main.rs hard-bails if OAuth is enabled
+    // without an allowlist, but defence-in-depth re-checks here.
+    let login_lower = gh_user.login.to_ascii_lowercase();
+    if !state.config.allowed_github_logins.contains(&login_lower) {
+        log::warn!(
+            target: "sakimori_hub::auth",
+            "rejecting OAuth login for github user {} (not on allowed_github_logins)",
+            gh_user.login,
+        );
+        return Err(ApiError::unauthorized(
+            "this GitHub user is not allowed on this hub",
+        ));
+    }
+    let user_id = state
+        .store
+        .upsert_user(UpsertUserSpec {
+            github_user_id: gh_user.id,
+            github_login: gh_user.login.clone(),
+            display_name: gh_user.name.clone(),
+            avatar_url: gh_user.avatar_url.clone(),
+        })
+        .await
+        .map_err(ApiError::internal)?;
+    // Mint the *session* cookie (separate from the oauth-state
+    // cookie which we now clear).
+    let session = crate::auth::session::mint_session_token(secret);
+    state
+        .store
+        .create_session(
+            user_id,
+            session.token_hash,
+            state.config.session_ttl_secs,
+            user_agent,
+        )
+        .await
+        .map_err(ApiError::internal)?;
+    let session_cookie = crate::auth::session::build_set_cookie(
+        &session.cookie_value,
+        state.config.session_ttl_secs,
+        state.config.cookie_secure,
+    )
+    .map_err(ApiError::internal)?;
+    let clear_state = state_oauth_clear_cookie(state.config.cookie_secure);
+    let mut resp = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(http::header::LOCATION, "/")
+        .body(axum::body::Body::empty())
+        .map_err(ApiError::internal)?;
+    let h = resp.headers_mut();
+    h.append(
+        http::header::SET_COOKIE,
+        session_cookie.parse().map_err(ApiError::internal)?,
+    );
+    h.append(
+        http::header::SET_COOKIE,
+        clear_state.parse().map_err(ApiError::internal)?,
+    );
+    Ok(resp)
+}
+
+async fn auth_logout(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> Result<Response, ApiError> {
+    if let Some(secret) = state.config.session_secret.as_deref()
+        && let Some(cookie_header) = headers
+            .get(http::header::COOKIE)
+            .and_then(|v| v.to_str().ok())
+        && let Some(value) = crate::auth::session::extract_session_cookie(cookie_header)
+        && let Some(parsed) = crate::auth::verify_cookie(secret, value)
+    {
+        // Best-effort revoke — even if the DB call errors, we
+        // still tell the browser to drop the cookie. Don't leak
+        // the cause via response status.
+        let _ = state.store.revoke_session(parsed.token_hash).await;
+    }
+    let clear = crate::auth::session::build_clear_cookie(state.config.cookie_secure);
+    let mut resp = Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .body(axum::body::Body::empty())
+        .map_err(ApiError::internal)?;
+    resp.headers_mut().insert(
+        http::header::SET_COOKIE,
+        clear.parse().map_err(ApiError::internal)?,
+    );
+    Ok(resp)
+}
+
+#[derive(Serialize)]
+struct MeResp {
+    user: StoredUser,
+}
+
+async fn auth_me(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<MeResp>, ApiError> {
+    let secret = state
+        .config
+        .session_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::unauthorized("not signed in"))?;
+    let user = cookie_session_user(&state, secret, &headers)
+        .await?
+        .ok_or_else(|| ApiError::unauthorized("not signed in"))?;
+    Ok(Json(MeResp { user }))
+}
+
+fn require_oauth_client_id(state: &AppState) -> Result<&str, ApiError> {
+    state
+        .config
+        .github_client_id
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("github_client_id not configured"))
+}
+
+fn state_oauth_set_cookie(value: &str, secure: bool) -> anyhow::Result<String> {
+    if value.contains([';', '\r', '\n']) {
+        anyhow::bail!("oauth state cookie value contained a control character");
+    }
+    let mut s =
+        format!("{OAUTH_STATE_COOKIE}={value}; Path=/auth; HttpOnly; SameSite=Lax; Max-Age=600");
+    if secure {
+        s.push_str("; Secure");
+    }
+    Ok(s)
+}
+
+fn state_oauth_clear_cookie(secure: bool) -> String {
+    let mut s = format!("{OAUTH_STATE_COOKIE}=; Path=/auth; HttpOnly; SameSite=Lax; Max-Age=0");
+    if secure {
+        s.push_str("; Secure");
+    }
+    s
+}
+
+fn extract_named_cookie<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    for part in cookie_header.split(';') {
+        let part = part.trim();
+        if let Some(value) = part.strip_prefix(&format!("{name}=")) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+// ---------------- actions oidc exchange ----------------
+
+#[derive(Debug, Deserialize)]
+pub struct ActionsExchangeBody {
+    /// Raw OIDC JWT obtained inside the workflow via
+    /// `$ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`.
+    pub jwt: String,
+}
+
+#[derive(Serialize)]
+struct ActionsExchangeResp {
+    token: String,
+    record: crate::store::StoredActionsToken,
+}
+
+async fn auth_actions_exchange(
+    State(state): State<AppState>,
+    Json(body): Json<ActionsExchangeBody>,
+) -> Result<Json<ActionsExchangeResp>, ApiError> {
+    let verifier = state
+        .actions_verifier
+        .as_ref()
+        .ok_or_else(|| ApiError::not_found("actions oidc exchange disabled"))?
+        .clone();
+    let audience = state
+        .config
+        .actions_oidc_audience
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("actions_oidc_audience not configured"))?
+        .to_string();
+    if state.config.allowed_actions_repositories.is_empty() {
+        return Err(ApiError::not_found("actions oidc exchange disabled"));
+    }
+    // Verification is sync (jsonwebtoken doesn't have an async
+    // shape) and the JWKS fetch path may block on the network —
+    // off the runtime thread.
+    let jwt = body.jwt;
+    let claims = tokio::task::spawn_blocking(move || verifier.verify(&jwt))
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(|e| ApiError::unauthorized(format!("oidc verify: {e}")))?;
+    // Audience defence in depth — the verifier already checked,
+    // but `ActionsClaims` is a pub deserialise target so a future
+    // refactor that swaps the verifier could regress quietly.
+    if claims.aud != audience {
+        return Err(ApiError::unauthorized(format!(
+            "audience mismatch (expected {audience:?}, got {:?})",
+            claims.aud
+        )));
+    }
+    if !crate::auth::repository_matches(
+        &state.config.allowed_actions_repositories,
+        &claims.repository,
+    ) {
+        log::warn!(
+            target: "sakimori_hub::auth",
+            "rejecting actions exchange for repository {} (not on allowlist)",
+            claims.repository,
+        );
+        return Err(ApiError::unauthorized(
+            "this repository is not allowed on this hub",
+        ));
+    }
+    // TTL = min(JWT `exp` - now, configured cap). The cap stops
+    // a future-dated JWT from minting a 4-hour token; the JWT
+    // bound stops a long cap from outliving the JWT itself (the
+    // workflow's authorising moment).
+    let now_secs = Utc::now().timestamp();
+    let jwt_remaining = claims.exp.saturating_sub(now_secs);
+    if jwt_remaining <= 0 {
+        return Err(ApiError::unauthorized("oidc jwt already expired"));
+    }
+    let ttl = jwt_remaining.min(state.config.actions_token_ttl_secs);
+    let minted = state
+        .store
+        .mint_actions_token(crate::store::ActionsTokenSpec {
+            repository: claims.repository,
+            repository_owner: claims.repository_owner,
+            workflow_ref: claims.workflow_ref.or(claims.workflow),
+            subject: claims.sub,
+            ttl_secs: ttl,
+        })
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(ActionsExchangeResp {
+        token: minted.cleartext,
+        record: minted.record,
+    }))
+}
+
+// ---------------- device authorization flow ----------------
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceCodeReq {
+    /// Operator-supplied label that ends up on the minted
+    /// personal token (e.g. "sakimori CLI on ada-laptop").
+    pub label: String,
+}
+
+#[derive(Serialize)]
+struct DeviceCodeResp {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    /// Pre-built URL operators can scan/click — same content as
+    /// `verification_uri` with the user_code pre-filled as the
+    /// `?code=` query param.
+    verification_uri_complete: String,
+    expires_in: i64,
+    /// Min seconds between consecutive `POST /auth/device/token`
+    /// polls. Sub-`interval` polls get `slow_down`.
+    interval: i64,
+}
+
+const DEVICE_CODE_TTL_SECS: i64 = 600;
+const DEVICE_CODE_MIN_POLL_INTERVAL_SECS: i64 = 5;
+
+async fn auth_device_code(
+    State(state): State<AppState>,
+    Json(body): Json<DeviceCodeReq>,
+) -> Result<Json<DeviceCodeResp>, ApiError> {
+    // Browser login must be configured — without it there's no
+    // way for an operator to approve the request.
+    if state.oauth.is_none() {
+        return Err(ApiError::not_found("device flow requires browser login"));
+    }
+    let base = state
+        .config
+        .external_base_url
+        .as_deref()
+        .ok_or_else(|| ApiError::internal("external_base_url not configured"))?
+        .trim_end_matches('/');
+    let minted = state
+        .store
+        .mint_device_code(body.label, DEVICE_CODE_TTL_SECS)
+        .await
+        .map_err(|e| ApiError::bad_request(format!("device code: {e}")))?;
+    let verification_uri = format!("{base}/auth/device");
+    let verification_uri_complete = format!(
+        "{base}/auth/device?code={}",
+        urlencoding::encode(&minted.user_code)
+    );
+    Ok(Json(DeviceCodeResp {
+        device_code: minted.device_code,
+        user_code: minted.user_code,
+        verification_uri,
+        verification_uri_complete,
+        expires_in: DEVICE_CODE_TTL_SECS,
+        interval: DEVICE_CODE_MIN_POLL_INTERVAL_SECS,
+    }))
+}
+
+#[derive(Deserialize)]
+struct DevicePageQuery {
+    #[serde(default)]
+    code: Option<String>,
+}
+
+async fn auth_device_page(
+    State(state): State<AppState>,
+    Query(q): Query<DevicePageQuery>,
+    axum::Extension(user): axum::Extension<StoredUser>,
+) -> Result<Html<String>, ApiError> {
+    // Three states:
+    //   - no code in URL: blank form to paste one in.
+    //   - code in URL, lookup succeeds + pending: confirm form.
+    //   - code in URL, anything else: error page.
+    let mut body = String::new();
+    body.push_str(&format!(
+        "<h1>Approve a CLI sign-in</h1><p>Signed in as <code>{}</code>.</p>",
+        html_escape(&user.github_login),
+    ));
+    if let Some(code) = q.code.as_deref() {
+        match state.store.find_device_code_by_user_code(code).await {
+            Ok(Some(row)) if row.status == DeviceCodeStatus::Pending => {
+                body.push_str(&format!(
+                    "<p>Authorize CLI client <code>{}</code> with code \
+                     <strong>{}</strong>?</p>\
+                     <form method=\"post\" action=\"/auth/device/approve\">\
+                       <input type=\"hidden\" name=\"user_code\" value=\"{}\">\
+                       <button type=\"submit\" name=\"decision\" value=\"approve\">\
+                         Approve\
+                       </button>\
+                       <button type=\"submit\" name=\"decision\" value=\"deny\">\
+                         Deny\
+                       </button>\
+                     </form>",
+                    html_escape(&row.label),
+                    html_escape(&row.user_code),
+                    html_escape(&row.user_code),
+                ));
+            }
+            Ok(Some(_)) => body.push_str(
+                "<p>That code is no longer pending — it may have been \
+                 approved, denied, expired, or already consumed.</p>",
+            ),
+            Ok(None) => body.push_str("<p>Unknown code. Check for typos and try again.</p>"),
+            Err(e) => return Err(ApiError::internal(e)),
+        }
+    } else {
+        body.push_str(
+            "<form method=\"get\" action=\"/auth/device\">\
+               <label>Code: \
+                 <input name=\"code\" autocomplete=\"off\" autofocus required>\
+               </label>\
+               <button type=\"submit\">Continue</button>\
+             </form>",
+        );
+    }
+    Ok(Html(format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\">\
+         <title>sakimori-hub device flow</title>\
+         <style>body{{font-family:system-ui,sans-serif;margin:2rem;max-width:32rem}}\
+         input,button{{font-size:1rem;padding:.3rem .5rem;margin:.2rem 0}}\
+         code{{background:#f4f4f4;padding:.1rem .3rem;border-radius:.2rem}}\
+         </style></head><body>{body}</body></html>"
+    )))
+}
+
+#[derive(Deserialize)]
+struct DeviceApproveBody {
+    user_code: String,
+    decision: String,
+}
+
+async fn auth_device_approve(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<StoredUser>,
+    axum::Form(body): axum::Form<DeviceApproveBody>,
+) -> Result<Html<String>, ApiError> {
+    let Some(row) = state
+        .store
+        .find_device_code_by_user_code(&body.user_code)
+        .await
+        .map_err(ApiError::internal)?
+    else {
+        return Err(ApiError::not_found("unknown user_code"));
+    };
+    if row.status != DeviceCodeStatus::Pending {
+        return Err(ApiError::bad_request("code is no longer pending"));
+    }
+    let decided = match body.decision.as_str() {
+        "approve" => {
+            // Race window: between `find_device_code_by_user_code`
+            // and `approve_device_code` the row could expire or
+            // be flipped by another tab. The store update guards
+            // against pending+unexpired; if it returns false, we
+            // surface 400 instead of cheerfully claiming success.
+            let ok = state
+                .store
+                .approve_device_code(row.id, user.id)
+                .await
+                .map_err(ApiError::internal)?;
+            if !ok {
+                return Err(ApiError::bad_request("code is no longer pending"));
+            }
+            "approved"
+        }
+        "deny" => {
+            let ok = state
+                .store
+                .deny_device_code(row.id)
+                .await
+                .map_err(ApiError::internal)?;
+            if !ok {
+                return Err(ApiError::bad_request("code is no longer pending"));
+            }
+            "denied"
+        }
+        other => {
+            return Err(ApiError::bad_request(format!(
+                "unknown decision {other:?} (expected approve|deny)"
+            )));
+        }
+    };
+    Ok(Html(format!(
+        "<!doctype html><html><body style=\"font-family:system-ui,sans-serif;margin:2rem\">\
+         <h1>Code {decided}</h1>\
+         <p>You can close this tab — your CLI will pick up the change on its next poll.</p>\
+         </body></html>"
+    )))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DeviceTokenReq {
+    pub device_code: String,
+}
+
+#[derive(Serialize)]
+struct DeviceTokenOk {
+    token: String,
+}
+
+async fn auth_device_token(
+    State(state): State<AppState>,
+    Json(body): Json<DeviceTokenReq>,
+) -> Result<Response, ApiError> {
+    let outcome = state
+        .store
+        .poll_device_code(body.device_code, DEVICE_CODE_MIN_POLL_INTERVAL_SECS)
+        .await
+        .map_err(ApiError::internal)?;
+    // The HTTP shape mirrors RFC 8628 — `{error: "..."}` for the
+    // non-terminal "keep waiting" states, plus the final
+    // success/error shapes. We use 400 for the polling errors
+    // (per RFC) and 200 only on success.
+    match outcome {
+        DevicePollOutcome::Approved { cleartext } => {
+            Ok(Json(DeviceTokenOk { token: cleartext }).into_response())
+        }
+        DevicePollOutcome::Pending { slow_down } => Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            message: if slow_down {
+                "slow_down".into()
+            } else {
+                "authorization_pending".into()
+            },
+        }),
+        DevicePollOutcome::Denied => Err(ApiError::bad_request("access_denied")),
+        DevicePollOutcome::Expired => Err(ApiError::bad_request("expired_token")),
+        DevicePollOutcome::AlreadyConsumed => Err(ApiError::bad_request("expired_token")),
+    }
+}
+
+// ---------------- personal api tokens ----------------
+
+#[derive(Debug, Deserialize)]
+pub struct TokenCreateBody {
+    pub label: String,
+    /// Optional expiry, RFC3339. `None` = never expires.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TokenCreateResp {
+    /// One-shot cleartext. The server never holds this again; the
+    /// user MUST capture it on this response or lose it forever.
+    token: String,
+    record: StoredApiToken,
+}
+
+async fn tokens_create(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<StoredUser>,
+    Json(body): Json<TokenCreateBody>,
+) -> Result<Json<TokenCreateResp>, ApiError> {
+    let expires_at = match body.expires_at.as_deref() {
+        Some(s) => Some(
+            DateTime::parse_from_rfc3339(s)
+                .map(|d| d.with_timezone(&Utc))
+                .map_err(|e| ApiError::bad_request(format!("invalid `expires_at`: {e}")))?,
+        ),
+        None => None,
+    };
+    let minted = state
+        .store
+        .create_api_token(user.id, body.label, expires_at)
+        .await
+        .map_err(|e| ApiError::bad_request(format!("create token: {e}")))?;
+    Ok(Json(TokenCreateResp {
+        token: minted.cleartext,
+        record: minted.record,
+    }))
+}
+
+#[derive(Serialize)]
+struct TokenListResp {
+    tokens: Vec<StoredApiToken>,
+}
+
+async fn tokens_list(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<StoredUser>,
+) -> Result<Json<TokenListResp>, ApiError> {
+    let tokens = state
+        .store
+        .list_api_tokens(user.id)
+        .await
+        .map_err(ApiError::internal)?;
+    Ok(Json(TokenListResp { tokens }))
+}
+
+#[derive(Deserialize)]
+pub struct TokenRevokeBody {
+    pub id: i64,
+}
+
+async fn tokens_revoke(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<StoredUser>,
+    Json(body): Json<TokenRevokeBody>,
+) -> Result<StatusCode, ApiError> {
+    let revoked = state
+        .store
+        .revoke_api_token(body.id, user.id)
+        .await
+        .map_err(ApiError::internal)?;
+    if revoked {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError::not_found(format!(
+            "no active token {} for this user",
+            body.id
+        )))
+    }
+}
+
+// ---------------- error type ----------------
+
+pub struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl ApiError {
+    fn internal(e: impl std::fmt::Display) -> Self {
+        // Sanitise so a multi-line `anyhow::Error::Display` chain
+        // (e.g. embedded newlines from a SQL error) can't smuggle
+        // a fake log line via splitting tooling.
+        let msg = e.to_string().replace(['\n', '\r'], " ");
+        log::error!(target: "sakimori_hub::api", "internal error: {msg}");
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "internal error".into(),
+        }
+    }
+    fn bad_request(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: msg.into(),
+        }
+    }
+    fn not_found(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            message: msg.into(),
+        }
+    }
+    fn unauthorized(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            message: msg.into(),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = serde_json::json!({ "error": self.message }).to_string();
+        (
+            self.status,
+            [(header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::SESSION_COOKIE_NAME;
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use sakimori_core::deps::Ecosystem;
+    use sakimori_core::installs::ExecutionMode;
+    use tower::ServiceExt;
+
+    fn state_with(config: ServerConfig) -> AppState {
+        AppState::new(Arc::new(Store::open_in_memory().unwrap()), config)
+    }
+    fn state() -> AppState {
+        state_with(ServerConfig::default())
+    }
+
+    async fn body_string(resp: Response) -> String {
+        let bytes = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn healthz_reports_ok_and_schema_version() {
+        let app = router(state());
+        let resp = app
+            .oneshot(Request::get("/healthz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("\"status\":\"ok\""));
+        assert!(body.contains("\"count\":0"));
+        assert!(body.contains("\"schema_version\":9"));
+        assert!(body.contains("\"matching_mode\":\"exact_versions_and_semver_ranges\""));
+    }
+
+    #[tokio::test]
+    async fn ingest_single_then_list() {
+        let st = state();
+        let app = router(st.clone());
+        let ev = InstallEvent::new(Ecosystem::Crates, "serde", "1.0.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_project_path("/home/runner/work/r/r");
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&ev).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(body_string(resp).await.contains("\"accepted\":1"));
+
+        let resp = app
+            .oneshot(
+                Request::get("/installs?ecosystem=crates")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("\"name\":\"serde\""));
+        assert!(body.contains("\"source\":\"actions\""));
+    }
+
+    #[tokio::test]
+    async fn ingest_batch_is_atomic() {
+        let st = state();
+        let app = router(st.clone());
+        let batch = vec![
+            InstallEvent::new(Ecosystem::Npm, "a", "1"),
+            InstallEvent::new(Ecosystem::Npm, "b", "2"),
+        ];
+        let resp = app
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&batch).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(body_string(resp).await.contains("\"accepted\":2"));
+        assert_eq!(st.store.count().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn ingest_explicit_source_override() {
+        let st = state();
+        let app = router(st.clone());
+        // Path looks like a desktop but the proxy supplies the
+        // explicit source — the hub must trust it.
+        let body = serde_json::json!({
+            "ecosystem": "npm",
+            "name": "a",
+            "version": "1",
+            "resolved_at": Utc::now().to_rfc3339(),
+            "execution_mode": "persistent",
+            "project_path": "/Users/alice/proj",
+            "source": "actions",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let rows = st.store.list(ListFilter::default()).await.unwrap();
+        assert_eq!(rows[0].source, Source::Actions);
+    }
+
+    #[tokio::test]
+    async fn ingest_rejects_oversized_batch() {
+        let st = state_with(ServerConfig {
+            max_batch: 2,
+            ..ServerConfig::default()
+        });
+        let app = router(st.clone());
+        let batch: Vec<_> = (0..5)
+            .map(|i| InstallEvent::new(Ecosystem::Npm, format!("p{i}"), "1"))
+            .collect();
+        let resp = app
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&batch).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(st.store.count().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn ingest_rejects_oversized_body() {
+        let st = state_with(ServerConfig {
+            body_limit_bytes: 64,
+            ..ServerConfig::default()
+        });
+        let app = router(st);
+        // Pad past 64 B with a noisy field value so the request
+        // body exceeds the configured limit.
+        let big = "x".repeat(2048);
+        let body = serde_json::json!({
+            "ecosystem": "npm",
+            "name": big,
+            "version": "1",
+            "resolved_at": Utc::now().to_rfc3339(),
+            "execution_mode": "persistent",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // axum's DefaultBodyLimit returns 413 on overflow.
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn list_rejects_bad_source() {
+        let app = router(state());
+        let resp = app
+            .oneshot(
+                Request::get("/installs?source=bogus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn list_rejects_bad_since() {
+        let app = router(state());
+        let resp = app
+            .oneshot(
+                Request::get("/installs?since=not-a-date")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn advisory_import_scan_then_list_findings() {
+        let st = state();
+        let app = router(st.clone());
+
+        // Seed an install via the API.
+        let ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0");
+        app.clone()
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&ev).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Import a matching advisory.
+        let adv = serde_json::json!({
+            "id": "GHSA-test",
+            "summary": "test",
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "left-pad"},
+                          "versions": ["1.3.0"]}],
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/advisories")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&adv).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(body_string(resp).await.contains("\"created\":1"));
+
+        // Run scan.
+        let resp = app
+            .clone()
+            .oneshot(Request::post("/scan").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let scan_body = body_string(resp).await;
+        assert!(scan_body.contains("\"new_findings\":1"));
+
+        // GET /findings returns the match.
+        let resp = app
+            .clone()
+            .oneshot(Request::get("/findings").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("GHSA-test"));
+        assert!(body.contains("left-pad"));
+        assert!(body.contains("\"severity\":\"critical\""));
+
+        // Filter by min_severity above the only match → empty.
+        // (No severity higher than critical, so use a name filter
+        // via source: the only finding has source=unknown.)
+        let resp = app
+            .oneshot(
+                Request::get("/findings?source=actions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("\"findings\":[]"));
+    }
+
+    #[tokio::test]
+    async fn advisories_import_returns_400_on_range_with_huge_name() {
+        let app = router(state());
+        // Range-only advisory whose package name exceeds the cap.
+        // Pre-range-validation slice would have inserted it
+        // because validate_advisory walked affected_versions only.
+        let body = serde_json::json!({
+            "id": "GHSA-rangeval",
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "x".repeat(1024)},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"fixed": "2.0.0"}
+                ]}]
+            }],
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/advisories")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn advisories_import_returns_400_on_empty_id() {
+        let app = router(state());
+        let body = serde_json::json!({"id": ""});
+        let resp = app
+            .oneshot(
+                Request::post("/advisories")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let text = body_string(resp).await;
+        assert!(text.contains("advisory id is empty"));
+    }
+
+    #[tokio::test]
+    async fn advisories_import_returns_400_on_oversized_summary() {
+        let app = router(state());
+        let body = serde_json::json!({
+            "id": "GHSA-1",
+            "summary": "x".repeat(9000),
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/advisories")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn findings_rejects_bad_min_severity() {
+        let app = router(state());
+        let resp = app
+            .oneshot(
+                Request::get("/findings?min_severity=bogus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn advisories_import_batch_and_list() {
+        let st = state();
+        let app = router(st.clone());
+        let batch = serde_json::json!([
+            {"id": "A", "database_specific": {"severity": "HIGH"},
+             "affected": [{"package": {"ecosystem": "npm", "name": "p1"}, "versions": ["1"]}]},
+            {"id": "B", "database_specific": {"severity": "LOW"},
+             "affected": [{"package": {"ecosystem": "npm", "name": "p2"}, "versions": ["1"]}]}
+        ]);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/advisories")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&batch).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let resp = app
+            .oneshot(Request::get("/advisories").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = body_string(resp).await;
+        assert!(body.contains("\"osv_id\":\"A\""));
+        assert!(body.contains("\"osv_id\":\"B\""));
+    }
+
+    // ---------- dispatch endpoints ----------
+
+    use std::sync::Mutex;
+
+    type RecordedCall = (String, Vec<(String, String)>, Vec<u8>);
+
+    struct RecordingClient {
+        calls: Mutex<Vec<RecordedCall>>,
+        status: u16,
+    }
+
+    impl crate::dispatch::WebhookClient for RecordingClient {
+        fn post(
+            &self,
+            url: &str,
+            headers: &[(String, String)],
+            body: &[u8],
+        ) -> std::result::Result<u16, String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((url.into(), headers.to_vec(), body.to_vec()));
+            Ok(self.status)
+        }
+    }
+
+    fn state_with_client(client: Arc<dyn crate::dispatch::WebhookClient>) -> AppState {
+        AppState {
+            store: Arc::new(Store::open_in_memory().unwrap()),
+            config: ServerConfig::default(),
+            webhook: client,
+            dispatch_lock: Arc::new(tokio::sync::Mutex::new(())),
+            oauth: None,
+            actions_verifier: None,
+        }
+    }
+
+    async fn seed_one_finding(st: &AppState) {
+        st.store
+            .insert(crate::store::IngestRecord {
+                event: InstallEvent::new(Ecosystem::Npm, "p", "1.0.0")
+                    .with_mode(ExecutionMode::Persistent)
+                    .with_project_path("/home/runner/work/r/r"),
+                source: None,
+            })
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-x",
+            "summary": "boom",
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "p"}, "versions": ["1.0.0"]}],
+        }))
+        .unwrap();
+        st.store.upsert_advisory(adv, None).await.unwrap();
+        st.store.scan_findings().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn target_create_then_dispatch_delivers_signed_post() {
+        let recorder = Arc::new(RecordingClient {
+            calls: Mutex::new(Vec::new()),
+            status: 202,
+        });
+        let st = state_with_client(recorder.clone());
+        let app = router(st.clone());
+        seed_one_finding(&st).await;
+
+        let body = serde_json::json!({
+            "label": "ops",
+            "url": "https://ops.example.com/hook",
+            "secret": "0123456789abcdef0123",
+            "min_severity": "high",
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/dispatch-targets")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = app
+            .clone()
+            .oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let report = body_string(resp).await;
+        assert!(report.contains("\"considered\":1"));
+        assert!(report.contains("\"delivered\":1"));
+
+        // Snapshot under the lock, then drop it before any further
+        // `.await` so clippy's `await_holding_lock` stays quiet.
+        let snapshot: Vec<RecordedCall> = recorder.calls.lock().unwrap().clone();
+        assert_eq!(snapshot.len(), 1);
+        let (url, headers, body_bytes) = &snapshot[0];
+        assert_eq!(url, "https://ops.example.com/hook");
+        let sig = headers
+            .iter()
+            .find(|(k, _)| k == "X-Sakimori-Signature")
+            .unwrap();
+        let recomputed = crate::dispatch::sign(b"0123456789abcdef0123", body_bytes);
+        assert_eq!(sig.1, recomputed);
+        let label_hdr = headers
+            .iter()
+            .find(|(k, _)| k == "X-Sakimori-Target")
+            .unwrap();
+        assert_eq!(label_hdr.1, "ops");
+
+        // Idempotency: second run produces zero deliveries.
+        let resp = app
+            .clone()
+            .oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let report = body_string(resp).await;
+        assert!(report.contains("\"considered\":0"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_non_2xx_records_failure_and_retries() {
+        let recorder = Arc::new(RecordingClient {
+            calls: Mutex::new(Vec::new()),
+            status: 500,
+        });
+        let st = state_with_client(recorder.clone());
+        let app = router(st.clone());
+        seed_one_finding(&st).await;
+        st.store
+            .register_target(crate::store::TargetSpec {
+                label: "t".into(),
+                url: "https://t/".into(),
+                secret: "0123456789abcdef0123".into(),
+                min_severity: Severity::Low,
+                source_filter: None,
+            })
+            .await
+            .unwrap();
+        // First run: one failure recorded.
+        let r1 = app
+            .clone()
+            .oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(body_string(r1).await.contains("\"failed\":1"));
+        // Second run: still pending (no success), so re-attempts.
+        let r2 = app
+            .clone()
+            .oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert!(body_string(r2).await.contains("\"considered\":1"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_dispatch_runs_do_not_double_fire() {
+        // Slow client that holds the call open long enough that a
+        // second `/dispatch/run` racing the first would re-pull
+        // the same pending row if the dispatch lock weren't doing
+        // its job.
+        struct SlowClient {
+            calls: Mutex<Vec<RecordedCall>>,
+        }
+        impl crate::dispatch::WebhookClient for SlowClient {
+            fn post(
+                &self,
+                url: &str,
+                headers: &[(String, String)],
+                body: &[u8],
+            ) -> std::result::Result<u16, String> {
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((url.into(), headers.to_vec(), body.to_vec()));
+                Ok(200)
+            }
+        }
+        let client = Arc::new(SlowClient {
+            calls: Mutex::new(Vec::new()),
+        });
+        let st = state_with_client(client.clone());
+        let app = router(st.clone());
+        seed_one_finding(&st).await;
+        st.store
+            .register_target(crate::store::TargetSpec {
+                label: "t".into(),
+                url: "https://t.example.com/".into(),
+                secret: "0123456789abcdef0123".into(),
+                min_severity: Severity::Low,
+                source_filter: None,
+            })
+            .await
+            .unwrap();
+
+        let app1 = app.clone();
+        let app2 = app.clone();
+        let h1 = tokio::spawn(async move {
+            app1.oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+                .await
+                .unwrap()
+        });
+        // Stagger slightly so the second request unambiguously arrives
+        // while the first is mid-flight.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let h2 = tokio::spawn(async move {
+            app2.oneshot(Request::post("/dispatch/run").body(Body::empty()).unwrap())
+                .await
+                .unwrap()
+        });
+        let _ = h1.await.unwrap();
+        let _ = h2.await.unwrap();
+
+        let calls = client.calls.lock().unwrap();
+        assert_eq!(
+            calls.len(),
+            1,
+            "dispatch lock must serialise concurrent runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn target_create_rejects_short_secret() {
+        let app = router(state());
+        let body = serde_json::json!({
+            "label": "ops",
+            "url": "https://ops.example/",
+            "secret": "tiny",
+            "min_severity": "high",
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/dispatch-targets")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ---------- bearer token ----------
+
+    fn state_with_token(token: &str) -> AppState {
+        AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                ingest_token: Some(token.into()),
+                // Disable Secure so tests can compose without a TLS terminator.
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        )
+    }
+
+    // ---------- GitHub OAuth (stub) ----------
+
+    struct StubExchange {
+        user: crate::auth::GitHubUser,
+    }
+    impl crate::auth::OAuthExchange for StubExchange {
+        fn exchange_code(
+            &self,
+            _code: &str,
+        ) -> std::result::Result<crate::auth::GitHubUser, crate::auth::GitHubAuthError> {
+            Ok(self.user.clone())
+        }
+    }
+
+    fn state_with_oauth(user: crate::auth::GitHubUser) -> AppState {
+        // Tests pre-allow whatever login the stub returns so the
+        // happy-path callbacks succeed. The "denied" test
+        // constructs its own state with an empty allowlist.
+        let login = user.login.to_ascii_lowercase();
+        let mut st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                ingest_token: Some("0123456789abcdef0123".into()),
+                session_secret: Some(b"server-secret-1234567890abcdef-xyz".to_vec()),
+                external_base_url: Some("https://hub.example.com".into()),
+                github_client_id: Some("client-abc".into()),
+                allowed_github_logins: vec![login],
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        st.oauth = Some(Arc::new(StubExchange { user }));
+        st
+    }
+
+    /// Pull the `Set-Cookie` value for `name` out of a response.
+    fn extract_set_cookie(resp: &Response, name: &str) -> Option<String> {
+        for h in resp.headers().get_all(http::header::SET_COOKIE).iter() {
+            let s = h.to_str().ok()?;
+            if let Some(rest) = s.strip_prefix(&format!("{name}=")) {
+                // value is up to the first `;`.
+                return Some(rest.split(';').next().unwrap_or("").to_string());
+            }
+        }
+        None
+    }
+
+    #[tokio::test]
+    async fn oauth_login_redirects_and_sets_state_cookie() {
+        let app = router(state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        }));
+        let resp = app
+            .oneshot(
+                Request::get("/auth/github/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let loc = resp
+            .headers()
+            .get(http::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(loc.starts_with("https://github.com/login/oauth/authorize?"));
+        assert!(loc.contains("client_id=client-abc"));
+        assert!(
+            loc.contains("redirect_uri=https%3A%2F%2Fhub.example.com%2Fauth%2Fgithub%2Fcallback")
+        );
+        let state_cookie = extract_set_cookie(&resp, OAUTH_STATE_COOKIE).unwrap();
+        assert!(!state_cookie.is_empty());
+        // The state cookie value must appear as the `state` query param.
+        let needle = format!("state={}", urlencoding::encode(&state_cookie));
+        assert!(loc.contains(&needle), "loc={loc} state={state_cookie}");
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_creates_session_on_state_match() {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 42,
+            login: "ada".into(),
+            name: Some("Ada Lovelace".into()),
+            avatar_url: None,
+        });
+        let app = router(st.clone());
+        // Step 1: /login to obtain the state cookie.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/auth/github/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let state_value = extract_set_cookie(&resp, OAUTH_STATE_COOKIE).unwrap();
+        // Step 2: /callback with the matching state.
+        let resp = app
+            .oneshot(
+                Request::get(format!(
+                    "/auth/github/callback?code=ignored&state={}",
+                    urlencoding::encode(&state_value),
+                ))
+                .header("cookie", format!("{OAUTH_STATE_COOKIE}={state_value}"))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let session_cookie = extract_set_cookie(&resp, SESSION_COOKIE_NAME).unwrap();
+        assert!(!session_cookie.is_empty());
+        // Session should resolve to the upserted user.
+        let secret = st.config.session_secret.as_deref().unwrap();
+        let parsed = crate::auth::verify_cookie(secret, &session_cookie).unwrap();
+        let user = st
+            .store
+            .session_user(parsed.token_hash)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(user.github_user_id, 42);
+        assert_eq!(user.github_login, "ada");
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_rejects_state_mismatch() {
+        let app = router(state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        }));
+        // Obtain a legitimate state cookie.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/auth/github/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let state_value = extract_set_cookie(&resp, OAUTH_STATE_COOKIE).unwrap();
+        // Use a *different* `state` query value — attacker drive-by.
+        let resp = app
+            .oneshot(
+                Request::get("/auth/github/callback?code=ignored&state=attacker-controlled")
+                    .header("cookie", format!("{OAUTH_STATE_COOKIE}={state_value}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_rejects_user_not_on_allowlist() {
+        // Operator allowlist = ["ada"], OAuth returns user "mallory".
+        let mut st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                session_secret: Some(b"server-secret-1234567890abcdef-xyz".to_vec()),
+                external_base_url: Some("https://hub.example.com".into()),
+                github_client_id: Some("client-abc".into()),
+                allowed_github_logins: vec!["ada".into()],
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        st.oauth = Some(Arc::new(StubExchange {
+            user: crate::auth::GitHubUser {
+                id: 99,
+                login: "mallory".into(),
+                name: None,
+                avatar_url: None,
+            },
+        }));
+        let app = router(st.clone());
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/auth/github/login")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let state_value = extract_set_cookie(&resp, OAUTH_STATE_COOKIE).unwrap();
+        let resp = app
+            .oneshot(
+                Request::get(format!(
+                    "/auth/github/callback?code=ignored&state={}",
+                    urlencoding::encode(&state_value),
+                ))
+                .header("cookie", format!("{OAUTH_STATE_COOKIE}={state_value}"))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        // No session row created.
+        assert!(extract_set_cookie(&resp, SESSION_COOKIE_NAME).is_none());
+    }
+
+    #[tokio::test]
+    async fn cookie_csrf_rejects_cross_site_origin() {
+        // Valid cookie + wrong Origin = 401 (CSRF defence).
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", s.cookie_value),
+                    )
+                    .header("origin", "https://attacker.example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn cookie_csrf_referer_prefix_bypass_is_rejected() {
+        // Regression: a naïve `referer.starts_with(base)` would
+        // accept `https://hub.example.com.attacker.tld/x` for
+        // `base = https://hub.example.com`. Require a `/`
+        // separator (or exact match).
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", s.cookie_value),
+                    )
+                    .header("referer", "https://hub.example.com.attacker.tld/x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "host suffix attack must NOT pass referer check"
+        );
+    }
+
+    #[tokio::test]
+    async fn cookie_csrf_rejects_missing_origin_and_referer() {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", s.cookie_value),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "cookie request without Origin or Referer must be refused"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_only_deploy_rejects_bearer_token() {
+        // session_secret set, ingest_token unset — operator wants
+        // OAuth only. A `Authorization: Bearer ...` request must
+        // NOT succeed, even with a syntactically valid header.
+        let st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                session_secret: Some(b"server-secret-1234567890abcdef-xyz".to_vec()),
+                external_base_url: Some("https://hub.example.com".into()),
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", "Bearer any-old-string-abcdef")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn session_cookie_unlocks_protected_endpoint() {
+        // Browser path: a valid session cookie should authorize
+        // `POST /scan` without an Authorization header.
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let user_id = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let session = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(user_id, session.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", session.cookie_value),
+                    )
+                    // Matching Origin satisfies the CSRF guard.
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid session cookie + matching Origin must satisfy the bearer-token gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_me_returns_user_when_signed_in() {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 7,
+            login: "linus".into(),
+            name: Some("Linus".into()),
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 7,
+                github_login: "linus".into(),
+                display_name: Some("Linus".into()),
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/auth/me")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", s.cookie_value),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("\"github_login\":\"linus\""));
+
+        // Without the cookie, 401.
+        let resp = app
+            .oneshot(Request::get("/auth/me").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ---------- actions oidc exchange ----------
+
+    struct StubActionsVerifier {
+        claims: Mutex<crate::auth::ActionsClaims>,
+        err: Mutex<Option<crate::auth::ActionsAuthError>>,
+    }
+
+    impl crate::auth::ActionsOidcVerifier for StubActionsVerifier {
+        fn verify(
+            &self,
+            _jwt: &str,
+        ) -> std::result::Result<crate::auth::ActionsClaims, crate::auth::ActionsAuthError>
+        {
+            if let Some(e) = self.err.lock().unwrap().take() {
+                return Err(e);
+            }
+            Ok(self.claims.lock().unwrap().clone())
+        }
+    }
+
+    fn state_with_actions(
+        repos: Vec<&str>,
+        audience: &str,
+        claims: crate::auth::ActionsClaims,
+    ) -> (AppState, Arc<StubActionsVerifier>) {
+        let verifier = Arc::new(StubActionsVerifier {
+            claims: Mutex::new(claims),
+            err: Mutex::new(None),
+        });
+        let mut st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                allowed_actions_repositories: repos.iter().map(|s| (*s).into()).collect(),
+                actions_oidc_audience: Some(audience.into()),
+                actions_token_ttl_secs: 900,
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        st.actions_verifier = Some(verifier.clone());
+        (st, verifier)
+    }
+
+    fn fresh_actions_claims(repo: &str, audience: &str) -> crate::auth::ActionsClaims {
+        crate::auth::ActionsClaims {
+            iss: crate::auth::GITHUB_ACTIONS_ISSUER.into(),
+            aud: audience.into(),
+            sub: format!("repo:{repo}:ref:refs/heads/main"),
+            repository: repo.into(),
+            repository_owner: repo.split('/').next().unwrap_or("").into(),
+            workflow: Some(".github/workflows/ci.yml".into()),
+            workflow_ref: None,
+            exp: chrono::Utc::now().timestamp() + 3600,
+        }
+    }
+
+    #[tokio::test]
+    async fn actions_exchange_mints_short_lived_token() {
+        let (st, _v) = state_with_actions(
+            vec!["org/repo"],
+            "https://hub.example.com",
+            fresh_actions_claims("org/repo", "https://hub.example.com"),
+        );
+        let app = router(st.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "stub"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let token = parsed["token"].as_str().unwrap();
+        assert!(token.starts_with("sha_"));
+        // record carries repository + expires_at
+        assert_eq!(parsed["record"]["repository"], "org/repo");
+    }
+
+    #[tokio::test]
+    async fn actions_exchange_rejects_repo_not_on_allowlist() {
+        let (st, _) = state_with_actions(
+            vec!["org/other"],
+            "https://hub.example.com",
+            fresh_actions_claims("org/repo", "https://hub.example.com"),
+        );
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "stub"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn actions_exchange_rejects_audience_mismatch() {
+        // Verifier returns claims with aud != configured.
+        let (st, _) = state_with_actions(
+            vec!["org/repo"],
+            "https://hub.example.com",
+            fresh_actions_claims("org/repo", "wrong-audience"),
+        );
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "stub"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn actions_exchange_disabled_when_no_repositories() {
+        let mut st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                actions_oidc_audience: Some("hub".into()),
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        let verifier: Arc<dyn crate::auth::ActionsOidcVerifier> = Arc::new(StubActionsVerifier {
+            claims: Mutex::new(fresh_actions_claims("org/repo", "hub")),
+            err: Mutex::new(None),
+        });
+        st.actions_verifier = Some(verifier);
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn actions_token_unlocks_protected_endpoint() {
+        let (st, _) = state_with_actions(
+            vec!["org/repo"],
+            "https://hub.example.com",
+            fresh_actions_claims("org/repo", "https://hub.example.com"),
+        );
+        let app = router(st.clone());
+        // Exchange.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "stub"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let token =
+            serde_json::from_str::<serde_json::Value>(&body_string(resp).await).unwrap()["token"]
+                .as_str()
+                .unwrap()
+                .to_string();
+        // Without ANY auth — must be 401 (proves the middleware
+        // isn't no-op'ing in an Actions-only deploy).
+        let resp = app
+            .clone()
+            .oneshot(Request::post("/scan").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Actions-only deploy must NOT leave writes ungated"
+        );
+        // With the minted sha_ token — 200.
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn actions_exchange_rejects_already_expired_jwt() {
+        let mut claims = fresh_actions_claims("org/repo", "hub");
+        claims.exp = chrono::Utc::now().timestamp() - 10;
+        let (st, _) = state_with_actions(vec!["org/repo"], "hub", claims);
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/actions/exchange")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"jwt": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ---------- personal api tokens ----------
+
+    /// Convenience: log a fresh user in (oauth stubbed) and
+    /// return `(state, cookie_header)` ready for `/api/tokens`.
+    // ---------- device authorization flow ----------
+
+    #[tokio::test]
+    async fn device_flow_end_to_end() {
+        let (st, cookie) = device_flow_signed_in().await;
+        let app = router(st);
+
+        // 1. CLI requests a device + user code.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/code")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "sakimori CLI ada"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let device_code = parsed["device_code"].as_str().unwrap().to_string();
+        let user_code = parsed["user_code"].as_str().unwrap().to_string();
+        assert!(
+            parsed["verification_uri"]
+                .as_str()
+                .unwrap()
+                .ends_with("/auth/device")
+        );
+        assert!(
+            parsed["verification_uri_complete"]
+                .as_str()
+                .unwrap()
+                .contains("code=")
+        );
+        assert_eq!(parsed["interval"], 5);
+
+        // 2. CLI polls — should be pending.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": &device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(body_string(resp).await.contains("authorization_pending"));
+
+        // 3. Operator browses to /auth/device with the code and clicks Approve.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/approve")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(format!(
+                        "user_code={}&decision=approve",
+                        urlencoding::encode(&user_code)
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(body_string(resp).await.contains("approved"));
+
+        // 4. CLI polls again — should get the cleartext token.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": &device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let token =
+            serde_json::from_str::<serde_json::Value>(&body_string(resp).await).unwrap()["token"]
+                .as_str()
+                .unwrap()
+                .to_string();
+        assert!(token.starts_with("shp_"));
+
+        // 5. Re-poll should be `expired_token` (one-shot).
+        let resp = app
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": &device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(body_string(resp).await.contains("expired_token"));
+    }
+
+    #[tokio::test]
+    async fn device_flow_deny_returns_access_denied() {
+        let (st, cookie) = device_flow_signed_in().await;
+        let app = router(st);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/code")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let device_code = parsed["device_code"].as_str().unwrap().to_string();
+        let user_code = parsed["user_code"].as_str().unwrap().to_string();
+        app.clone()
+            .oneshot(
+                Request::post("/auth/device/approve")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(format!(
+                        "user_code={}&decision=deny",
+                        urlencoding::encode(&user_code)
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let resp = app
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(body_string(resp).await.contains("access_denied"));
+    }
+
+    #[tokio::test]
+    async fn device_flow_slow_down_on_fast_poll() {
+        let (st, _cookie) = device_flow_signed_in().await;
+        let app = router(st);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/code")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let device_code = serde_json::from_str::<serde_json::Value>(&body_string(resp).await)
+            .unwrap()["device_code"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        // First poll: authorization_pending.
+        let r1 = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": &device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(body_string(r1).await.contains("authorization_pending"));
+        // Immediate second poll inside the 5s window: slow_down.
+        let r2 = app
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": &device_code}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(body_string(r2).await.contains("slow_down"));
+    }
+
+    #[tokio::test]
+    async fn device_flow_unknown_device_code_is_expired() {
+        let (st, _) = device_flow_signed_in().await;
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/device/token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"device_code": "garbage"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        assert!(body_string(resp).await.contains("expired_token"));
+    }
+
+    #[tokio::test]
+    async fn device_flow_get_page_works_without_origin_or_referer() {
+        // Regression: GET /auth/device must NOT require an
+        // Origin/Referer header — operators open the
+        // verification link from terminals, fresh tabs, or
+        // bookmarks, none of which set them. CSRF is only an
+        // issue on POSTs.
+        let (st, cookie) = device_flow_signed_in().await;
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::get("/auth/device")
+                    .header("cookie", &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn device_flow_approve_race_returns_400_when_already_consumed() {
+        // Same user_code approved twice (form-resubmit / race
+        // tab): the second POST must NOT pretend it succeeded.
+        let (st, cookie) = device_flow_signed_in().await;
+        let app = router(st);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/auth/device/code")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let user_code = parsed["user_code"].as_str().unwrap().to_string();
+        let approve_req = || {
+            Request::post("/auth/device/approve")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("cookie", &cookie)
+                .header("origin", "https://hub.example.com")
+                .body(Body::from(format!(
+                    "user_code={}&decision=approve",
+                    urlencoding::encode(&user_code)
+                )))
+                .unwrap()
+        };
+        // First click → ok.
+        let r1 = app.clone().oneshot(approve_req()).await.unwrap();
+        assert_eq!(r1.status(), StatusCode::OK);
+        // Second click on the same form (now the row is approved,
+        // not pending) → 400, not a fake "approved".
+        let r2 = app.oneshot(approve_req()).await.unwrap();
+        assert_eq!(r2.status(), StatusCode::BAD_REQUEST);
+        assert!(body_string(r2).await.contains("no longer pending"));
+    }
+
+    #[tokio::test]
+    async fn device_flow_code_requires_browser_oauth_configured() {
+        // No oauth on AppState → /auth/device/code 404s.
+        let st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                external_base_url: Some("https://hub.example.com".into()),
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        let app = router(st);
+        let resp = app
+            .oneshot(
+                Request::post("/auth/device/code")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Logged-in operator state used by the device-flow tests
+    /// above. Reuses `state_with_oauth` for the stub, then mints
+    /// a session for "ada".
+    async fn device_flow_signed_in() -> (AppState, String) {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let cookie = format!("{SESSION_COOKIE_NAME}={}", s.cookie_value);
+        (st, cookie)
+    }
+
+    async fn signed_in_state(login: &str) -> (AppState, String) {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 1,
+            login: login.into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 1,
+                github_login: login.into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let cookie = format!("{SESSION_COOKIE_NAME}={}", s.cookie_value);
+        (st, cookie)
+    }
+
+    #[tokio::test]
+    async fn personal_token_create_list_revoke_happy_path() {
+        let (st, cookie) = signed_in_state("ada").await;
+        let app = router(st.clone());
+
+        // Create.
+        let body = serde_json::json!({"label": "laptop-ci"});
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body_text = body_string(resp).await;
+        assert_eq!(status, StatusCode::OK, "create body: {body_text}");
+        let parsed: serde_json::Value = serde_json::from_str(&body_text).unwrap();
+        let token = parsed["token"].as_str().unwrap().to_string();
+        let id = parsed["record"]["id"].as_i64().unwrap();
+        assert!(token.starts_with("shp_"));
+        assert_eq!(parsed["record"]["label"], "laptop-ci");
+
+        // List shows it.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/tokens")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_string(resp).await;
+        assert!(body.contains("\"label\":\"laptop-ci\""));
+        // Cleartext token must NOT appear in the list response.
+        assert!(!body.contains(&token));
+
+        // Revoke (POST body for the id — see router comment).
+        let resp = app
+            .oneshot(
+                Request::post("/api/tokens/revoke")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"id": id})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn personal_token_authenticates_protected_endpoint() {
+        // The point of personal tokens: a CLI / Actions workflow
+        // hits `POST /scan` with `Authorization: Bearer shp_...`
+        // and gets in (no shared secret needed, no cookie needed).
+        let (st, cookie) = signed_in_state("ada").await;
+        let app = router(st.clone());
+        // Mint a token via the API.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "ci"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let token =
+            serde_json::from_str::<serde_json::Value>(&body_string(resp).await).unwrap()["token"]
+                .as_str()
+                .unwrap()
+                .to_string();
+        // Hit /scan with the token. No cookie. No Origin.
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn personal_token_revoked_token_is_rejected() {
+        let (st, cookie) = signed_in_state("ada").await;
+        let app = router(st.clone());
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let token = parsed["token"].as_str().unwrap().to_string();
+        let id = parsed["record"]["id"].as_i64().unwrap();
+        // Revoke directly via the store to keep the test focused
+        // on the middleware's behaviour for a stale token.
+        st.store.revoke_api_token(id, 1).await.unwrap();
+        let resp = app
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn personal_token_blocked_after_user_removed_from_allowlist() {
+        // Offboarding regression: a personal token minted by
+        // user "ada" must stop working as soon as "ada" leaves
+        // SAKIMORI_HUB_ALLOWED_GITHUB_LOGINS, even before each
+        // token is individually revoked.
+        let (st, cookie) = signed_in_state("ada").await;
+        let app = router(st.clone());
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let token =
+            serde_json::from_str::<serde_json::Value>(&body_string(resp).await).unwrap()["token"]
+                .as_str()
+                .unwrap()
+                .to_string();
+        // Token works while ada is on the allowlist.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Operator removes ada from the allowlist (simulate by
+        // building a fresh AppState reusing the same store).
+        let mut st2 = AppState::new(
+            st.store.clone(),
+            ServerConfig {
+                ingest_token: Some("0123456789abcdef0123".into()),
+                session_secret: Some(b"server-secret-1234567890abcdef-xyz".to_vec()),
+                external_base_url: Some("https://hub.example.com".into()),
+                github_client_id: Some("client-abc".into()),
+                allowed_github_logins: vec!["someone-else".into()],
+                cookie_secure: false,
+                ..ServerConfig::default()
+            },
+        );
+        st2.oauth = st.oauth.clone();
+        let app2 = router(st2);
+        let resp = app2
+            .oneshot(
+                Request::post("/scan")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "offboarded user's tokens must stop working without per-token revoke"
+        );
+    }
+
+    #[tokio::test]
+    async fn personal_token_endpoints_require_session_not_bearer() {
+        // Operator who only has the legacy shared secret must NOT
+        // be able to mint personal tokens (those are per-user).
+        let app = router(state_with_token("0123456789abcdef0123"));
+        let resp = app
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer 0123456789abcdef0123")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "x"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Without session_secret configured the tokens routes
+        // return 404 (the surface is unavailable), with it but
+        // no session 401. Either way: NOT 200.
+        assert_ne!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn personal_token_revoke_other_users_token_returns_404() {
+        // User A mints a token; user B tries to revoke it via id.
+        let (st_a, cookie_a) = signed_in_state("ada").await;
+        // Manually create a second user + their token in the
+        // same store, then build a session for them.
+        let uid_b = st_a
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 2,
+                github_login: "linus".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let secret = st_a.config.session_secret.as_deref().unwrap().to_vec();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st_a.store
+            .create_session(uid_b, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let cookie_b = format!("{SESSION_COOKIE_NAME}={}", s.cookie_value);
+        let app = router(st_a.clone());
+        // Ada mints.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/tokens")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie_a)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"label": "ada's"})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let id = parsed["record"]["id"].as_i64().unwrap();
+        // Linus tries to revoke Ada's token.
+        let resp = app
+            .oneshot(
+                Request::post("/api/tokens/revoke")
+                    .header("content-type", "application/json")
+                    .header("cookie", &cookie_b)
+                    .header("origin", "https://hub.example.com")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"id": id})).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Must be NOT FOUND, not NO_CONTENT — Linus has no
+        // visibility into Ada's tokens.
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn logout_revokes_session() {
+        let st = state_with_oauth(crate::auth::GitHubUser {
+            id: 3,
+            login: "ada".into(),
+            name: None,
+            avatar_url: None,
+        });
+        let secret = st.config.session_secret.as_deref().unwrap().to_vec();
+        let uid = st
+            .store
+            .upsert_user(crate::store::UpsertUserSpec {
+                github_user_id: 3,
+                github_login: "ada".into(),
+                display_name: None,
+                avatar_url: None,
+            })
+            .await
+            .unwrap();
+        let s = crate::auth::session::mint_session_token(&secret);
+        st.store
+            .create_session(uid, s.token_hash, 3600, None)
+            .await
+            .unwrap();
+        let app = router(st.clone());
+        let resp = app
+            .oneshot(
+                Request::post("/auth/logout")
+                    .header(
+                        "cookie",
+                        format!("{SESSION_COOKIE_NAME}={}", s.cookie_value),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert!(
+            st.store.session_user(s.token_hash).await.unwrap().is_none(),
+            "session must be revoked"
+        );
+    }
+
+    #[tokio::test]
+    async fn writes_require_bearer_token_when_configured() {
+        let app = router(state_with_token("0123456789abcdef0123"));
+        // No header → 401.
+        let ev = InstallEvent::new(Ecosystem::Npm, "p", "1");
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&ev).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Wrong token → 401.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer wrong-secret-abcdef")
+                    .body(Body::from(serde_json::to_vec(&ev).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Right token → 200.
+        let resp = app
+            .oneshot(
+                Request::post("/ingest")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer 0123456789abcdef0123")
+                    .body(Body::from(serde_json::to_vec(&ev).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn reads_are_gated_by_default_when_token_set() {
+        // Secure-by-default: a vanilla `wrangler deploy` to
+        // Cloudflare Containers must not leak inventory just
+        // because the operator forgot a `--public-reads` flag.
+        // Only `/healthz` stays open for probes.
+        let app = router(state_with_token("0123456789abcdef0123"));
+        for path in [
+            "/installs",
+            "/findings",
+            "/advisories",
+            "/dispatch-targets",
+            "/",
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(Request::get(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "{path} must require the bearer token by default"
+            );
+        }
+        let resp = app
+            .oneshot(Request::get("/healthz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "/healthz must always stay open for probes"
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_open_when_public_reads_opt_in() {
+        // Opt-in for operators who put Cloudflare Access (or
+        // equivalent) in front of the read surface.
+        let st = AppState::new(
+            Arc::new(Store::open_in_memory().unwrap()),
+            ServerConfig {
+                ingest_token: Some("0123456789abcdef0123".into()),
+                public_reads: true,
+                ..ServerConfig::default()
+            },
+        );
+        let app = router(st);
+        for path in [
+            "/healthz",
+            "/installs",
+            "/findings",
+            "/advisories",
+            "/dispatch-targets",
+            "/",
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(Request::get(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "{path} must be public");
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_target_delete_also_requires_token() {
+        // Catches a regression where adding a new write endpoint
+        // forgets to add it to the `protected` sub-router.
+        let app = router(state_with_token("0123456789abcdef0123"));
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .method(axum::http::Method::DELETE)
+                    .uri("/dispatch-targets/1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn target_delete_returns_404_when_missing() {
+        let app = router(state());
+        let resp = app
+            .oneshot(
+                Request::delete("/dispatch-targets/9999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn index_html_escapes_user_supplied_fields() {
+        let st = state();
+        let app = router(st.clone());
+        st.store
+            .insert(IngestRecord {
+                event: InstallEvent::new(Ecosystem::Npm, "<script>", "\"1\"&v")
+                    .with_project_path("</td><td>x"),
+                source: None,
+            })
+            .await
+            .unwrap();
+        let resp = app
+            .oneshot(Request::get("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("<table"));
+        // Every dangerous character is escaped in the rendered cells.
+        assert!(body.contains("&lt;script&gt;"));
+        assert!(body.contains("&quot;1&quot;&amp;v"));
+        assert!(body.contains("&lt;/td&gt;&lt;td&gt;x"));
+        // And the raw injection attempt does NOT appear as live markup.
+        assert!(!body.contains("<script>1"));
+    }
+}

--- a/crates/sakimori-hub/src/store.rs
+++ b/crates/sakimori-hub/src/store.rs
@@ -1,0 +1,3828 @@
+//! SQLite-backed install inventory.
+//!
+//! One row per `InstallEvent`. We do not de-duplicate at insert time
+//! — two distinct `npm install`s of the same `(name, version)` are
+//! two separate inventory events, both worth surfacing (different
+//! timestamps, possibly different project paths). De-duplication for
+//! the advisory-JOIN dispatcher will happen at query time.
+//!
+//! ## Connection model
+//!
+//! Single [`rusqlite::Connection`] behind a `Mutex`. SQLite's own
+//! per-process locking would let us hand out multiple connections,
+//! but the ingest rate is bounded by HTTP request volume — a single
+//! writer is plenty for the foreseeable team-size deploy target. We
+//! run the connection's blocking calls inside
+//! [`tokio::task::spawn_blocking`] so the tokio runtime stays
+//! responsive under load.
+//!
+//! ## Time representation
+//!
+//! `resolved_at` and `ingested_at` are stored **twice** per row:
+//!
+//! - `*_ms` (`INTEGER NOT NULL`) — epoch milliseconds, UTC. This is
+//!   the column used for `ORDER BY` and the `since` filter. Storing
+//!   as a fixed-width integer side-steps text-comparison hazards
+//!   (mixed offsets, missing/varying fractional seconds, `Z` vs
+//!   `+00:00`) and is what we add the time-range index on.
+//! - `*_text` (`TEXT NOT NULL`) — RFC3339 rendering of the same
+//!   instant, normalised to UTC at write time. Kept for human-
+//!   readable inspection of the DB and for the JSON read API,
+//!   which deserialises straight to [`chrono::DateTime<Utc>`].
+//!
+//! Both are written from the same `DateTime<Utc>` value so they can
+//! never disagree.
+//!
+//! ## Durability
+//!
+//! Pragmas are `journal_mode=WAL` + `synchronous=NORMAL`. Under
+//! crash/power loss the most-recent commit *may* be lost; longer
+//! WAL state remains safe. This is a deliberate trade-off for an
+//! inventory: one missed proxy-side event is a tiny gap in history
+//! the proxy can re-emit, while `synchronous=FULL` would dominate
+//! per-insert latency. Operators who need strict durability can
+//! flip the pragma via `PRAGMA synchronous=FULL` against the open
+//! file.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::types::Type as SqlType;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use tokio::sync::Mutex;
+
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+
+use crate::classify::{Source, classify};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredEvent {
+    pub id: i64,
+    pub ecosystem: String,
+    pub name: String,
+    pub version: String,
+    pub resolved_at: DateTime<Utc>,
+    pub execution_mode: ExecutionMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+    pub source: Source,
+    /// Wall-clock time the hub received the event. Distinct from
+    /// `resolved_at` (which is when the proxy resolved the fetch) so
+    /// a delayed batch upload of older events is detectable.
+    pub ingested_at: DateTime<Utc>,
+}
+
+/// An event submitted via the ingest API, paired with an optional
+/// explicit `source` override. When present the override wins over
+/// the heuristic classifier — the proxy knows its own runtime
+/// context more reliably than we can infer from `(project_path,
+/// user_agent)` alone.
+#[derive(Debug, Clone)]
+pub struct IngestRecord {
+    pub event: InstallEvent,
+    pub source: Option<Source>,
+}
+
+impl From<InstallEvent> for IngestRecord {
+    fn from(event: InstallEvent) -> Self {
+        Self {
+            event,
+            source: None,
+        }
+    }
+}
+
+/// Query filters for [`Store::list`]. All fields are AND-combined;
+/// `None` means "no filter on this axis".
+#[derive(Debug, Default, Clone)]
+pub struct ListFilter {
+    pub ecosystem: Option<String>,
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub source: Option<Source>,
+    pub since: Option<DateTime<Utc>>,
+    pub limit: Option<u32>,
+}
+
+#[derive(Clone)]
+pub struct Store {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl Store {
+    /// Open (and migrate, if needed) the SQLite file at `path`. Use
+    /// `":memory:"` for an ephemeral test store.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let conn = Connection::open(path)
+            .with_context(|| format!("opening sqlite at {}", path.display()))?;
+        Self::from_conn(conn)
+    }
+
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().context("opening in-memory sqlite")?;
+        Self::from_conn(conn)
+    }
+
+    fn from_conn(mut conn: Connection) -> Result<Self> {
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA foreign_keys = ON;",
+        )
+        .context("setting sqlite pragmas")?;
+        migrate(&mut conn)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Insert one event and return its assigned row id.
+    pub async fn insert(&self, record: IngestRecord) -> Result<i64> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            insert_blocking(&guard, &record)
+        })
+        .await
+        .context("spawn_blocking insert join")?
+    }
+
+    /// Atomic batch insert. All rows commit together or the
+    /// transaction is rolled back and no rows are visible. Returns
+    /// the assigned ids in input order.
+    pub async fn insert_many(&self, records: Vec<IngestRecord>) -> Result<Vec<i64>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = conn.blocking_lock();
+            let tx = guard.transaction().context("opening insert tx")?;
+            let mut ids = Vec::with_capacity(records.len());
+            for rec in &records {
+                ids.push(insert_blocking(&tx, rec)?);
+            }
+            tx.commit().context("committing insert tx")?;
+            Ok(ids)
+        })
+        .await
+        .context("spawn_blocking insert_many join")?
+    }
+
+    /// List events matching `filter`, newest `resolved_at` first.
+    pub async fn list(&self, filter: ListFilter) -> Result<Vec<StoredEvent>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            list_blocking(&guard, &filter)
+        })
+        .await
+        .context("spawn_blocking list join")?
+    }
+
+    /// Total row count — small, cheap helper for the HTML view.
+    pub async fn count(&self) -> Result<i64> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let n: i64 = guard
+                .query_row("SELECT COUNT(*) FROM installs", [], |r| r.get(0))
+                .context("counting installs")?;
+            Ok(n)
+        })
+        .await
+        .context("spawn_blocking count join")?
+    }
+
+    /// Current `schema_version` value. Exposed so the next slice
+    /// can guard its dispatcher against an unknown future schema.
+    pub async fn schema_version(&self) -> Result<i32> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let v: i32 = guard
+                .query_row("SELECT version FROM schema_version WHERE id = 1", [], |r| {
+                    r.get(0)
+                })
+                .context("reading schema_version")?;
+            Ok(v)
+        })
+        .await
+        .context("spawn_blocking schema_version join")?
+    }
+}
+
+const CURRENT_SCHEMA_VERSION: i32 = 9;
+
+/// Numbered migration registry. New entries append at the end and
+/// run inside a transaction; the `schema_version` row is then
+/// bumped. We keep it as an in-source `&[Migration]` rather than
+/// embedding SQL files so the compiler enforces that every shipped
+/// build carries every migration.
+struct Migration {
+    version: i32,
+    sql: &'static str,
+}
+
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        sql: "CREATE TABLE installs (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            ecosystem       TEXT NOT NULL,
+            name            TEXT NOT NULL,
+            version         TEXT NOT NULL,
+            resolved_at_ms  INTEGER NOT NULL,
+            resolved_at_text TEXT NOT NULL,
+            execution_mode  TEXT NOT NULL,
+            project_path    TEXT,
+            user_agent      TEXT,
+            source          TEXT NOT NULL,
+            ingested_at_ms  INTEGER NOT NULL,
+            ingested_at_text TEXT NOT NULL
+         );
+         CREATE INDEX idx_installs_eco_name_ver
+             ON installs(ecosystem, name, version);
+         CREATE INDEX idx_installs_resolved_at_ms
+             ON installs(resolved_at_ms);
+         CREATE INDEX idx_installs_source
+             ON installs(source);",
+    },
+    Migration {
+        version: 2,
+        sql: "CREATE TABLE advisories (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            osv_id          TEXT NOT NULL UNIQUE,
+            summary         TEXT,
+            severity        TEXT NOT NULL,
+            published_at_ms INTEGER,
+            raw_json        TEXT NOT NULL,
+            ingested_at_ms  INTEGER NOT NULL
+         );
+         CREATE TABLE advisory_affected (
+            advisory_id     INTEGER NOT NULL REFERENCES advisories(id) ON DELETE CASCADE,
+            ecosystem       TEXT NOT NULL,
+            name            TEXT NOT NULL,
+            version         TEXT NOT NULL,
+            PRIMARY KEY (advisory_id, ecosystem, name, version)
+         );
+         CREATE INDEX idx_advisory_affected_lookup
+             ON advisory_affected(ecosystem, name, version);
+         CREATE TABLE findings (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            advisory_id     INTEGER NOT NULL REFERENCES advisories(id) ON DELETE CASCADE,
+            install_id      INTEGER NOT NULL REFERENCES installs(id) ON DELETE CASCADE,
+            created_at_ms   INTEGER NOT NULL,
+            UNIQUE (advisory_id, install_id)
+         );
+         CREATE INDEX idx_findings_advisory   ON findings(advisory_id);
+         CREATE INDEX idx_findings_install    ON findings(install_id);
+         CREATE INDEX idx_findings_created_at ON findings(created_at_ms);",
+    },
+    Migration {
+        version: 3,
+        sql: "CREATE TABLE dispatch_targets (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            label           TEXT NOT NULL UNIQUE,
+            url             TEXT NOT NULL,
+            secret          TEXT NOT NULL,
+            min_severity    TEXT NOT NULL,
+            source_filter   TEXT,
+            enabled         INTEGER NOT NULL DEFAULT 1,
+            created_at_ms   INTEGER NOT NULL
+         );
+         CREATE TABLE dispatch_attempts (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            finding_id      INTEGER NOT NULL REFERENCES findings(id) ON DELETE CASCADE,
+            target_id       INTEGER NOT NULL REFERENCES dispatch_targets(id) ON DELETE CASCADE,
+            attempt_at_ms   INTEGER NOT NULL,
+            success         INTEGER NOT NULL,
+            http_status     INTEGER,
+            error           TEXT
+         );
+         CREATE INDEX idx_dispatch_attempts_lookup
+             ON dispatch_attempts(finding_id, target_id, success);
+         CREATE INDEX idx_dispatch_attempts_target
+             ON dispatch_attempts(target_id, attempt_at_ms);",
+    },
+    Migration {
+        version: 4,
+        sql: "ALTER TABLE dispatch_targets ADD COLUMN deleted_at_ms INTEGER;
+         -- Defence in depth against the application-level dedupe: even
+         -- if a future bug double-fires `record_attempt(.., true, ..)`,
+         -- the second insert hits this index and errors out instead of
+         -- silently double-counting a delivered finding.
+         CREATE UNIQUE INDEX idx_dispatch_attempts_success_unique
+             ON dispatch_attempts(finding_id, target_id) WHERE success = 1;",
+    },
+    Migration {
+        version: 5,
+        sql: "CREATE TABLE advisory_ranges (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            advisory_id      INTEGER NOT NULL REFERENCES advisories(id) ON DELETE CASCADE,
+            ecosystem        TEXT NOT NULL,
+            name             TEXT NOT NULL,
+            -- Interval is `[introduced, upper)` when
+            -- upper_inclusive=0 (came from a `fixed` / `limit`
+            -- close), `[introduced, upper]` when upper_inclusive=1
+            -- (came from `last_affected`). Storing the bound's
+            -- inclusivity lets the scanner use < vs <= rather
+            -- than fabricating an exclusive bound by bumping the
+            -- patch, which would over-match prereleases.
+            -- `upper` is NULL when the range is explicitly
+            -- unbounded above.
+            introduced       TEXT NOT NULL,
+            upper            TEXT,
+            upper_inclusive  INTEGER NOT NULL DEFAULT 0
+         );
+         CREATE INDEX idx_advisory_ranges_lookup
+             ON advisory_ranges(ecosystem, name);",
+    },
+    Migration {
+        version: 6,
+        sql: "CREATE TABLE users (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            github_user_id    INTEGER NOT NULL UNIQUE,
+            github_login      TEXT NOT NULL,
+            display_name      TEXT,
+            avatar_url        TEXT,
+            created_at_ms     INTEGER NOT NULL,
+            last_login_at_ms  INTEGER NOT NULL
+         );
+         CREATE INDEX idx_users_github_login ON users(github_login);
+         -- Sessions: we store a SHA-256 hash of the cookie value,
+         -- never the cleartext, so a DB dump can't impersonate
+         -- live users. The cookie itself is HMAC-signed
+         -- (see `crate::auth::session`) so even the hash lookup
+         -- requires a valid signature.
+         CREATE TABLE sessions (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            token_hash        BLOB NOT NULL UNIQUE,
+            user_id           INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at_ms     INTEGER NOT NULL,
+            expires_at_ms     INTEGER NOT NULL,
+            revoked_at_ms     INTEGER,
+            user_agent        TEXT
+         );
+         CREATE INDEX idx_sessions_user ON sessions(user_id);
+         CREATE INDEX idx_sessions_expires ON sessions(expires_at_ms);",
+    },
+    Migration {
+        version: 7,
+        sql: "CREATE TABLE api_tokens (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id           INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            -- Cleartext token never persisted; only its SHA-256
+            -- hash. A DB dump can revoke but not impersonate.
+            token_hash        BLOB NOT NULL UNIQUE,
+            -- First 12 chars of the cleartext token (including
+            -- the `shp_` prefix), so the list UI can show
+            -- `shp_AbCdEfGh…` for human recognition without ever
+            -- revealing the full secret again. NOT sensitive on
+            -- its own — even the full prefix is ~6 bytes of
+            -- entropy, far short of brute-forceable.
+            prefix            TEXT NOT NULL,
+            -- Operator-supplied human label (e.g. \"laptop-CI\",
+            -- \"github-actions-ci-bootstrap\").
+            label             TEXT NOT NULL,
+            created_at_ms     INTEGER NOT NULL,
+            -- Best-effort `last seen at` for the list UI. Updated
+            -- async on successful auth so request latency isn't
+            -- coupled to a DB write.
+            last_used_at_ms   INTEGER,
+            -- Optional expiry. NULL = never expires (operator
+            -- has to revoke explicitly).
+            expires_at_ms     INTEGER,
+            -- Set on revoke; NULL while active.
+            revoked_at_ms     INTEGER
+         );
+         CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);",
+    },
+    Migration {
+        version: 8,
+        sql: "CREATE TABLE actions_tokens (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            -- SHA-256 of the cleartext `sha_<...>` token; the
+            -- cleartext only lives in the workflow's memory and
+            -- never reaches the DB.
+            token_hash        BLOB NOT NULL UNIQUE,
+            -- First 12 chars (`sha_AbCdEfGh`) for the audit view.
+            -- Not sensitive on its own.
+            prefix            TEXT NOT NULL,
+            -- `org/repo` exactly as `repository` was in the OIDC
+            -- JWT. The `repository_owner`/`workflow_ref` columns
+            -- below are observability — the auth decision was
+            -- already taken when the token was minted, so they're
+            -- not load-bearing for middleware.
+            repository        TEXT NOT NULL,
+            repository_owner  TEXT NOT NULL,
+            workflow_ref      TEXT,
+            -- JWT `sub` claim, kept for audit (it encodes
+            -- environment / ref / pull-request context).
+            subject           TEXT NOT NULL,
+            created_at_ms     INTEGER NOT NULL,
+            -- Required for actions tokens — they are explicitly
+            -- short-lived, no \"forever\" path.
+            expires_at_ms     INTEGER NOT NULL,
+            last_used_at_ms   INTEGER,
+            revoked_at_ms     INTEGER
+         );
+         CREATE INDEX idx_actions_tokens_repository
+             ON actions_tokens(repository, created_at_ms DESC);",
+    },
+    Migration {
+        version: 9,
+        sql: "CREATE TABLE device_codes (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            -- Random 32-byte secret the CLI keeps. UNIQUE so a
+            -- duplicate collision (~astronomically unlikely with
+            -- 256 bits) becomes a loud DB error, not a silent
+            -- account-swap.
+            device_code       TEXT NOT NULL UNIQUE,
+            -- Short human-readable code the operator types in
+            -- the browser. UNIQUE constraint enforces the
+            -- one-active-code property — colliding mint retries
+            -- on the application side (see store::mint_device_code).
+            user_code         TEXT NOT NULL UNIQUE,
+            -- pending | approved | denied | consumed | expired
+            status            TEXT NOT NULL,
+            -- Operator-supplied label that gets carried onto the
+            -- minted api_tokens row at consume time.
+            label             TEXT NOT NULL,
+            -- Populated at approval time; the consume step mints
+            -- the personal token under this user.
+            approving_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+            -- Populated at consume time. After consume, this row
+            -- is dead weight — the polled CLI now holds the
+            -- cleartext token; subsequent polls see `consumed`.
+            consumed_token_id INTEGER REFERENCES api_tokens(id) ON DELETE SET NULL,
+            created_at_ms     INTEGER NOT NULL,
+            expires_at_ms     INTEGER NOT NULL,
+            -- Rate-limits the CLI's poll cadence — see the
+            -- store::lookup_device_code `slow_down` rule. NULL
+            -- before the first poll.
+            last_polled_at_ms INTEGER,
+            approved_at_ms    INTEGER,
+            consumed_at_ms    INTEGER
+         );
+         CREATE INDEX idx_device_codes_user_code ON device_codes(user_code);
+         CREATE INDEX idx_device_codes_expires  ON device_codes(expires_at_ms);",
+    },
+];
+
+fn migrate(conn: &mut Connection) -> Result<()> {
+    // schema_version is a CHECKed singleton so a manual repair or a
+    // half-applied migration can't leave two rows that race the
+    // "current version?" read. The CHECK clause does the work of
+    // a `UNIQUE`-on-1 + `NOT NULL` constraint in one line.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_version (
+             id            INTEGER PRIMARY KEY CHECK (id = 1),
+             version       INTEGER NOT NULL,
+             applied_at_ms INTEGER NOT NULL
+         );",
+    )
+    .context("creating schema_version table")?;
+
+    // Distinguish "no row yet" from "query errored". `.ok()` would
+    // silently swallow corruption / wrong-shape-table problems.
+    let current: Option<i32> = conn
+        .query_row("SELECT version FROM schema_version WHERE id = 1", [], |r| {
+            r.get(0)
+        })
+        .optional()
+        .context("reading schema_version")?;
+    let from = current.unwrap_or(0);
+    if from > CURRENT_SCHEMA_VERSION {
+        anyhow::bail!(
+            "schema_version {from} is newer than this binary supports ({CURRENT_SCHEMA_VERSION}); \
+             refusing to downgrade"
+        );
+    }
+
+    // Each migration + its schema_version bump runs inside one
+    // transaction. A crash before commit leaves the DB at the
+    // *previous* version, and `migrate()` on the next open retries
+    // the same migration cleanly.
+    for m in MIGRATIONS {
+        if m.version > from {
+            let tx = conn
+                .transaction()
+                .with_context(|| format!("opening tx for migration v{}", m.version))?;
+            tx.execute_batch(m.sql)
+                .with_context(|| format!("running migration v{}", m.version))?;
+            tx.execute(
+                "INSERT INTO schema_version (id, version, applied_at_ms) VALUES (1, ?1, ?2)
+                 ON CONFLICT(id) DO UPDATE SET version = excluded.version,
+                                               applied_at_ms = excluded.applied_at_ms",
+                params![m.version, Utc::now().timestamp_millis()],
+            )
+            .with_context(|| format!("bumping schema_version to v{}", m.version))?;
+            tx.commit()
+                .with_context(|| format!("committing migration v{}", m.version))?;
+        }
+    }
+    Ok(())
+}
+
+fn insert_blocking(conn: &Connection, record: &IngestRecord) -> Result<i64> {
+    let event = &record.event;
+    let source = record
+        .source
+        .unwrap_or_else(|| classify(event.project_path.as_deref(), event.user_agent.as_deref()));
+    let resolved_ms = event.resolved_at.timestamp_millis();
+    let ingested_at = Utc::now();
+    let ingested_ms = ingested_at.timestamp_millis();
+    conn.execute(
+        "INSERT INTO installs
+            (ecosystem, name, version,
+             resolved_at_ms, resolved_at_text,
+             execution_mode, project_path, user_agent, source,
+             ingested_at_ms, ingested_at_text)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        params![
+            event.ecosystem,
+            event.name,
+            event.version,
+            resolved_ms,
+            event.resolved_at.to_rfc3339(),
+            execution_mode_to_str(event.execution_mode),
+            event.project_path,
+            event.user_agent,
+            source.as_str(),
+            ingested_ms,
+            ingested_at.to_rfc3339(),
+        ],
+    )
+    .context("inserting install event")?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn list_blocking(conn: &Connection, filter: &ListFilter) -> Result<Vec<StoredEvent>> {
+    let mut sql = String::from(
+        "SELECT id, ecosystem, name, version,
+                resolved_at_ms, execution_mode, project_path, user_agent,
+                source, ingested_at_ms
+           FROM installs
+          WHERE 1=1",
+    );
+    let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(eco) = &filter.ecosystem {
+        sql.push_str(" AND ecosystem = ?");
+        binds.push(Box::new(eco.clone()));
+    }
+    if let Some(name) = &filter.name {
+        sql.push_str(" AND name = ?");
+        binds.push(Box::new(name.clone()));
+    }
+    if let Some(ver) = &filter.version {
+        sql.push_str(" AND version = ?");
+        binds.push(Box::new(ver.clone()));
+    }
+    if let Some(source) = filter.source {
+        sql.push_str(" AND source = ?");
+        binds.push(Box::new(source.as_str().to_string()));
+    }
+    if let Some(since) = filter.since {
+        sql.push_str(" AND resolved_at_ms >= ?");
+        binds.push(Box::new(since.timestamp_millis()));
+    }
+    sql.push_str(" ORDER BY resolved_at_ms DESC, id DESC");
+    let limit = filter.limit.unwrap_or(1000).min(10_000);
+    sql.push_str(" LIMIT ?");
+    binds.push(Box::new(limit as i64));
+
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = binds.iter().map(|b| b.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql).context("preparing list query")?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(bind_refs), row_to_event)
+        .context("executing list query")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("decoding install row")?);
+    }
+    Ok(out)
+}
+
+fn row_to_event(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredEvent> {
+    let resolved_ms: i64 = row.get(4)?;
+    let exec_mode: String = row.get(5)?;
+    let source: String = row.get(8)?;
+    let ingested_ms: i64 = row.get(9)?;
+    Ok(StoredEvent {
+        id: row.get(0)?,
+        ecosystem: row.get(1)?,
+        name: row.get(2)?,
+        version: row.get(3)?,
+        resolved_at: ms_to_utc(resolved_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, SqlType::Integer, e.into())
+        })?,
+        execution_mode: execution_mode_from_str(&exec_mode).ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                5,
+                SqlType::Text,
+                format!("unknown execution_mode {exec_mode}").into(),
+            )
+        })?,
+        project_path: row.get(6)?,
+        user_agent: row.get(7)?,
+        source: Source::parse(&source).ok_or_else(|| {
+            rusqlite::Error::FromSqlConversionFailure(
+                8,
+                SqlType::Text,
+                format!("unknown source {source}").into(),
+            )
+        })?,
+        ingested_at: ms_to_utc(ingested_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(9, SqlType::Integer, e.into())
+        })?,
+    })
+}
+
+fn ms_to_utc(ms: i64) -> Result<DateTime<Utc>> {
+    Utc.timestamp_millis_opt(ms)
+        .single()
+        .ok_or_else(|| anyhow::anyhow!("epoch ms {ms} out of range"))
+}
+
+fn execution_mode_to_str(m: ExecutionMode) -> &'static str {
+    match m {
+        ExecutionMode::Persistent => "persistent",
+        ExecutionMode::Ephemeral => "ephemeral",
+        ExecutionMode::Unknown => "unknown",
+    }
+}
+
+fn execution_mode_from_str(s: &str) -> Option<ExecutionMode> {
+    match s {
+        "persistent" => Some(ExecutionMode::Persistent),
+        "ephemeral" => Some(ExecutionMode::Ephemeral),
+        "unknown" => Some(ExecutionMode::Unknown),
+        _ => None,
+    }
+}
+
+// ---------------- advisory / findings ----------------
+
+use crate::advisories::{OsvAdvisory, Severity};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredAdvisory {
+    pub id: i64,
+    pub osv_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    pub severity: Severity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<DateTime<Utc>>,
+    pub ingested_at: DateTime<Utc>,
+    /// Number of `affected_versions` rows attached. Range-only
+    /// advisories will be zero here — see `affected_ranges_count`
+    /// for those.
+    pub affected_count: i64,
+    /// Number of `advisory_ranges` rows attached (SemVer ranges).
+    /// A non-zero value means the advisory can still produce
+    /// findings even when `affected_count` is zero.
+    pub affected_ranges_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredFinding {
+    pub id: i64,
+    pub created_at: DateTime<Utc>,
+    pub advisory: StoredAdvisory,
+    pub install: StoredEvent,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FindingFilter {
+    pub min_severity: Option<Severity>,
+    pub source: Option<Source>,
+    pub limit: Option<u32>,
+}
+
+/// Result of a scan pass — how much was JOINed and how many NEW
+/// `(advisory, install)` pairs landed (existing pairs are
+/// idempotent thanks to the `UNIQUE` constraint). `matching_mode`
+/// is a stable string identifying *how* the JOIN was decided so
+/// consumers don't mistake "no match" for "definitely not
+/// vulnerable" — currently `"exact_versions_and_semver_ranges"`,
+/// covering both `affected[].versions[]` literal matches and
+/// SemVer 2.0 `affected[].ranges[]` (npm + crates only; PyPI's
+/// PEP 440 and NuGet's variant are not yet evaluated).
+///
+/// ## Consistency model
+///
+/// `scan_findings` runs the entire `INSERT OR IGNORE ... SELECT
+/// JOIN` plus its surrounding count snapshots inside one SQLite
+/// transaction. Installs/advisories committed by other writers
+/// *after* the transaction opens won't be visible to this scan
+/// (they'll roll into the next one). `new_findings` therefore
+/// counts rows this scan created, not rows that exist in the
+/// table at wall-clock "now".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScanReport {
+    pub installs_scanned: i64,
+    pub advisories_considered: i64,
+    pub new_findings: i64,
+    pub total_findings: i64,
+    pub matching_mode: &'static str,
+}
+
+impl Default for ScanReport {
+    fn default() -> Self {
+        Self {
+            installs_scanned: 0,
+            advisories_considered: 0,
+            new_findings: 0,
+            total_findings: 0,
+            matching_mode: MATCHING_MODE,
+        }
+    }
+}
+
+/// Stable identifier for the JOIN strategy. Surfaced in scan
+/// responses and `/healthz` so consumers can branch on what kind
+/// of "no match" they're looking at.
+pub const MATCHING_MODE: &str = "exact_versions_and_semver_ranges";
+
+impl Store {
+    /// Upsert an advisory by its OSV id, optionally with the
+    /// literal incoming JSON bytes for audit/replay. When
+    /// `raw_json` is `None`, the store falls back to re-serialising
+    /// the parsed shape (which loses any fields outside the modelled
+    /// subset). Returns `(id, is_new)`.
+    pub async fn upsert_advisory(
+        &self,
+        adv: OsvAdvisory,
+        raw_json: Option<serde_json::Value>,
+    ) -> Result<(i64, bool)> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = conn.blocking_lock();
+            let tx = guard.transaction().context("opening advisory tx")?;
+            let result = upsert_advisory_blocking(&tx, &adv, raw_json.as_ref())?;
+            tx.commit().context("committing advisory tx")?;
+            Ok(result)
+        })
+        .await
+        .context("spawn_blocking upsert_advisory join")?
+    }
+
+    /// Bulk upsert. Each tuple is `(parsed_advisory, optional raw
+    /// incoming JSON)`. All rows commit in one transaction. Returns
+    /// `(created, refreshed)` counts.
+    pub async fn upsert_advisories(
+        &self,
+        advs: Vec<(OsvAdvisory, Option<serde_json::Value>)>,
+    ) -> Result<(usize, usize)> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = conn.blocking_lock();
+            let tx = guard.transaction().context("opening advisories tx")?;
+            let mut created = 0;
+            let mut refreshed = 0;
+            for (adv, raw) in &advs {
+                let (_, is_new) = upsert_advisory_blocking(&tx, adv, raw.as_ref())?;
+                if is_new {
+                    created += 1;
+                } else {
+                    refreshed += 1;
+                }
+            }
+            tx.commit().context("committing advisories tx")?;
+            Ok((created, refreshed))
+        })
+        .await
+        .context("spawn_blocking upsert_advisories join")?
+    }
+
+    /// JOIN installs × advisory_affected on
+    /// `(ecosystem, name, version)`. Inserts the matching pairs
+    /// into `findings` with `INSERT OR IGNORE`, so re-running scan
+    /// only adds the *new* matches that have appeared since last
+    /// pass. Cheap to run repeatedly.
+    pub async fn scan_findings(&self) -> Result<ScanReport> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = conn.blocking_lock();
+            let tx = guard.transaction().context("opening scan tx")?;
+            let installs_scanned: i64 =
+                tx.query_row("SELECT COUNT(*) FROM installs", [], |r| r.get(0))?;
+            let advisories_considered: i64 =
+                tx.query_row("SELECT COUNT(*) FROM advisories", [], |r| r.get(0))?;
+            let before: i64 = tx.query_row("SELECT COUNT(*) FROM findings", [], |r| r.get(0))?;
+            // Phase A: exact-version JOIN. `INSERT OR IGNORE`
+            // keeps it idempotent against the `UNIQUE(advisory_id,
+            // install_id)` constraint, so re-scans are cheap.
+            let now_ms = Utc::now().timestamp_millis();
+            tx.execute(
+                "INSERT OR IGNORE INTO findings (advisory_id, install_id, created_at_ms)
+                 SELECT aff.advisory_id, i.id, ?1
+                   FROM installs i
+                   JOIN advisory_affected aff
+                     ON aff.ecosystem = i.ecosystem
+                    AND aff.name      = i.name
+                    AND aff.version   = i.version",
+                params![now_ms],
+            )
+            .context("running exact-version JOIN insert")?;
+            // Phase B: SemVer range JOIN. SQLite can't evaluate
+            // semver comparisons natively, so we pull the (range,
+            // install) candidates pre-filtered to matching
+            // (ecosystem, name) and decide membership in Rust.
+            // Bounded by the *index* on advisory_ranges so we
+            // don't materialise the cartesian product.
+            range_match_insert(&tx, now_ms)?;
+            let after: i64 = tx.query_row("SELECT COUNT(*) FROM findings", [], |r| r.get(0))?;
+            tx.commit().context("committing scan tx")?;
+            Ok(ScanReport {
+                installs_scanned,
+                advisories_considered,
+                new_findings: after - before,
+                total_findings: after,
+                matching_mode: MATCHING_MODE,
+            })
+        })
+        .await
+        .context("spawn_blocking scan_findings join")?
+    }
+
+    pub async fn list_advisories(&self, limit: Option<u32>) -> Result<Vec<StoredAdvisory>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let limit = limit.unwrap_or(1000).min(10_000) as i64;
+            let mut stmt = guard
+                .prepare(
+                    "SELECT a.id, a.osv_id, a.summary, a.severity, a.published_at_ms,
+                            a.ingested_at_ms,
+                            (SELECT COUNT(*) FROM advisory_affected WHERE advisory_id = a.id),
+                            (SELECT COUNT(*) FROM advisory_ranges   WHERE advisory_id = a.id)
+                       FROM advisories a
+                       ORDER BY a.ingested_at_ms DESC, a.id DESC
+                       LIMIT ?1",
+                )
+                .context("preparing list_advisories")?;
+            let rows = stmt
+                .query_map(params![limit], row_to_advisory)
+                .context("executing list_advisories")?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.context("decoding advisory row")?);
+            }
+            Ok(out)
+        })
+        .await
+        .context("spawn_blocking list_advisories join")?
+    }
+
+    pub async fn list_findings(&self, filter: FindingFilter) -> Result<Vec<StoredFinding>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            list_findings_blocking(&guard, &filter)
+        })
+        .await
+        .context("spawn_blocking list_findings join")?
+    }
+}
+
+/// Field-length caps. Out of an abundance of caution we trim the
+/// upper bound of any single advisory field to keep a single
+/// malicious payload from amplifying into a multi-MB row. The
+/// numbers are deliberately generous (the 1 MiB body limit is the
+/// hard ceiling) but tight enough that an attacker can't stuff a
+/// 900 KiB summary into one row.
+const MAX_OSV_ID_LEN: usize = 256;
+const MAX_ECOSYSTEM_LEN: usize = 64;
+const MAX_NAME_LEN: usize = 256;
+const MAX_VERSION_LEN: usize = 256;
+const MAX_SUMMARY_LEN: usize = 8192;
+const MAX_AFFECTED_ROWS: usize = 10_000;
+
+/// Surface validation failures separately from storage errors so
+/// the HTTP layer can map them to `400` instead of `500`.
+#[derive(Debug, thiserror::Error)]
+pub enum AdvisoryValidationError {
+    #[error("advisory id is empty")]
+    EmptyId,
+    #[error("advisory id exceeds {MAX_OSV_ID_LEN} chars")]
+    OsvIdTooLong,
+    #[error("advisory summary exceeds {MAX_SUMMARY_LEN} chars")]
+    SummaryTooLong,
+    #[error("advisory has {0} affected versions (cap {MAX_AFFECTED_ROWS})")]
+    TooManyAffected(usize),
+    #[error("affected.ecosystem exceeds {MAX_ECOSYSTEM_LEN} chars")]
+    EcosystemTooLong,
+    #[error("affected.name length out of range (1..={MAX_NAME_LEN})")]
+    NameOutOfRange,
+    #[error("affected.version length out of range (1..={MAX_VERSION_LEN})")]
+    VersionOutOfRange,
+}
+
+pub fn validate_advisory(adv: &OsvAdvisory) -> std::result::Result<(), AdvisoryValidationError> {
+    validate_advisory_inner(adv)
+}
+
+fn validate_advisory_inner(adv: &OsvAdvisory) -> std::result::Result<(), AdvisoryValidationError> {
+    if adv.id.is_empty() {
+        return Err(AdvisoryValidationError::EmptyId);
+    }
+    if adv.id.len() > MAX_OSV_ID_LEN {
+        return Err(AdvisoryValidationError::OsvIdTooLong);
+    }
+    if let Some(s) = &adv.summary
+        && s.len() > MAX_SUMMARY_LEN
+    {
+        return Err(AdvisoryValidationError::SummaryTooLong);
+    }
+    let avs = adv.affected_versions();
+    let ars = adv.affected_ranges();
+    // Total = exact rows + range rows. A range-only advisory
+    // that ships 50k bounded intervals would otherwise sneak past
+    // the cap because it has zero exact `versions[]`.
+    let total = avs.len().saturating_add(ars.len());
+    if total > MAX_AFFECTED_ROWS {
+        return Err(AdvisoryValidationError::TooManyAffected(total));
+    }
+    for av in &avs {
+        if av.ecosystem.len() > MAX_ECOSYSTEM_LEN {
+            return Err(AdvisoryValidationError::EcosystemTooLong);
+        }
+        if av.name.is_empty() || av.name.len() > MAX_NAME_LEN {
+            return Err(AdvisoryValidationError::NameOutOfRange);
+        }
+        if av.version.is_empty() || av.version.len() > MAX_VERSION_LEN {
+            return Err(AdvisoryValidationError::VersionOutOfRange);
+        }
+    }
+    for ar in &ars {
+        if ar.ecosystem.len() > MAX_ECOSYSTEM_LEN {
+            return Err(AdvisoryValidationError::EcosystemTooLong);
+        }
+        if ar.name.is_empty() || ar.name.len() > MAX_NAME_LEN {
+            return Err(AdvisoryValidationError::NameOutOfRange);
+        }
+    }
+    Ok(())
+}
+
+/// App-side range matcher. Runs after the SQL exact-version JOIN
+/// inside `scan_findings`. The flow is:
+///
+/// 1. Read every `(advisory_id, ecosystem, name, introduced,
+///    fixed)` from `advisory_ranges` (one SQL pass, bounded by
+///    the index lookup `(ecosystem, name)` on the install side).
+/// 2. For each install whose `(ecosystem, name)` has at least one
+///    range, parse the install version and test membership.
+/// 3. Insert matches into `findings` via the same
+///    `INSERT OR IGNORE` so the partial unique index keeps it
+///    idempotent against the exact-version path.
+///
+/// Versions that fail to parse on either side are silently
+/// skipped (logged at `trace`) — we'd rather under-detect than
+/// fabricate a match.
+fn range_match_insert(tx: &rusqlite::Transaction<'_>, now_ms: i64) -> Result<()> {
+    // Pull only the (eco, name) pairs that any range targets, plus
+    // the matching installs in one go. JOIN happens in SQL on the
+    // cheap text-equality keys; the semver compare happens in
+    // Rust on the small filtered set.
+    let mut stmt = tx
+        .prepare(
+            "SELECT r.advisory_id, r.introduced, r.upper, r.upper_inclusive,
+                    i.id, i.version
+               FROM advisory_ranges r
+               JOIN installs i
+                 ON i.ecosystem = r.ecosystem
+                AND i.name      = r.name",
+        )
+        .context("preparing range_match query")?;
+    let mut rows = stmt.query([]).context("executing range_match query")?;
+    // Re-use one prepared INSERT across all candidate rows.
+    let mut ins = tx
+        .prepare(
+            "INSERT OR IGNORE INTO findings (advisory_id, install_id, created_at_ms)
+             VALUES (?1, ?2, ?3)",
+        )
+        .context("preparing range_match insert")?;
+    while let Some(row) = rows.next().context("walking range_match candidates")? {
+        let advisory_id: i64 = row.get(0)?;
+        let introduced_s: String = row.get(1)?;
+        let upper_s: Option<String> = row.get(2)?;
+        let upper_inclusive: i64 = row.get(3)?;
+        let install_id: i64 = row.get(4)?;
+        let version_s: String = row.get(5)?;
+        if !version_in_range(
+            &version_s,
+            &introduced_s,
+            upper_s.as_deref(),
+            upper_inclusive != 0,
+        ) {
+            continue;
+        }
+        ins.execute(params![advisory_id, install_id, now_ms])
+            .context("inserting range-match finding")?;
+    }
+    Ok(())
+}
+
+/// Shared membership predicate so the scan and the prune apply
+/// the same inclusivity rules. Returns `false` when *anything*
+/// fails to parse — that's the conservative "no match" stance the
+/// matcher promises.
+fn version_in_range(
+    version: &str,
+    introduced: &str,
+    upper: Option<&str>,
+    upper_inclusive: bool,
+) -> bool {
+    let Ok(v) = semver::Version::parse(version) else {
+        return false;
+    };
+    let Ok(intro) = semver::Version::parse(introduced) else {
+        return false;
+    };
+    if v < intro {
+        return false;
+    }
+    if let Some(upper_s) = upper {
+        let Ok(upper) = semver::Version::parse(upper_s) else {
+            return false;
+        };
+        if upper_inclusive {
+            if v > upper {
+                return false;
+            }
+        } else if v >= upper {
+            return false;
+        }
+    }
+    true
+}
+
+fn upsert_advisory_blocking(
+    tx: &rusqlite::Transaction<'_>,
+    adv: &OsvAdvisory,
+    raw_json: Option<&serde_json::Value>,
+) -> Result<(i64, bool)> {
+    // Defence in depth — the server pre-validates, but if a future
+    // caller forgets, we still reject before touching disk.
+    validate_advisory(adv).map_err(anyhow::Error::from)?;
+    let severity = adv.severity().as_str();
+    // Prefer the literal incoming bytes so future parser
+    // improvements can re-derive fields (e.g. SEMVER range
+    // matching) without re-fetching from OSV. Fall back to a
+    // re-serialised projection when the caller didn't have the
+    // original — documented in the public method as a lossy mode.
+    let raw = match raw_json {
+        Some(v) => serde_json::to_string(v).context("serialising raw advisory JSON")?,
+        None => serde_json::to_string(&serde_advisory_for_storage(adv))
+            .context("re-serialising advisory for storage")?,
+    };
+    let published_at_ms = adv.published.map(|d| d.timestamp_millis());
+    let ingested_at_ms = Utc::now().timestamp_millis();
+    let existing: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM advisories WHERE osv_id = ?1",
+            params![adv.id],
+            |r| r.get(0),
+        )
+        .optional()
+        .context("looking up existing advisory")?;
+    let (id, is_new) = match existing {
+        Some(id) => {
+            tx.execute(
+                "UPDATE advisories
+                    SET summary = ?1,
+                        severity = ?2,
+                        published_at_ms = ?3,
+                        raw_json = ?4,
+                        ingested_at_ms = ?5
+                  WHERE id = ?6",
+                params![
+                    adv.summary,
+                    severity,
+                    published_at_ms,
+                    raw,
+                    ingested_at_ms,
+                    id
+                ],
+            )
+            .context("updating advisory")?;
+            // Replace affected rows + ranges: cheaper and clearer
+            // than computing a diff, and the (advisory, eco, name,
+            // ver) PK keeps it small.
+            tx.execute(
+                "DELETE FROM advisory_affected WHERE advisory_id = ?1",
+                params![id],
+            )
+            .context("clearing prior affected rows")?;
+            tx.execute(
+                "DELETE FROM advisory_ranges WHERE advisory_id = ?1",
+                params![id],
+            )
+            .context("clearing prior advisory ranges")?;
+            (id, false)
+        }
+        None => {
+            tx.execute(
+                "INSERT INTO advisories
+                    (osv_id, summary, severity, published_at_ms, raw_json, ingested_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    adv.id,
+                    adv.summary,
+                    severity,
+                    published_at_ms,
+                    raw,
+                    ingested_at_ms
+                ],
+            )
+            .context("inserting advisory")?;
+            (tx.last_insert_rowid(), true)
+        }
+    };
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT OR IGNORE INTO advisory_affected
+                    (advisory_id, ecosystem, name, version)
+                 VALUES (?1, ?2, ?3, ?4)",
+            )
+            .context("preparing affected insert")?;
+        for av in adv.affected_versions() {
+            stmt.execute(params![id, av.ecosystem, av.name, av.version])
+                .context("inserting affected row")?;
+        }
+    }
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO advisory_ranges
+                    (advisory_id, ecosystem, name, introduced, upper, upper_inclusive)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .context("preparing range insert")?;
+        for r in adv.affected_ranges() {
+            stmt.execute(params![
+                id,
+                r.ecosystem,
+                r.name,
+                r.introduced.to_string(),
+                r.upper.as_ref().map(|v| v.to_string()),
+                if r.upper_inclusive { 1 } else { 0 },
+            ])
+            .context("inserting advisory range row")?;
+        }
+    }
+    // Prune stale findings: for this advisory, drop any finding
+    // whose install no longer matches under the *refreshed*
+    // affected set (exact-version OR semver range). This keeps
+    // `findings` honest about "what would the current rules say?"
+    // when a publisher narrows their advisory. Notification
+    // history (whether we already *delivered* a finding) lives
+    // in `dispatch_attempts` and is protected by the
+    // `UNIQUE WHERE success=1` index, so pruning here does not
+    // re-fire alerts that already went out.
+    prune_stale_findings_for_advisory(tx, id)?;
+    Ok((id, is_new))
+}
+
+/// Walk every finding currently attached to `advisory_id`; drop
+/// the ones whose install doesn't satisfy the refreshed
+/// affected/range set. Done in Rust rather than pure SQL because
+/// the range check needs `semver::Version` comparison.
+fn prune_stale_findings_for_advisory(
+    tx: &rusqlite::Transaction<'_>,
+    advisory_id: i64,
+) -> Result<()> {
+    // Read current ranges into memory once.
+    let mut range_stmt = tx
+        .prepare(
+            "SELECT ecosystem, name, introduced, upper, upper_inclusive
+               FROM advisory_ranges
+              WHERE advisory_id = ?1",
+        )
+        .context("preparing prune range read")?;
+    let ranges: Vec<(String, String, String, Option<String>, i64)> = range_stmt
+        .query_map(params![advisory_id], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })
+        .context("executing prune range read")?
+        .collect::<rusqlite::Result<_>>()
+        .context("decoding prune range rows")?;
+    // Walk findings + their installs.
+    let mut fstmt = tx
+        .prepare(
+            "SELECT f.id, i.ecosystem, i.name, i.version
+               FROM findings f
+               JOIN installs i ON i.id = f.install_id
+              WHERE f.advisory_id = ?1",
+        )
+        .context("preparing prune findings read")?;
+    let findings: Vec<(i64, String, String, String)> = fstmt
+        .query_map(params![advisory_id], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+        })
+        .context("executing prune findings read")?
+        .collect::<rusqlite::Result<_>>()
+        .context("decoding prune findings rows")?;
+    let mut del = tx
+        .prepare("DELETE FROM findings WHERE id = ?1")
+        .context("preparing prune findings delete")?;
+    for (fid, eco, name, version) in findings {
+        // Exact-version match?
+        let exact: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM advisory_affected
+                  WHERE advisory_id = ?1
+                    AND ecosystem  = ?2
+                    AND name       = ?3
+                    AND version    = ?4",
+                params![advisory_id, eco, name, version],
+                |r| r.get(0),
+            )
+            .context("counting exact match in prune")?;
+        if exact > 0 {
+            continue;
+        }
+        // Range match? Reuse the same inclusivity-aware predicate
+        // as scan_findings so prune and scan can never disagree.
+        let in_range = ranges
+            .iter()
+            .filter(|(e, n, _, _, _)| e == &eco && n == &name)
+            .any(|(_, _, intro_s, upper_s, upper_inclusive)| {
+                version_in_range(&version, intro_s, upper_s.as_deref(), *upper_inclusive != 0)
+            });
+        if !in_range {
+            del.execute(params![fid])
+                .context("deleting stale finding")?;
+        }
+    }
+    Ok(())
+}
+
+/// Lossy fallback used **only** when `upsert_advisory` is called
+/// without the original incoming JSON value. Re-shapes the parsed
+/// `OsvAdvisory` into a JSON projection covering just the modelled
+/// fields. The HTTP `POST /advisories` handler always supplies the
+/// original `serde_json::Value` so unmodelled OSV fields survive
+/// the round-trip; this helper is only reached by callers that
+/// genuinely don't have the source bytes (e.g. tests, future
+/// internal sync paths).
+fn serde_advisory_for_storage(adv: &OsvAdvisory) -> serde_json::Value {
+    serde_json::json!({
+        "id": adv.id,
+        "summary": adv.summary,
+        "published": adv.published,
+        "severity": adv.severity().as_str(),
+        "affected_versions": adv.affected_versions().iter().map(|v| {
+            serde_json::json!({"ecosystem": v.ecosystem, "name": v.name, "version": v.version})
+        }).collect::<Vec<_>>(),
+        "affected_ranges": adv.affected_ranges().iter().map(|r| {
+            serde_json::json!({
+                "ecosystem": r.ecosystem,
+                "name": r.name,
+                "introduced": r.introduced.to_string(),
+                "upper": r.upper.as_ref().map(|v| v.to_string()),
+                "upper_inclusive": r.upper_inclusive,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn row_to_advisory(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredAdvisory> {
+    let severity: String = row.get(3)?;
+    let published_at_ms: Option<i64> = row.get(4)?;
+    let ingested_at_ms: i64 = row.get(5)?;
+    let affected_count: i64 = row.get(6)?;
+    let affected_ranges_count: i64 = row.get(7)?;
+    Ok(StoredAdvisory {
+        id: row.get(0)?,
+        osv_id: row.get(1)?,
+        summary: row.get(2)?,
+        severity: Severity::parse(&severity).unwrap_or(Severity::Unknown),
+        published_at: match published_at_ms {
+            Some(ms) => Some(ms_to_utc(ms).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(4, SqlType::Integer, e.into())
+            })?),
+            None => None,
+        },
+        ingested_at: ms_to_utc(ingested_at_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(5, SqlType::Integer, e.into())
+        })?,
+        affected_count,
+        affected_ranges_count,
+    })
+}
+
+fn list_findings_blocking(conn: &Connection, filter: &FindingFilter) -> Result<Vec<StoredFinding>> {
+    let limit = filter.limit.unwrap_or(1000).min(10_000) as i64;
+    let mut sql = String::from(
+        "SELECT f.id, f.created_at_ms,
+                a.id, a.osv_id, a.summary, a.severity, a.published_at_ms, a.ingested_at_ms,
+                (SELECT COUNT(*) FROM advisory_affected WHERE advisory_id = a.id),
+                (SELECT COUNT(*) FROM advisory_ranges   WHERE advisory_id = a.id),
+                i.id, i.ecosystem, i.name, i.version, i.resolved_at_ms, i.execution_mode,
+                i.project_path, i.user_agent, i.source, i.ingested_at_ms
+           FROM findings f
+           JOIN advisories a ON a.id = f.advisory_id
+           JOIN installs   i ON i.id = f.install_id
+          WHERE 1=1",
+    );
+    let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(source) = filter.source {
+        sql.push_str(" AND i.source = ?");
+        binds.push(Box::new(source.as_str().to_string()));
+    }
+    // Push severity filtering into SQL so it applies *before* the
+    // ORDER BY/LIMIT — a Rust-side filter would skip older
+    // high-severity findings whenever they sat behind a page of
+    // newer low-severity rows.
+    if let Some(min) = filter.min_severity {
+        sql.push_str(
+            " AND (CASE a.severity \
+                       WHEN 'critical' THEN 4 \
+                       WHEN 'high'     THEN 3 \
+                       WHEN 'moderate' THEN 2 \
+                       WHEN 'low'      THEN 1 \
+                       ELSE 0 END) >= ?",
+        );
+        binds.push(Box::new(severity_rank(min) as i64));
+    }
+    sql.push_str(" ORDER BY f.created_at_ms DESC, f.id DESC LIMIT ?");
+    binds.push(Box::new(limit));
+    let bind_refs: Vec<&dyn rusqlite::ToSql> = binds.iter().map(|b| b.as_ref()).collect();
+    let mut stmt = conn.prepare(&sql).context("preparing list_findings")?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(bind_refs), |row| {
+            let created_at_ms: i64 = row.get(1)?;
+            let adv_severity: String = row.get(5)?;
+            let adv_published: Option<i64> = row.get(6)?;
+            let adv_ingested: i64 = row.get(7)?;
+            let install = StoredEvent {
+                id: row.get(10)?,
+                ecosystem: row.get(11)?,
+                name: row.get(12)?,
+                version: row.get(13)?,
+                resolved_at: ms_to_utc(row.get::<_, i64>(14)?).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(14, SqlType::Integer, e.into())
+                })?,
+                execution_mode: execution_mode_from_str(&row.get::<_, String>(15)?).ok_or_else(
+                    || {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            15,
+                            SqlType::Text,
+                            "unknown execution_mode".into(),
+                        )
+                    },
+                )?,
+                project_path: row.get(16)?,
+                user_agent: row.get(17)?,
+                source: Source::parse(&row.get::<_, String>(18)?).ok_or_else(|| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        18,
+                        SqlType::Text,
+                        "unknown source".into(),
+                    )
+                })?,
+                ingested_at: ms_to_utc(row.get::<_, i64>(19)?).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(19, SqlType::Integer, e.into())
+                })?,
+            };
+            let affected_count: i64 = row.get(8)?;
+            let affected_ranges_count: i64 = row.get(9)?;
+            Ok(StoredFinding {
+                id: row.get(0)?,
+                created_at: ms_to_utc(created_at_ms).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(1, SqlType::Integer, e.into())
+                })?,
+                advisory: StoredAdvisory {
+                    id: row.get(2)?,
+                    osv_id: row.get(3)?,
+                    summary: row.get(4)?,
+                    severity: Severity::parse(&adv_severity).unwrap_or(Severity::Unknown),
+                    published_at: match adv_published {
+                        Some(ms) => Some(ms_to_utc(ms).map_err(|e| {
+                            rusqlite::Error::FromSqlConversionFailure(6, SqlType::Integer, e.into())
+                        })?),
+                        None => None,
+                    },
+                    ingested_at: ms_to_utc(adv_ingested).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(7, SqlType::Integer, e.into())
+                    })?,
+                    affected_count,
+                    affected_ranges_count,
+                },
+                install,
+            })
+        })
+        .context("executing list_findings")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("decoding finding row")?);
+    }
+    Ok(out)
+}
+
+fn severity_rank(s: Severity) -> i32 {
+    match s {
+        Severity::Critical => 4,
+        Severity::High => 3,
+        Severity::Moderate => 2,
+        Severity::Low => 1,
+        Severity::Unknown => 0,
+    }
+}
+
+// ---------------- dispatch targets / pending deliveries ----------------
+
+/// Operator-supplied target spec for registration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TargetSpec {
+    pub label: String,
+    pub url: String,
+    pub secret: String,
+    pub min_severity: Severity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_filter: Option<Source>,
+}
+
+/// Stored target as returned by `list_targets`. We deliberately
+/// *redact* the secret on read so a leaked DB dump and a leaked
+/// `/dispatch-targets` response don't expose the same field —
+/// operators looking it up should fetch from the DB directly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredTarget {
+    pub id: i64,
+    pub label: String,
+    pub url: String,
+    pub min_severity: Severity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_filter: Option<Source>,
+    pub enabled: bool,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Flat projection of a `(finding, advisory, install, target)`
+/// JOIN that the dispatcher needs to construct a payload without
+/// re-querying. Keeps the dispatcher I/O bounded to one SELECT
+/// per `run_once` regardless of batch size.
+#[derive(Debug, Clone)]
+pub struct PendingDelivery {
+    pub finding_id: i64,
+    pub finding_created_at: DateTime<Utc>,
+    pub target_id: i64,
+    pub target_label: String,
+    pub target_url: String,
+    pub target_secret: String,
+    pub advisory_osv_id: String,
+    pub advisory_severity: Severity,
+    pub advisory_summary: Option<String>,
+    pub advisory_published_at: Option<DateTime<Utc>>,
+    pub install_ecosystem: String,
+    pub install_name: String,
+    pub install_version: String,
+    pub install_source: Source,
+    pub install_project_path: Option<String>,
+    pub install_resolved_at: DateTime<Utc>,
+}
+
+impl Store {
+    pub async fn register_target(&self, spec: TargetSpec) -> Result<i64> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "INSERT INTO dispatch_targets
+                        (label, url, secret, min_severity, source_filter, enabled, created_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6)",
+                    params![
+                        spec.label,
+                        spec.url,
+                        spec.secret,
+                        spec.min_severity.as_str(),
+                        spec.source_filter.map(|s| s.as_str().to_string()),
+                        Utc::now().timestamp_millis(),
+                    ],
+                )
+                .context("inserting dispatch target")?;
+            Ok(guard.last_insert_rowid())
+        })
+        .await
+        .context("spawn_blocking register_target join")?
+    }
+
+    pub async fn list_targets(&self) -> Result<Vec<StoredTarget>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let mut stmt = guard
+                .prepare(
+                    "SELECT id, label, url, min_severity, source_filter, enabled, created_at_ms
+                       FROM dispatch_targets
+                      WHERE deleted_at_ms IS NULL
+                       ORDER BY id ASC",
+                )
+                .context("preparing list_targets")?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let sev: String = row.get(3)?;
+                    let src: Option<String> = row.get(4)?;
+                    let enabled: i64 = row.get(5)?;
+                    let created_at_ms: i64 = row.get(6)?;
+                    Ok(StoredTarget {
+                        id: row.get(0)?,
+                        label: row.get(1)?,
+                        url: row.get(2)?,
+                        min_severity: Severity::parse(&sev).unwrap_or(Severity::Unknown),
+                        source_filter: src.and_then(|s| Source::parse(&s)),
+                        enabled: enabled != 0,
+                        created_at: ms_to_utc(created_at_ms).map_err(|e| {
+                            rusqlite::Error::FromSqlConversionFailure(6, SqlType::Integer, e.into())
+                        })?,
+                    })
+                })
+                .context("executing list_targets")?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.context("decoding target row")?);
+            }
+            Ok(out)
+        })
+        .await
+        .context("spawn_blocking list_targets join")?
+    }
+
+    /// Soft-delete: stamps `deleted_at_ms`, the target stops
+    /// appearing in `list_targets` and `pending_deliveries`, but
+    /// its `dispatch_attempts` rows survive for audit/forensics
+    /// (with a foreign-key still pointing at the now-hidden row).
+    /// Returns true if any active target with this id existed.
+    pub async fn delete_target(&self, id: i64) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let n = guard
+                .execute(
+                    "UPDATE dispatch_targets
+                        SET deleted_at_ms = ?1
+                      WHERE id = ?2 AND deleted_at_ms IS NULL",
+                    params![Utc::now().timestamp_millis(), id],
+                )
+                .context("soft-deleting target")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking delete_target join")?
+    }
+
+    /// Up to `batch` pending `(finding, target)` deliveries:
+    /// targets are enabled (and not soft-deleted), the advisory's
+    /// severity rank meets the target's `min_severity`, the
+    /// install's source matches the target's `source_filter` (or
+    /// that filter is unset), no successful attempt exists yet,
+    /// and the attempt count is below `attempt_cap`. Oldest
+    /// findings first. The companion count of `(finding, target)`
+    /// pairs that *would* have qualified except for hitting the
+    /// attempt cap is returned alongside, computed inside the
+    /// same connection-lock critical section so the two numbers
+    /// agree.
+    pub async fn pending_deliveries_with_stats(
+        &self,
+        batch: u32,
+        attempt_cap: i64,
+    ) -> Result<(Vec<PendingDelivery>, i64)> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let pending = pending_deliveries_blocking(&guard, batch, attempt_cap)?;
+            let over_cap: i64 = guard
+                .query_row(
+                    "SELECT COUNT(*) FROM (
+                       SELECT 1
+                         FROM findings f
+                         JOIN advisories     a ON a.id = f.advisory_id
+                         JOIN installs       i ON i.id = f.install_id
+                         CROSS JOIN dispatch_targets t
+                        WHERE t.enabled = 1
+                          AND t.deleted_at_ms IS NULL
+                          AND (CASE a.severity
+                                    WHEN 'critical' THEN 4
+                                    WHEN 'high'     THEN 3
+                                    WHEN 'moderate' THEN 2
+                                    WHEN 'low'      THEN 1
+                                    ELSE 0 END)
+                              >=
+                              (CASE t.min_severity
+                                    WHEN 'critical' THEN 4
+                                    WHEN 'high'     THEN 3
+                                    WHEN 'moderate' THEN 2
+                                    WHEN 'low'      THEN 1
+                                    ELSE 0 END)
+                          AND (t.source_filter IS NULL OR t.source_filter = i.source)
+                          AND NOT EXISTS (
+                                SELECT 1 FROM dispatch_attempts da
+                                 WHERE da.finding_id = f.id
+                                   AND da.target_id  = t.id
+                                   AND da.success    = 1
+                              )
+                          AND (
+                                SELECT COUNT(*) FROM dispatch_attempts da2
+                                 WHERE da2.finding_id = f.id
+                                   AND da2.target_id  = t.id
+                              ) >= ?1
+                     )",
+                    params![attempt_cap],
+                    |r| r.get(0),
+                )
+                .context("counting over-cap pairs")?;
+            Ok((pending, over_cap))
+        })
+        .await
+        .context("spawn_blocking pending_deliveries_with_stats join")?
+    }
+
+    pub async fn pending_deliveries(
+        &self,
+        batch: u32,
+        attempt_cap: i64,
+    ) -> Result<Vec<PendingDelivery>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            pending_deliveries_blocking(&guard, batch, attempt_cap)
+        })
+        .await
+        .context("spawn_blocking pending_deliveries join")?
+    }
+}
+
+fn pending_deliveries_blocking(
+    conn: &Connection,
+    batch: u32,
+    attempt_cap: i64,
+) -> Result<Vec<PendingDelivery>> {
+    let limit = batch.min(10_000) as i64;
+    let mut stmt = conn
+        .prepare(
+            "SELECT f.id, f.created_at_ms,
+                            t.id, t.label, t.url, t.secret,
+                            a.osv_id, a.severity, a.summary, a.published_at_ms,
+                            i.ecosystem, i.name, i.version, i.source, i.project_path,
+                            i.resolved_at_ms
+                       FROM findings f
+                       JOIN advisories     a ON a.id = f.advisory_id
+                       JOIN installs       i ON i.id = f.install_id
+                       CROSS JOIN dispatch_targets t
+                      WHERE t.enabled = 1
+                        AND t.deleted_at_ms IS NULL
+                        AND (CASE a.severity
+                                  WHEN 'critical' THEN 4
+                                  WHEN 'high'     THEN 3
+                                  WHEN 'moderate' THEN 2
+                                  WHEN 'low'      THEN 1
+                                  ELSE 0 END)
+                            >=
+                            (CASE t.min_severity
+                                  WHEN 'critical' THEN 4
+                                  WHEN 'high'     THEN 3
+                                  WHEN 'moderate' THEN 2
+                                  WHEN 'low'      THEN 1
+                                  ELSE 0 END)
+                        AND (t.source_filter IS NULL OR t.source_filter = i.source)
+                        AND NOT EXISTS (
+                              SELECT 1 FROM dispatch_attempts da
+                               WHERE da.finding_id = f.id
+                                 AND da.target_id  = t.id
+                                 AND da.success    = 1
+                            )
+                        AND (
+                              SELECT COUNT(*) FROM dispatch_attempts da2
+                               WHERE da2.finding_id = f.id
+                                 AND da2.target_id  = t.id
+                            ) < ?1
+                      ORDER BY f.created_at_ms ASC, f.id ASC, t.id ASC
+                      LIMIT ?2",
+        )
+        .context("preparing pending_deliveries")?;
+    let rows = stmt
+        .query_map(params![attempt_cap, limit], |row| {
+            let sev: String = row.get(7)?;
+            let pub_ms: Option<i64> = row.get(9)?;
+            let src: String = row.get(13)?;
+            Ok(PendingDelivery {
+                finding_id: row.get(0)?,
+                finding_created_at: ms_to_utc(row.get::<_, i64>(1)?).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(1, SqlType::Integer, e.into())
+                })?,
+                target_id: row.get(2)?,
+                target_label: row.get(3)?,
+                target_url: row.get(4)?,
+                target_secret: row.get(5)?,
+                advisory_osv_id: row.get(6)?,
+                advisory_severity: Severity::parse(&sev).unwrap_or(Severity::Unknown),
+                advisory_summary: row.get(8)?,
+                advisory_published_at: match pub_ms {
+                    Some(ms) => Some(ms_to_utc(ms).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(9, SqlType::Integer, e.into())
+                    })?),
+                    None => None,
+                },
+                install_ecosystem: row.get(10)?,
+                install_name: row.get(11)?,
+                install_version: row.get(12)?,
+                install_source: Source::parse(&src).ok_or_else(|| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        13,
+                        SqlType::Text,
+                        "unknown source".into(),
+                    )
+                })?,
+                install_project_path: row.get(14)?,
+                install_resolved_at: ms_to_utc(row.get::<_, i64>(15)?).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(15, SqlType::Integer, e.into())
+                })?,
+            })
+        })
+        .context("executing pending_deliveries")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("decoding pending row")?);
+    }
+    Ok(out)
+}
+
+impl Store {
+    pub async fn record_attempt(
+        &self,
+        finding_id: i64,
+        target_id: i64,
+        success: bool,
+        http_status: Option<i64>,
+        error: Option<String>,
+    ) -> Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "INSERT INTO dispatch_attempts
+                        (finding_id, target_id, attempt_at_ms, success, http_status, error)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        finding_id,
+                        target_id,
+                        Utc::now().timestamp_millis(),
+                        if success { 1 } else { 0 },
+                        http_status,
+                        error,
+                    ],
+                )
+                .context("inserting dispatch attempt")?;
+            Ok(())
+        })
+        .await
+        .context("spawn_blocking record_attempt join")?
+    }
+
+    /// Set / clear the enabled flag on a target. Returns whether
+    /// any row was affected.
+    pub async fn set_target_enabled(&self, id: i64, enabled: bool) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let n = guard
+                .execute(
+                    "UPDATE dispatch_targets
+                        SET enabled = ?1
+                      WHERE id = ?2 AND deleted_at_ms IS NULL",
+                    params![if enabled { 1 } else { 0 }, id],
+                )
+                .context("updating target enabled flag")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking set_target_enabled join")?
+    }
+}
+
+// ---------------- users + sessions ----------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredUser {
+    pub id: i64,
+    pub github_user_id: i64,
+    pub github_login: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_login_at: DateTime<Utc>,
+}
+
+/// Profile fields the OAuth callback hands the store. Kept
+/// separate from `StoredUser` so callers can't accidentally pass
+/// a `created_at` from the GitHub side (we always stamp our own).
+#[derive(Debug, Clone)]
+pub struct UpsertUserSpec {
+    pub github_user_id: i64,
+    pub github_login: String,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+}
+
+impl Store {
+    /// Insert-or-update on `github_user_id`. Returns the row id;
+    /// updates `last_login_at_ms` on every call so a subsequent
+    /// `last_login_at` lookup is meaningful.
+    pub async fn upsert_user(&self, spec: UpsertUserSpec) -> Result<i64> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            guard
+                .execute(
+                    "INSERT INTO users
+                        (github_user_id, github_login, display_name, avatar_url,
+                         created_at_ms, last_login_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                     ON CONFLICT(github_user_id) DO UPDATE SET
+                         github_login   = excluded.github_login,
+                         display_name   = excluded.display_name,
+                         avatar_url     = excluded.avatar_url,
+                         last_login_at_ms = excluded.last_login_at_ms",
+                    params![
+                        spec.github_user_id,
+                        spec.github_login,
+                        spec.display_name,
+                        spec.avatar_url,
+                        now,
+                    ],
+                )
+                .context("upsert user")?;
+            let id: i64 = guard
+                .query_row(
+                    "SELECT id FROM users WHERE github_user_id = ?1",
+                    params![spec.github_user_id],
+                    |r| r.get(0),
+                )
+                .context("looking up upserted user")?;
+            Ok(id)
+        })
+        .await
+        .context("spawn_blocking upsert_user join")?
+    }
+
+    pub async fn create_session(
+        &self,
+        user_id: i64,
+        token_hash: [u8; 32],
+        ttl_secs: i64,
+        user_agent: Option<String>,
+    ) -> Result<i64> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let expires = now + ttl_secs * 1000;
+            guard
+                .execute(
+                    "INSERT INTO sessions
+                        (token_hash, user_id, created_at_ms, expires_at_ms, user_agent)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![token_hash.as_slice(), user_id, now, expires, user_agent],
+                )
+                .context("inserting session")?;
+            Ok(guard.last_insert_rowid())
+        })
+        .await
+        .context("spawn_blocking create_session join")?
+    }
+
+    /// Resolve a session by token hash. Returns `Some(user)` iff
+    /// the session exists, isn't revoked, and hasn't expired. We
+    /// re-shape the query so a single round-trip joins users to
+    /// avoid a separate `find_user` call from every middleware
+    /// invocation.
+    pub async fn session_user(&self, token_hash: [u8; 32]) -> Result<Option<StoredUser>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let row = guard
+                .query_row(
+                    "SELECT u.id, u.github_user_id, u.github_login, u.display_name,
+                            u.avatar_url, u.created_at_ms, u.last_login_at_ms
+                       FROM sessions s
+                       JOIN users    u ON u.id = s.user_id
+                      WHERE s.token_hash = ?1
+                        AND s.revoked_at_ms IS NULL
+                        AND s.expires_at_ms > ?2",
+                    params![token_hash.as_slice(), now],
+                    |row| {
+                        let created_ms: i64 = row.get(5)?;
+                        let last_ms: i64 = row.get(6)?;
+                        Ok(StoredUser {
+                            id: row.get(0)?,
+                            github_user_id: row.get(1)?,
+                            github_login: row.get(2)?,
+                            display_name: row.get(3)?,
+                            avatar_url: row.get(4)?,
+                            created_at: ms_to_utc(created_ms).map_err(|e| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    5,
+                                    SqlType::Integer,
+                                    e.into(),
+                                )
+                            })?,
+                            last_login_at: ms_to_utc(last_ms).map_err(|e| {
+                                rusqlite::Error::FromSqlConversionFailure(
+                                    6,
+                                    SqlType::Integer,
+                                    e.into(),
+                                )
+                            })?,
+                        })
+                    },
+                )
+                .optional()
+                .context("session_user query")?;
+            Ok(row)
+        })
+        .await
+        .context("spawn_blocking session_user join")?
+    }
+
+    pub async fn revoke_session(&self, token_hash: [u8; 32]) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let n = guard
+                .execute(
+                    "UPDATE sessions
+                        SET revoked_at_ms = ?1
+                      WHERE token_hash = ?2 AND revoked_at_ms IS NULL",
+                    params![Utc::now().timestamp_millis(), token_hash.as_slice()],
+                )
+                .context("revoking session")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking revoke_session join")?
+    }
+}
+
+// ---------------- personal api tokens ----------------
+
+/// Returned by [`Store::list_api_tokens`] / hand-back of
+/// [`Store::create_api_token`]. The cleartext token is NEVER on
+/// this struct — `create_api_token` returns it separately and the
+/// caller must show it to the user immediately because the
+/// server never sees it again.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredApiToken {
+    pub id: i64,
+    pub user_id: i64,
+    /// Human-readable first 12 chars of the cleartext token
+    /// (always starts `shp_`). Safe to show in any list UI.
+    pub prefix: String,
+    pub label: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// All-prefix marker for personal tokens. The middleware fast-
+/// fails any bearer value that doesn't start with `shp_` so the
+/// hash lookup never touches attacker-controlled prefixes that
+/// would otherwise force a DB round-trip per noise request.
+pub const API_TOKEN_PREFIX: &str = "shp_";
+const API_TOKEN_BYTES: usize = 32;
+/// Length of the public-safe prefix recorded for the list UI
+/// (`shp_` + 8 chars of the base64url body). Long enough to be
+/// distinguishable in a list view, short enough to leak negligible
+/// entropy.
+const API_TOKEN_PREFIX_DISPLAY_LEN: usize = 12;
+
+/// One-shot newly-minted token. `cleartext` is what we show the
+/// user once; `record` is what's persisted.
+#[derive(Debug)]
+pub struct MintedApiToken {
+    pub cleartext: String,
+    pub record: StoredApiToken,
+}
+
+impl Store {
+    /// Mint and persist a fresh personal API token. The cleartext
+    /// returned here is the only chance to capture it; the DB
+    /// only stores its SHA-256 hash.
+    pub async fn create_api_token(
+        &self,
+        user_id: i64,
+        label: String,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<MintedApiToken> {
+        if label.is_empty() {
+            anyhow::bail!("api token label is empty");
+        }
+        if label.len() > 128 {
+            anyhow::bail!("api token label exceeds 128 chars");
+        }
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            use base64::Engine;
+            use rand::RngCore;
+            let mut raw = [0u8; API_TOKEN_BYTES];
+            rand::thread_rng().fill_bytes(&mut raw);
+            let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+            let cleartext = format!("{API_TOKEN_PREFIX}{body}");
+            let prefix = cleartext
+                .chars()
+                .take(API_TOKEN_PREFIX_DISPLAY_LEN)
+                .collect::<String>();
+            let mut h = sha2::Sha256::new();
+            h.update(cleartext.as_bytes());
+            let hash: [u8; 32] = h.finalize().into();
+            let now = Utc::now().timestamp_millis();
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "INSERT INTO api_tokens
+                        (user_id, token_hash, prefix, label,
+                         created_at_ms, last_used_at_ms,
+                         expires_at_ms, revoked_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, NULL)",
+                    params![
+                        user_id,
+                        hash.as_slice(),
+                        prefix,
+                        label,
+                        now,
+                        expires_at.map(|d| d.timestamp_millis()),
+                    ],
+                )
+                .context("inserting api token")?;
+            let id = guard.last_insert_rowid();
+            Ok(MintedApiToken {
+                cleartext,
+                record: StoredApiToken {
+                    id,
+                    user_id,
+                    prefix,
+                    label,
+                    created_at: ms_to_utc(now)?,
+                    last_used_at: None,
+                    expires_at,
+                    revoked_at: None,
+                },
+            })
+        })
+        .await
+        .context("spawn_blocking create_api_token join")?
+    }
+
+    pub async fn list_api_tokens(&self, user_id: i64) -> Result<Vec<StoredApiToken>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let mut stmt = guard
+                .prepare(
+                    "SELECT id, user_id, prefix, label, created_at_ms,
+                            last_used_at_ms, expires_at_ms, revoked_at_ms
+                       FROM api_tokens
+                      WHERE user_id = ?1
+                      ORDER BY created_at_ms DESC, id DESC",
+                )
+                .context("preparing list_api_tokens")?;
+            let rows = stmt
+                .query_map(params![user_id], row_to_api_token)
+                .context("executing list_api_tokens")?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.context("decoding api token row")?);
+            }
+            Ok(out)
+        })
+        .await
+        .context("spawn_blocking list_api_tokens join")?
+    }
+
+    /// Soft-revoke by id, scoped to the calling user so one user
+    /// can't yank another user's tokens. Returns true iff an
+    /// active row matching both `(id, user_id)` was revoked.
+    pub async fn revoke_api_token(&self, id: i64, user_id: i64) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let n = guard
+                .execute(
+                    "UPDATE api_tokens
+                        SET revoked_at_ms = ?1
+                      WHERE id = ?2 AND user_id = ?3 AND revoked_at_ms IS NULL",
+                    params![Utc::now().timestamp_millis(), id, user_id],
+                )
+                .context("revoking api token")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking revoke_api_token join")?
+    }
+
+    /// Look up the user behind a presented token hash. Returns
+    /// `Some((user, token_id))` iff a matching row exists and is
+    /// not revoked / not expired. The token_id is used by the
+    /// caller to async-update `last_used_at_ms`.
+    pub async fn api_token_user(&self, token_hash: [u8; 32]) -> Result<Option<(StoredUser, i64)>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let row = guard
+                .query_row(
+                    "SELECT u.id, u.github_user_id, u.github_login, u.display_name,
+                            u.avatar_url, u.created_at_ms, u.last_login_at_ms,
+                            t.id
+                       FROM api_tokens t
+                       JOIN users      u ON u.id = t.user_id
+                      WHERE t.token_hash    = ?1
+                        AND t.revoked_at_ms IS NULL
+                        AND (t.expires_at_ms IS NULL OR t.expires_at_ms > ?2)",
+                    params![token_hash.as_slice(), now],
+                    |row| {
+                        let created_ms: i64 = row.get(5)?;
+                        let last_ms: i64 = row.get(6)?;
+                        let token_id: i64 = row.get(7)?;
+                        Ok((
+                            StoredUser {
+                                id: row.get(0)?,
+                                github_user_id: row.get(1)?,
+                                github_login: row.get(2)?,
+                                display_name: row.get(3)?,
+                                avatar_url: row.get(4)?,
+                                created_at: ms_to_utc(created_ms).map_err(|e| {
+                                    rusqlite::Error::FromSqlConversionFailure(
+                                        5,
+                                        SqlType::Integer,
+                                        e.into(),
+                                    )
+                                })?,
+                                last_login_at: ms_to_utc(last_ms).map_err(|e| {
+                                    rusqlite::Error::FromSqlConversionFailure(
+                                        6,
+                                        SqlType::Integer,
+                                        e.into(),
+                                    )
+                                })?,
+                            },
+                            token_id,
+                        ))
+                    },
+                )
+                .optional()
+                .context("api_token_user query")?;
+            Ok(row)
+        })
+        .await
+        .context("spawn_blocking api_token_user join")?
+    }
+
+    /// Best-effort `last_used_at` bump. Fire-and-forget — the
+    /// caller spawns this and does NOT await for the request
+    /// path, so a slow DB write can't add latency. Errors are
+    /// `log::warn!`'d.
+    pub async fn touch_api_token(&self, token_id: i64) -> Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "UPDATE api_tokens SET last_used_at_ms = ?1 WHERE id = ?2",
+                    params![Utc::now().timestamp_millis(), token_id],
+                )
+                .context("touching api token")?;
+            Ok(())
+        })
+        .await
+        .context("spawn_blocking touch_api_token join")?
+    }
+}
+
+fn row_to_api_token(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredApiToken> {
+    let created_ms: i64 = row.get(4)?;
+    let last_ms: Option<i64> = row.get(5)?;
+    let exp_ms: Option<i64> = row.get(6)?;
+    let rev_ms: Option<i64> = row.get(7)?;
+    Ok(StoredApiToken {
+        id: row.get(0)?,
+        user_id: row.get(1)?,
+        prefix: row.get(2)?,
+        label: row.get(3)?,
+        created_at: ms_to_utc(created_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, SqlType::Integer, e.into())
+        })?,
+        last_used_at: last_ms
+            .map(|m| {
+                ms_to_utc(m).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(5, SqlType::Integer, e.into())
+                })
+            })
+            .transpose()?,
+        expires_at: exp_ms
+            .map(|m| {
+                ms_to_utc(m).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(6, SqlType::Integer, e.into())
+                })
+            })
+            .transpose()?,
+        revoked_at: rev_ms
+            .map(|m| {
+                ms_to_utc(m).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(7, SqlType::Integer, e.into())
+                })
+            })
+            .transpose()?,
+    })
+}
+
+/// Hash a presented cleartext API token. Caller is responsible
+/// for first verifying the [`API_TOKEN_PREFIX`] before calling
+/// this — passing arbitrary attacker bytes through SHA-256 and
+/// then through the DB still works correctly, but the
+/// fast-fail prefix check keeps `noise` traffic out of the DB.
+pub fn hash_api_token(cleartext: &str) -> [u8; 32] {
+    let mut h = sha2::Sha256::new();
+    h.update(cleartext.as_bytes());
+    h.finalize().into()
+}
+
+// ---------------- actions tokens ----------------
+
+/// Bearer-namespace marker for tokens minted via the GitHub
+/// Actions OIDC exchange. Distinguishable from `shp_` (per-user
+/// personal tokens) at the middleware's fast-fail step.
+pub const ACTIONS_TOKEN_PREFIX: &str = "sha_";
+const ACTIONS_TOKEN_BYTES: usize = 32;
+const ACTIONS_TOKEN_PREFIX_DISPLAY_LEN: usize = 12;
+
+#[derive(Debug, Clone)]
+pub struct ActionsTokenSpec {
+    pub repository: String,
+    pub repository_owner: String,
+    pub workflow_ref: Option<String>,
+    pub subject: String,
+    pub ttl_secs: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredActionsToken {
+    pub id: i64,
+    pub prefix: String,
+    pub repository: String,
+    pub repository_owner: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_ref: Option<String>,
+    pub subject: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Principal information surfaced by the middleware when an
+/// actions token authenticates a request. Used by the future
+/// team/RBAC slice to scope writes to the matching repository's
+/// team; today the writes don't read this back out, but exposing
+/// the struct now keeps the lookup signature stable.
+#[derive(Debug, Clone)]
+pub struct ActionsPrincipal {
+    pub token_id: i64,
+    pub repository: String,
+    pub repository_owner: String,
+}
+
+#[derive(Debug)]
+pub struct MintedActionsToken {
+    pub cleartext: String,
+    pub record: StoredActionsToken,
+}
+
+impl Store {
+    pub async fn mint_actions_token(&self, spec: ActionsTokenSpec) -> Result<MintedActionsToken> {
+        if spec.ttl_secs < 1 {
+            anyhow::bail!("actions token ttl must be >= 1 second");
+        }
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            use base64::Engine;
+            use rand::RngCore;
+            let mut raw = [0u8; ACTIONS_TOKEN_BYTES];
+            rand::thread_rng().fill_bytes(&mut raw);
+            let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+            let cleartext = format!("{ACTIONS_TOKEN_PREFIX}{body}");
+            let prefix = cleartext
+                .chars()
+                .take(ACTIONS_TOKEN_PREFIX_DISPLAY_LEN)
+                .collect::<String>();
+            let mut h = sha2::Sha256::new();
+            h.update(cleartext.as_bytes());
+            let hash: [u8; 32] = h.finalize().into();
+            let now = Utc::now().timestamp_millis();
+            let expires_at_ms = now + spec.ttl_secs * 1000;
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "INSERT INTO actions_tokens
+                        (token_hash, prefix, repository, repository_owner,
+                         workflow_ref, subject,
+                         created_at_ms, expires_at_ms, last_used_at_ms,
+                         revoked_at_ms)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL)",
+                    params![
+                        hash.as_slice(),
+                        prefix,
+                        spec.repository,
+                        spec.repository_owner,
+                        spec.workflow_ref,
+                        spec.subject,
+                        now,
+                        expires_at_ms,
+                    ],
+                )
+                .context("inserting actions token")?;
+            let id = guard.last_insert_rowid();
+            Ok(MintedActionsToken {
+                cleartext,
+                record: StoredActionsToken {
+                    id,
+                    prefix,
+                    repository: spec.repository,
+                    repository_owner: spec.repository_owner,
+                    workflow_ref: spec.workflow_ref,
+                    subject: spec.subject,
+                    created_at: ms_to_utc(now)?,
+                    expires_at: ms_to_utc(expires_at_ms)?,
+                },
+            })
+        })
+        .await
+        .context("spawn_blocking mint_actions_token join")?
+    }
+
+    pub async fn actions_token_principal(
+        &self,
+        token_hash: [u8; 32],
+    ) -> Result<Option<ActionsPrincipal>> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let row = guard
+                .query_row(
+                    "SELECT id, repository, repository_owner
+                       FROM actions_tokens
+                      WHERE token_hash    = ?1
+                        AND revoked_at_ms IS NULL
+                        AND expires_at_ms > ?2",
+                    params![token_hash.as_slice(), now],
+                    |row| {
+                        Ok(ActionsPrincipal {
+                            token_id: row.get(0)?,
+                            repository: row.get(1)?,
+                            repository_owner: row.get(2)?,
+                        })
+                    },
+                )
+                .optional()
+                .context("actions_token_principal query")?;
+            Ok(row)
+        })
+        .await
+        .context("spawn_blocking actions_token_principal join")?
+    }
+
+    pub async fn touch_actions_token(&self, token_id: i64) -> Result<()> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            guard
+                .execute(
+                    "UPDATE actions_tokens SET last_used_at_ms = ?1 WHERE id = ?2",
+                    params![Utc::now().timestamp_millis(), token_id],
+                )
+                .context("touching actions token")?;
+            Ok(())
+        })
+        .await
+        .context("spawn_blocking touch_actions_token join")?
+    }
+}
+
+pub fn hash_actions_token(cleartext: &str) -> [u8; 32] {
+    let mut h = sha2::Sha256::new();
+    h.update(cleartext.as_bytes());
+    h.finalize().into()
+}
+
+// ---------------- device authorization flow ----------------
+
+/// User-code alphabet — uppercase A–Z minus the four "looks-like-
+/// something-else" characters (I/O confuse with 1/0, S/Z confuse
+/// in some fonts). 22 chars; 8-position user codes give ~35 bits
+/// of entropy which is plenty for the 10-minute window with the
+/// slow-down poll throttle.
+const USER_CODE_ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRTUVWXY";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DeviceCodeStatus {
+    Pending,
+    Approved,
+    Denied,
+    /// CLI successfully polled and got the token. Further polls
+    /// look like `expired` to the caller.
+    Consumed,
+    Expired,
+}
+
+impl DeviceCodeStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Approved => "approved",
+            Self::Denied => "denied",
+            Self::Consumed => "consumed",
+            Self::Expired => "expired",
+        }
+    }
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "approved" => Some(Self::Approved),
+            "denied" => Some(Self::Denied),
+            "consumed" => Some(Self::Consumed),
+            "expired" => Some(Self::Expired),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredDeviceCode {
+    pub id: i64,
+    pub user_code: String,
+    pub label: String,
+    pub status: DeviceCodeStatus,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub struct MintedDeviceCode {
+    /// Secret the CLI keeps and polls with.
+    pub device_code: String,
+    /// Short human-readable code shown to the user (e.g. "ABCD-EFGH").
+    pub user_code: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Outcome of a `poll_device_code` call. Maps onto the RFC 8628
+/// error codes the CLI returns to the user.
+pub enum DevicePollOutcome {
+    /// CLI should keep polling. `slow_down` if the poll cadence
+    /// is too fast; otherwise plain `pending`.
+    Pending { slow_down: bool },
+    /// Operator denied the device. Final.
+    Denied,
+    /// CLI polled too late (or never showed up). Final.
+    Expired,
+    /// Already consumed. Final — repeat polls after success.
+    AlreadyConsumed,
+    /// First post-approval poll. Cleartext token is in the body;
+    /// the CLI should immediately stop polling.
+    Approved { cleartext: String },
+}
+
+impl Store {
+    /// Mint a device + user code pair. Retries up to 5 times if
+    /// `user_code` collides — uniqueness violations are
+    /// astronomically rare in a 10-min window with 22^8 codes,
+    /// but the retry keeps a worst-case duplicate-mint loud.
+    pub async fn mint_device_code(&self, label: String, ttl_secs: i64) -> Result<MintedDeviceCode> {
+        if label.is_empty() {
+            anyhow::bail!("device code label is empty");
+        }
+        if label.len() > 128 {
+            anyhow::bail!("device code label exceeds 128 chars");
+        }
+        if ttl_secs < 60 {
+            anyhow::bail!("device code ttl must be >= 60 seconds");
+        }
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            use base64::Engine;
+            use rand::RngCore;
+            let now = Utc::now().timestamp_millis();
+            let expires_at_ms = now + ttl_secs * 1000;
+            let guard = conn.blocking_lock();
+            // Opportunistic GC of long-expired rows. The endpoint
+            // is unauthenticated and rows live for 10 minutes; a
+            // background loop would be cleaner but this keeps the
+            // table bounded without one. 24h grace is enough to
+            // debug after-the-fact.
+            guard
+                .execute(
+                    "DELETE FROM device_codes
+                      WHERE expires_at_ms < ?1
+                        AND created_at_ms < ?2",
+                    params![now - 24 * 3600 * 1000, now - 24 * 3600 * 1000],
+                )
+                .context("GC'ing expired device codes")?;
+            // Active-row cap. Unauthenticated endpoints need a
+            // ceiling — a quick-and-dirty 10_000 lets a real
+            // operator never see it, but stops a pathological
+            // flood from filling the disk.
+            let pending: i64 = guard
+                .query_row(
+                    "SELECT COUNT(*) FROM device_codes
+                      WHERE status = 'pending' AND expires_at_ms > ?1",
+                    params![now],
+                    |r| r.get(0),
+                )
+                .context("counting pending device codes")?;
+            if pending >= 10_000 {
+                anyhow::bail!("too many pending device codes ({pending}); retry shortly");
+            }
+            for _ in 0..5 {
+                let mut raw = [0u8; 32];
+                rand::thread_rng().fill_bytes(&mut raw);
+                let device_code = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+                // 8 chars from USER_CODE_ALPHABET, formatted
+                // `XXXX-XXXX` for readability.
+                let mut chars = [0u8; 8];
+                rand::thread_rng().fill_bytes(&mut chars);
+                let mut buf = String::with_capacity(9);
+                for (i, b) in chars.iter().enumerate() {
+                    if i == 4 {
+                        buf.push('-');
+                    }
+                    let idx = (*b as usize) % USER_CODE_ALPHABET.len();
+                    buf.push(USER_CODE_ALPHABET[idx] as char);
+                }
+                let user_code = buf;
+                let res = guard.execute(
+                    "INSERT INTO device_codes
+                        (device_code, user_code, status, label,
+                         created_at_ms, expires_at_ms)
+                     VALUES (?1, ?2, 'pending', ?3, ?4, ?5)",
+                    params![device_code, user_code, label, now, expires_at_ms],
+                );
+                match res {
+                    Ok(_) => {
+                        return Ok(MintedDeviceCode {
+                            device_code,
+                            user_code,
+                            expires_at: ms_to_utc(expires_at_ms)?,
+                        });
+                    }
+                    Err(rusqlite::Error::SqliteFailure(e, _))
+                        if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+                    {
+                        continue; // retry on collision
+                    }
+                    Err(e) => return Err(anyhow::Error::from(e).context("inserting device code")),
+                }
+            }
+            anyhow::bail!("device_code generation failed after 5 retries")
+        })
+        .await
+        .context("spawn_blocking mint_device_code join")?
+    }
+
+    /// Look up a device_codes row by the human-friendly user_code.
+    /// Normalises by uppercasing + stripping the `-` separator so
+    /// `abcd-efgh`, `ABCDEFGH`, `ABCD-EFGH` all hit. Returns
+    /// `Ok(None)` for any not-found / not-pending shape — same
+    /// uniform-failure stance as session lookup.
+    pub async fn find_device_code_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> Result<Option<StoredDeviceCode>> {
+        let norm = normalise_user_code(user_code);
+        if norm.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            // Compare against the canonical stored form
+            // (`XXXX-XXXX`); but the operator probably typed
+            // without the dash, so we re-insert it before
+            // comparing.
+            let formatted = if norm.len() == 8 {
+                format!("{}-{}", &norm[..4], &norm[4..])
+            } else {
+                norm
+            };
+            let row = guard
+                .query_row(
+                    "SELECT id, user_code, label, status, created_at_ms, expires_at_ms
+                       FROM device_codes
+                      WHERE user_code = ?1",
+                    params![formatted],
+                    decode_device_code_row,
+                )
+                .optional()
+                .context("find_device_code_by_user_code query")?;
+            Ok(row)
+        })
+        .await
+        .context("spawn_blocking find_device_code_by_user_code join")?
+    }
+
+    /// Approve a pending device_code on behalf of `user_id` (the
+    /// browser-authenticated operator). Returns `false` if the
+    /// row isn't pending (already approved/denied/expired/etc.)
+    /// or doesn't exist.
+    pub async fn approve_device_code(&self, id: i64, user_id: i64) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let n = guard
+                .execute(
+                    "UPDATE device_codes
+                        SET status = 'approved',
+                            approving_user_id = ?1,
+                            approved_at_ms = ?2
+                      WHERE id = ?3
+                        AND status = 'pending'
+                        AND expires_at_ms > ?2",
+                    params![user_id, now, id],
+                )
+                .context("approving device code")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking approve_device_code join")?
+    }
+
+    pub async fn deny_device_code(&self, id: i64) -> Result<bool> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let n = guard
+                .execute(
+                    "UPDATE device_codes
+                        SET status = 'denied'
+                      WHERE id = ?1
+                        AND status = 'pending'
+                        AND expires_at_ms > ?2",
+                    params![id, now],
+                )
+                .context("denying device code")?;
+            Ok(n > 0)
+        })
+        .await
+        .context("spawn_blocking deny_device_code join")?
+    }
+
+    /// CLI poll. Implements the RFC-8628 state machine:
+    ///
+    /// - row absent / expired → `Expired`
+    /// - status = pending → `Pending { slow_down }` where
+    ///   `slow_down=true` iff the previous poll was less than
+    ///   `min_interval_secs` ago.
+    /// - status = denied → `Denied`
+    /// - status = consumed → `AlreadyConsumed`
+    /// - status = approved → mint personal token for the
+    ///   approving user, transition to `consumed`, return
+    ///   `Approved { cleartext }`. This is the only path that
+    ///   returns the cleartext — and only once.
+    pub async fn poll_device_code(
+        &self,
+        device_code: String,
+        min_interval_secs: i64,
+    ) -> Result<DevicePollOutcome> {
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut guard = conn.blocking_lock();
+            let now = Utc::now().timestamp_millis();
+            let tx = guard.transaction().context("opening poll tx")?;
+            #[allow(clippy::type_complexity)]
+            let row: Option<(i64, String, i64, Option<i64>, Option<i64>, String)> = tx
+                .query_row(
+                    "SELECT id, status, expires_at_ms, last_polled_at_ms,
+                            approving_user_id, label
+                       FROM device_codes
+                      WHERE device_code = ?1",
+                    params![device_code],
+                    |r| {
+                        Ok((
+                            r.get(0)?,
+                            r.get(1)?,
+                            r.get(2)?,
+                            r.get(3)?,
+                            r.get(4)?,
+                            r.get(5)?,
+                        ))
+                    },
+                )
+                .optional()
+                .context("poll_device_code lookup")?;
+            let Some((id, status_s, expires_at_ms, last_polled, approving_user_id, label)) = row
+            else {
+                tx.commit().ok();
+                return Ok(DevicePollOutcome::Expired);
+            };
+            // Stamp the poll time first (regardless of outcome)
+            // so subsequent polls see the throttle even when this
+            // one returns `pending`.
+            tx.execute(
+                "UPDATE device_codes SET last_polled_at_ms = ?1 WHERE id = ?2",
+                params![now, id],
+            )
+            .context("updating last_polled_at_ms")?;
+            if expires_at_ms <= now {
+                tx.execute(
+                    "UPDATE device_codes SET status = 'expired' WHERE id = ?1 AND status = 'pending'",
+                    params![id],
+                )
+                .ok();
+                tx.commit().context("committing expired-flip")?;
+                return Ok(DevicePollOutcome::Expired);
+            }
+            let status = DeviceCodeStatus::parse(&status_s).unwrap_or(DeviceCodeStatus::Expired);
+            match status {
+                DeviceCodeStatus::Pending => {
+                    let too_fast = last_polled
+                        .map(|t| (now - t) < min_interval_secs * 1000)
+                        .unwrap_or(false);
+                    tx.commit().context("committing pending poll")?;
+                    Ok(DevicePollOutcome::Pending { slow_down: too_fast })
+                }
+                DeviceCodeStatus::Denied => {
+                    tx.commit().context("committing denied poll")?;
+                    Ok(DevicePollOutcome::Denied)
+                }
+                DeviceCodeStatus::Consumed => {
+                    tx.commit().context("committing consumed poll")?;
+                    Ok(DevicePollOutcome::AlreadyConsumed)
+                }
+                DeviceCodeStatus::Expired => {
+                    tx.commit().context("committing expired poll")?;
+                    Ok(DevicePollOutcome::Expired)
+                }
+                DeviceCodeStatus::Approved => {
+                    let user_id = approving_user_id.ok_or_else(|| {
+                        anyhow::anyhow!("approved device_code without approving_user_id")
+                    })?;
+                    // Mint cleartext + insert api_token row.
+                    use base64::Engine;
+                    use rand::RngCore;
+                    let mut raw = [0u8; 32];
+                    rand::thread_rng().fill_bytes(&mut raw);
+                    let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(raw);
+                    let cleartext = format!("{API_TOKEN_PREFIX}{body}");
+                    let prefix = cleartext
+                        .chars()
+                        .take(12)
+                        .collect::<String>();
+                    let mut h = sha2::Sha256::new();
+                    h.update(cleartext.as_bytes());
+                    let hash: [u8; 32] = h.finalize().into();
+                    tx.execute(
+                        "INSERT INTO api_tokens
+                            (user_id, token_hash, prefix, label,
+                             created_at_ms, last_used_at_ms,
+                             expires_at_ms, revoked_at_ms)
+                         VALUES (?1, ?2, ?3, ?4, ?5, NULL, NULL, NULL)",
+                        params![user_id, hash.as_slice(), prefix, label, now],
+                    )
+                    .context("minting api token from device approval")?;
+                    let token_id = tx.last_insert_rowid();
+                    tx.execute(
+                        "UPDATE device_codes
+                            SET status = 'consumed',
+                                consumed_token_id = ?1,
+                                consumed_at_ms = ?2
+                          WHERE id = ?3",
+                        params![token_id, now, id],
+                    )
+                    .context("marking device code consumed")?;
+                    tx.commit().context("committing approve+consume")?;
+                    Ok(DevicePollOutcome::Approved { cleartext })
+                }
+            }
+        })
+        .await
+        .context("spawn_blocking poll_device_code join")?
+    }
+}
+
+fn decode_device_code_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredDeviceCode> {
+    let status_s: String = row.get(3)?;
+    let created_ms: i64 = row.get(4)?;
+    let expires_ms: i64 = row.get(5)?;
+    Ok(StoredDeviceCode {
+        id: row.get(0)?,
+        user_code: row.get(1)?,
+        label: row.get(2)?,
+        status: DeviceCodeStatus::parse(&status_s).unwrap_or(DeviceCodeStatus::Expired),
+        created_at: ms_to_utc(created_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(4, SqlType::Integer, e.into())
+        })?,
+        expires_at: ms_to_utc(expires_ms).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(5, SqlType::Integer, e.into())
+        })?,
+    })
+}
+
+fn normalise_user_code(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sakimori_core::deps::Ecosystem;
+
+    fn rec(ev: InstallEvent) -> IngestRecord {
+        ev.into()
+    }
+
+    #[tokio::test]
+    async fn insert_then_list_roundtrips() {
+        let s = Store::open_in_memory().unwrap();
+        let ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_project_path("/Users/alice/proj")
+            .with_user_agent("npm/10.0.0 node/20.0.0");
+        let id = s.insert(rec(ev)).await.unwrap();
+        assert!(id > 0);
+
+        let rows = s.list(ListFilter::default()).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "left-pad");
+        assert_eq!(rows[0].source, Source::Desktop);
+        assert_eq!(rows[0].execution_mode, ExecutionMode::Persistent);
+    }
+
+    #[tokio::test]
+    async fn explicit_source_overrides_heuristic() {
+        let s = Store::open_in_memory().unwrap();
+        // Path *looks* like Desktop, but the proxy already knows
+        // (e.g.) it's running on a GitLab runner and supplies the
+        // override.
+        let ev = InstallEvent::new(Ecosystem::Npm, "a", "1").with_project_path("/Users/alice/p");
+        s.insert(IngestRecord {
+            event: ev,
+            source: Some(Source::Actions),
+        })
+        .await
+        .unwrap();
+        let rows = s.list(ListFilter::default()).await.unwrap();
+        assert_eq!(rows[0].source, Source::Actions);
+    }
+
+    #[tokio::test]
+    async fn filters_compose() {
+        let s = Store::open_in_memory().unwrap();
+        for (name, ver, mode, path) in [
+            ("a", "1", ExecutionMode::Persistent, "/Users/alice/p"),
+            ("a", "2", ExecutionMode::Ephemeral, "/home/runner/work/r/r"),
+            ("b", "1", ExecutionMode::Persistent, "/Users/alice/p"),
+        ] {
+            let ev = InstallEvent::new(Ecosystem::Npm, name, ver)
+                .with_mode(mode)
+                .with_project_path(path);
+            s.insert(rec(ev)).await.unwrap();
+        }
+        let only_a = s
+            .list(ListFilter {
+                name: Some("a".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(only_a.len(), 2);
+        let only_actions = s
+            .list(ListFilter {
+                source: Some(Source::Actions),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(only_actions.len(), 1);
+        assert_eq!(only_actions[0].version, "2");
+    }
+
+    #[tokio::test]
+    async fn list_orders_newest_first() {
+        let s = Store::open_in_memory().unwrap();
+        let mut older = InstallEvent::new(Ecosystem::Npm, "a", "1");
+        older.resolved_at = Utc::now() - chrono::Duration::hours(1);
+        let newer = InstallEvent::new(Ecosystem::Npm, "a", "2");
+        s.insert(rec(older)).await.unwrap();
+        s.insert(rec(newer)).await.unwrap();
+        let rows = s.list(ListFilter::default()).await.unwrap();
+        assert_eq!(rows[0].version, "2");
+        assert_eq!(rows[1].version, "1");
+    }
+
+    #[tokio::test]
+    async fn mixed_offset_timestamps_order_correctly() {
+        // Two instants 1 hour apart, but the *older* one is rendered
+        // in a +09:00 offset and the *newer* one in `Z`. A naive
+        // lexicographic TEXT comparison would put the +09:00 string
+        // first; the epoch-ms storage gets it right.
+        let s = Store::open_in_memory().unwrap();
+        let base = Utc::now();
+        let older = base - chrono::Duration::hours(2);
+        let newer = base - chrono::Duration::hours(1);
+        let mut e_older = InstallEvent::new(Ecosystem::Npm, "a", "old");
+        e_older.resolved_at = older
+            .with_timezone(&chrono::FixedOffset::east_opt(9 * 3600).unwrap())
+            .with_timezone(&Utc);
+        let mut e_newer = InstallEvent::new(Ecosystem::Npm, "a", "new");
+        e_newer.resolved_at = newer;
+        s.insert(rec(e_older)).await.unwrap();
+        s.insert(rec(e_newer)).await.unwrap();
+        let rows = s.list(ListFilter::default()).await.unwrap();
+        assert_eq!(rows[0].version, "new");
+        assert_eq!(rows[1].version, "old");
+    }
+
+    #[tokio::test]
+    async fn count_reflects_inserts() {
+        let s = Store::open_in_memory().unwrap();
+        assert_eq!(s.count().await.unwrap(), 0);
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "a", "1")))
+            .await
+            .unwrap();
+        assert_eq!(s.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn since_filter_excludes_older() {
+        let s = Store::open_in_memory().unwrap();
+        let mut old = InstallEvent::new(Ecosystem::Npm, "a", "1");
+        old.resolved_at = Utc::now() - chrono::Duration::days(2);
+        let new = InstallEvent::new(Ecosystem::Npm, "a", "2");
+        s.insert(rec(old)).await.unwrap();
+        s.insert(rec(new)).await.unwrap();
+        let rows = s
+            .list(ListFilter {
+                since: Some(Utc::now() - chrono::Duration::hours(1)),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].version, "2");
+    }
+
+    #[tokio::test]
+    async fn insert_many_is_atomic_and_returns_ids() {
+        let s = Store::open_in_memory().unwrap();
+        let batch = vec![
+            rec(InstallEvent::new(Ecosystem::Npm, "a", "1")),
+            rec(InstallEvent::new(Ecosystem::Npm, "b", "2")),
+            rec(InstallEvent::new(Ecosystem::Npm, "c", "3")),
+        ];
+        let ids = s.insert_many(batch).await.unwrap();
+        assert_eq!(ids.len(), 3);
+        assert!(ids[0] < ids[1] && ids[1] < ids[2]);
+        assert_eq!(s.count().await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn schema_version_is_seeded() {
+        let s = Store::open_in_memory().unwrap();
+        assert_eq!(s.schema_version().await.unwrap(), CURRENT_SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn reopening_an_existing_file_does_not_re_run_migrations() {
+        // Catches the "CREATE TABLE installs lacks IF NOT EXISTS so a
+        // second open re-runs v1 and fails" regression: open, write,
+        // drop, re-open the same file path, assert the data is still
+        // visible and schema_version is unchanged.
+        let dir = tempdir();
+        let path = dir.join("hub.sqlite");
+        {
+            let s = Store::open(&path).unwrap();
+            s.insert(rec(InstallEvent::new(Ecosystem::Npm, "a", "1")))
+                .await
+                .unwrap();
+            assert_eq!(s.schema_version().await.unwrap(), CURRENT_SCHEMA_VERSION);
+        }
+        let s = Store::open(&path).unwrap();
+        assert_eq!(s.count().await.unwrap(), 1);
+        assert_eq!(s.schema_version().await.unwrap(), CURRENT_SCHEMA_VERSION);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn refuses_to_open_db_with_newer_schema() {
+        let dir = tempdir();
+        let path = dir.join("hub.sqlite");
+        // Seed a file claiming schema_version=999, then try to open
+        // it with the current binary.
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE schema_version (
+                     id INTEGER PRIMARY KEY CHECK (id = 1),
+                     version INTEGER NOT NULL,
+                     applied_at_ms INTEGER NOT NULL
+                 );
+                 INSERT INTO schema_version (id, version, applied_at_ms) VALUES (1, 999, 0);",
+            )
+            .unwrap();
+        }
+        let err = Store::open(&path).err().expect("should refuse");
+        assert!(format!("{err:#}").contains("refusing to downgrade"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::time::{SystemTime, UNIX_EPOCH};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!("sakimori-hub-test-{id}-{seq}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    // ---------- advisory + scan tests ----------
+
+    fn osv_adv(id: &str, eco: &str, name: &str, versions: &[&str]) -> OsvAdvisory {
+        let body = serde_json::json!({
+            "id": id,
+            "summary": format!("test advisory {id}"),
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": eco, "name": name},
+                "versions": versions,
+            }],
+        });
+        serde_json::from_value(body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn advisory_upsert_then_scan_creates_finding() {
+        let s = Store::open_in_memory().unwrap();
+        // Install first, then a matching advisory.
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")))
+            .await
+            .unwrap();
+        let (_, new) = s
+            .upsert_advisory(osv_adv("GHSA-1", "npm", "left-pad", &["1.3.0"]), None)
+            .await
+            .unwrap();
+        assert!(new);
+
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(report.installs_scanned, 1);
+        assert_eq!(report.advisories_considered, 1);
+        assert_eq!(report.new_findings, 1);
+        assert_eq!(report.total_findings, 1);
+
+        let findings = s.list_findings(FindingFilter::default()).await.unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].advisory.osv_id, "GHSA-1");
+        assert_eq!(findings[0].install.name, "left-pad");
+        assert_eq!(findings[0].install.version, "1.3.0");
+    }
+
+    #[tokio::test]
+    async fn scan_is_idempotent() {
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "a", "1")))
+            .await
+            .unwrap();
+        s.upsert_advisory(osv_adv("A", "npm", "a", &["1"]), None)
+            .await
+            .unwrap();
+        let first = s.scan_findings().await.unwrap();
+        let second = s.scan_findings().await.unwrap();
+        assert_eq!(first.new_findings, 1);
+        assert_eq!(second.new_findings, 0);
+        assert_eq!(second.total_findings, 1);
+    }
+
+    #[tokio::test]
+    async fn scan_finds_advisory_published_after_install() {
+        // The whole point of retroactive notification: install
+        // pre-dates the advisory's existence.
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Pypi, "django", "4.2.0")))
+            .await
+            .unwrap();
+        let pre = s.scan_findings().await.unwrap();
+        assert_eq!(pre.new_findings, 0);
+
+        s.upsert_advisory(osv_adv("GHSA-late", "PyPI", "django", &["4.2.0"]), None)
+            .await
+            .unwrap();
+        let post = s.scan_findings().await.unwrap();
+        assert_eq!(post.new_findings, 1);
+    }
+
+    #[tokio::test]
+    async fn shrinking_advisory_prunes_stale_findings() {
+        // The "publisher narrowed the advisory" case: an install
+        // that previously matched should disappear from /findings
+        // once the advisory's affected set no longer covers it.
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "1.0.0")))
+            .await
+            .unwrap();
+        s.upsert_advisory(
+            osv_adv("GHSA-narrow", "npm", "p", &["1.0.0", "1.0.1"]),
+            None,
+        )
+        .await
+        .unwrap();
+        s.scan_findings().await.unwrap();
+        assert_eq!(
+            s.list_findings(FindingFilter::default())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        // Narrow: only 1.0.1 remains affected — our 1.0.0 install
+        // is no longer covered.
+        s.upsert_advisory(osv_adv("GHSA-narrow", "npm", "p", &["1.0.1"]), None)
+            .await
+            .unwrap();
+        let after = s.list_findings(FindingFilter::default()).await.unwrap();
+        assert_eq!(
+            after.len(),
+            0,
+            "stale finding for 1.0.0 should be pruned after narrowing"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_json_round_trips_extra_fields() {
+        let s = Store::open_in_memory().unwrap();
+        let raw = serde_json::json!({
+            "id": "GHSA-raw",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "p"}, "versions": ["1"]}],
+            "extra_we_do_not_model": {"foo": "bar"},
+        });
+        let parsed: OsvAdvisory = serde_json::from_value(raw.clone()).unwrap();
+        s.upsert_advisory(parsed, Some(raw.clone())).await.unwrap();
+        // Pull the literal raw_json back via a direct SELECT to
+        // prove the "extra" field survived storage.
+        let conn = s.conn.clone();
+        let stored: String = tokio::task::spawn_blocking(move || {
+            let g = conn.blocking_lock();
+            g.query_row(
+                "SELECT raw_json FROM advisories WHERE osv_id = 'GHSA-raw'",
+                [],
+                |r| r.get::<_, String>(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+        let parsed_back: serde_json::Value = serde_json::from_str(&stored).unwrap();
+        assert_eq!(parsed_back["extra_we_do_not_model"]["foo"], "bar");
+    }
+
+    #[tokio::test]
+    async fn validation_rejects_empty_id() {
+        let s = Store::open_in_memory().unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({"id": ""})).unwrap();
+        let err = s.upsert_advisory(adv, None).await.err().unwrap();
+        assert!(format!("{err:#}").contains("advisory id is empty"));
+    }
+
+    #[tokio::test]
+    async fn validation_rejects_oversized_summary() {
+        let s = Store::open_in_memory().unwrap();
+        let huge = "x".repeat(9000);
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-1",
+            "summary": huge,
+        }))
+        .unwrap();
+        let err = s.upsert_advisory(adv, None).await.err().unwrap();
+        assert!(format!("{err:#}").contains("summary exceeds"));
+    }
+
+    #[tokio::test]
+    async fn upsert_replaces_affected_rows() {
+        let s = Store::open_in_memory().unwrap();
+        s.upsert_advisory(osv_adv("GHSA-x", "npm", "p", &["1.0.0", "1.0.1"]), None)
+            .await
+            .unwrap();
+        // Second upsert with a smaller set — the JOIN should not
+        // match the removed version.
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "1.0.1")))
+            .await
+            .unwrap();
+        s.upsert_advisory(osv_adv("GHSA-x", "npm", "p", &["1.0.0"]), None)
+            .await
+            .unwrap();
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(report.new_findings, 0, "1.0.1 was removed from affected");
+    }
+
+    #[tokio::test]
+    async fn min_severity_is_applied_before_limit() {
+        // Regression: with the previous Rust-side filter, asking for
+        // min_severity=high with limit=5 against a DB whose newest 5
+        // findings are low would return zero rows — even when older
+        // critical findings existed. SQL-side filtering must surface
+        // them.
+        let s = Store::open_in_memory().unwrap();
+        // Critical finding goes in FIRST, so its findings.id and
+        // findings.created_at_ms are the smallest in the table.
+        // ORDER BY f.created_at_ms DESC, f.id DESC then surfaces
+        // the low ones first — exactly the ordering that would
+        // hide the critical under a Rust-side post-LIMIT filter.
+        let ev = InstallEvent::new(Ecosystem::Npm, "boom", "1");
+        s.insert(rec(ev)).await.unwrap();
+        let crit: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "CRIT-OLD",
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "boom"}, "versions": ["1"]}],
+        }))
+        .unwrap();
+        s.upsert_advisory(crit, None).await.unwrap();
+        s.scan_findings().await.unwrap();
+        // Now 10 newer low-severity findings on top.
+        for i in 0..10 {
+            let ev = InstallEvent::new(Ecosystem::Npm, format!("low{i}"), "1");
+            s.insert(rec(ev)).await.unwrap();
+            let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+                "id": format!("LOW-{i}"),
+                "database_specific": {"severity": "LOW"},
+                "affected": [{"package": {"ecosystem": "npm", "name": format!("low{i}")},
+                              "versions": ["1"]}],
+            }))
+            .unwrap();
+            s.upsert_advisory(adv, None).await.unwrap();
+        }
+        s.scan_findings().await.unwrap();
+
+        let high_only = s
+            .list_findings(FindingFilter {
+                min_severity: Some(Severity::High),
+                limit: Some(5),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(high_only.len(), 1, "limit must not hide CRIT-OLD");
+        assert_eq!(high_only[0].advisory.osv_id, "CRIT-OLD");
+    }
+
+    #[tokio::test]
+    async fn semver_range_advisory_matches_install_in_range() {
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "lodash", "4.17.20")))
+            .await
+            .unwrap();
+        // Range-only advisory (no `versions[]`).
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-range",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "0"}, {"fixed": "4.17.21"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(report.new_findings, 1, "4.17.20 is inside [0, 4.17.21)");
+        let findings = s.list_findings(FindingFilter::default()).await.unwrap();
+        assert_eq!(findings[0].advisory.osv_id, "GHSA-range");
+    }
+
+    #[tokio::test]
+    async fn semver_range_excludes_install_above_fixed() {
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "lodash", "4.17.21")))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-range",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "0"}, {"fixed": "4.17.21"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(
+            report.new_findings, 0,
+            "4.17.21 == fixed bound, must not match"
+        );
+    }
+
+    #[tokio::test]
+    async fn semver_range_unbounded_upper_matches() {
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "9.9.9")))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-unbounded",
+            "database_specific": {"severity": "CRITICAL"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [{"introduced": "1.0.0"}]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        assert_eq!(s.scan_findings().await.unwrap().new_findings, 1);
+    }
+
+    #[tokio::test]
+    async fn semver_range_prune_drops_finding_after_narrow() {
+        // Advisory initially covers [0, 4.17.21); install at
+        // 4.17.20 matches. Then the advisory is narrowed to
+        // [4.17.18, 4.17.19) — 4.17.20 no longer in range, so the
+        // stale finding must be pruned by upsert.
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "lodash", "4.17.20")))
+            .await
+            .unwrap();
+        let wide: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-narrow",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "0"}, {"fixed": "4.17.21"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(wide, None).await.unwrap();
+        s.scan_findings().await.unwrap();
+        assert_eq!(
+            s.list_findings(FindingFilter::default())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        let narrow: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-narrow",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "4.17.18"}, {"fixed": "4.17.19"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(narrow, None).await.unwrap();
+        assert!(
+            s.list_findings(FindingFilter::default())
+                .await
+                .unwrap()
+                .is_empty(),
+            "4.17.20 no longer in the narrowed range — must be pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn semver_range_last_affected_is_inclusive_at_scan() {
+        // last_affected = 1.2.3 ⇒ stable 1.2.3 IS a match, 1.2.4
+        // is NOT, and 1.2.4-rc.1 also is NOT (the bug bump would
+        // have wrongly matched 1.2.3 stable when last_affected
+        // pointed at a prerelease).
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "1.2.3")))
+            .await
+            .unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "1.2.4")))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-incl",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"last_affected": "1.2.3"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        s.scan_findings().await.unwrap();
+        let findings = s.list_findings(FindingFilter::default()).await.unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].install.version, "1.2.3");
+    }
+
+    #[tokio::test]
+    async fn semver_range_malformed_close_does_not_fabricate_matches() {
+        // Regression: previously a malformed `fixed`/`last_affected`
+        // could degrade to "unbounded above" and silently match
+        // installs the advisory never named.
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "9.9.9")))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-bad",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"fixed": "not-a-version"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(
+            report.new_findings, 0,
+            "malformed close ⇒ drop the open ⇒ no fabricated matches"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_advisories_splits_versions_and_ranges_counts() {
+        let s = Store::open_in_memory().unwrap();
+        // Range-only advisory: zero versions, one range.
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "RNG",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"fixed": "2.0.0"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        let listed = s.list_advisories(None).await.unwrap();
+        assert_eq!(listed[0].affected_count, 0);
+        assert_eq!(listed[0].affected_ranges_count, 1);
+    }
+
+    #[tokio::test]
+    async fn semver_range_does_not_double_count_with_exact() {
+        // An advisory that lists BOTH the exact version AND a
+        // covering range must still produce only ONE finding per
+        // (advisory, install) pair (UNIQUE constraint).
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "p", "1.0.5")))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "GHSA-both",
+            "database_specific": {"severity": "HIGH"},
+            "affected": [{
+                "package": {"ecosystem": "npm", "name": "p"},
+                "versions": ["1.0.5"],
+                "ranges": [{"type": "SEMVER", "events": [
+                    {"introduced": "1.0.0"}, {"fixed": "2.0.0"}
+                ]}]
+            }],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        let report = s.scan_findings().await.unwrap();
+        assert_eq!(report.new_findings, 1);
+        assert_eq!(report.total_findings, 1);
+    }
+
+    #[tokio::test]
+    async fn list_findings_filters_by_min_severity() {
+        let s = Store::open_in_memory().unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "a", "1")))
+            .await
+            .unwrap();
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, "b", "1")))
+            .await
+            .unwrap();
+        // Two advisories with different severities.
+        let low: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "LOW", "database_specific": {"severity": "LOW"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "a"}, "versions": ["1"]}],
+        }))
+        .unwrap();
+        let critical: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": "CRIT", "database_specific": {"severity": "CRITICAL"},
+            "affected": [{"package": {"ecosystem": "npm", "name": "b"}, "versions": ["1"]}],
+        }))
+        .unwrap();
+        s.upsert_advisory(low, None).await.unwrap();
+        s.upsert_advisory(critical, None).await.unwrap();
+        s.scan_findings().await.unwrap();
+
+        let all = s.list_findings(FindingFilter::default()).await.unwrap();
+        assert_eq!(all.len(), 2);
+        let high_only = s
+            .list_findings(FindingFilter {
+                min_severity: Some(Severity::High),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(high_only.len(), 1);
+        assert_eq!(high_only[0].advisory.osv_id, "CRIT");
+    }
+
+    #[tokio::test]
+    async fn list_advisories_returns_affected_count() {
+        let s = Store::open_in_memory().unwrap();
+        s.upsert_advisory(osv_adv("GHSA-1", "npm", "p", &["1", "2", "3"]), None)
+            .await
+            .unwrap();
+        let advs = s.list_advisories(None).await.unwrap();
+        assert_eq!(advs.len(), 1);
+        assert_eq!(advs[0].affected_count, 3);
+    }
+
+    #[tokio::test]
+    async fn schema_version_is_current() {
+        let s = Store::open_in_memory().unwrap();
+        assert_eq!(s.schema_version().await.unwrap(), CURRENT_SCHEMA_VERSION);
+    }
+
+    // ---------- dispatch targets / pending ----------
+
+    fn target_spec(label: &str, min: Severity) -> TargetSpec {
+        TargetSpec {
+            label: label.into(),
+            url: "https://ops.example.com/hook".into(),
+            secret: "0123456789abcdef0123".into(),
+            min_severity: min,
+            source_filter: None,
+        }
+    }
+
+    async fn seeded_finding(s: &Store, name: &str, ver: &str, sev: &str) {
+        s.insert(rec(InstallEvent::new(Ecosystem::Npm, name, ver)))
+            .await
+            .unwrap();
+        let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+            "id": format!("ADV-{name}-{ver}"),
+            "database_specific": {"severity": sev},
+            "affected": [{"package": {"ecosystem": "npm", "name": name}, "versions": [ver]}],
+        }))
+        .unwrap();
+        s.upsert_advisory(adv, None).await.unwrap();
+        s.scan_findings().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pending_deliveries_respects_severity_filter() {
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "LOW").await;
+        seeded_finding(&s, "b", "1", "CRITICAL").await;
+        // Target is High+
+        s.register_target(target_spec("high-only", Severity::High))
+            .await
+            .unwrap();
+        let pending = s.pending_deliveries(100, DEFAULT_CAP).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].install_name, "b");
+    }
+
+    #[tokio::test]
+    async fn pending_deliveries_respects_source_filter() {
+        let s = Store::open_in_memory().unwrap();
+        // Install with desktop-y path; the heuristic classifies as Desktop.
+        let ev_desktop =
+            InstallEvent::new(Ecosystem::Npm, "a", "1").with_project_path("/Users/alice/p");
+        s.insert(rec(ev_desktop)).await.unwrap();
+        // Install with runner-y path; classifies as Actions.
+        let ev_actions =
+            InstallEvent::new(Ecosystem::Npm, "b", "1").with_project_path("/home/runner/work/r/r");
+        s.insert(rec(ev_actions)).await.unwrap();
+        for name in ["a", "b"] {
+            let adv: OsvAdvisory = serde_json::from_value(serde_json::json!({
+                "id": format!("X-{name}"),
+                "database_specific": {"severity": "CRITICAL"},
+                "affected": [{"package": {"ecosystem": "npm", "name": name}, "versions": ["1"]}],
+            }))
+            .unwrap();
+            s.upsert_advisory(adv, None).await.unwrap();
+        }
+        s.scan_findings().await.unwrap();
+        s.register_target(TargetSpec {
+            source_filter: Some(Source::Actions),
+            ..target_spec("actions-only", Severity::Low)
+        })
+        .await
+        .unwrap();
+        let pending = s.pending_deliveries(100, DEFAULT_CAP).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].install_source, Source::Actions);
+    }
+
+    #[tokio::test]
+    async fn record_attempt_then_pending_excludes_success() {
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "CRITICAL").await;
+        let tid = s
+            .register_target(target_spec("t", Severity::Low))
+            .await
+            .unwrap();
+        let pending = s.pending_deliveries(10, DEFAULT_CAP).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        s.record_attempt(pending[0].finding_id, tid, true, Some(200), None)
+            .await
+            .unwrap();
+        assert!(
+            s.pending_deliveries(10, DEFAULT_CAP)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn attempt_cap_excludes_repeat_failures() {
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "CRITICAL").await;
+        let tid = s
+            .register_target(target_spec("t", Severity::Low))
+            .await
+            .unwrap();
+        let pending = s.pending_deliveries(10, DEFAULT_CAP).await.unwrap();
+        let fid = pending[0].finding_id;
+        for _ in 0..3 {
+            s.record_attempt(fid, tid, false, Some(500), Some("nope".into()))
+                .await
+                .unwrap();
+        }
+        // Cap=3 ⇒ excluded.
+        assert!(s.pending_deliveries(10, 3).await.unwrap().is_empty());
+        // Cap=4 ⇒ one more attempt allowed.
+        assert_eq!(s.pending_deliveries(10, 4).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn disabled_target_is_excluded() {
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "CRITICAL").await;
+        let tid = s
+            .register_target(target_spec("t", Severity::Low))
+            .await
+            .unwrap();
+        s.set_target_enabled(tid, false).await.unwrap();
+        assert!(
+            s.pending_deliveries(10, DEFAULT_CAP)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_target_preserves_attempts() {
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "CRITICAL").await;
+        let tid = s
+            .register_target(target_spec("t", Severity::Low))
+            .await
+            .unwrap();
+        let pending = s.pending_deliveries(10, DEFAULT_CAP).await.unwrap();
+        let fid = pending[0].finding_id;
+        s.record_attempt(fid, tid, true, Some(200), None)
+            .await
+            .unwrap();
+        assert!(s.delete_target(tid).await.unwrap());
+        // Target no longer surfaces in list_targets, but the
+        // attempt row survives for audit. Read it via a direct
+        // query through the conn mutex.
+        assert!(s.list_targets().await.unwrap().is_empty());
+        let conn = s.conn.clone();
+        let attempts: i64 = tokio::task::spawn_blocking(move || {
+            let g = conn.blocking_lock();
+            g.query_row(
+                "SELECT COUNT(*) FROM dispatch_attempts WHERE target_id = ?1",
+                params![tid],
+                |r| r.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+        assert_eq!(attempts, 1, "attempt row should survive soft-delete");
+    }
+
+    #[tokio::test]
+    async fn unique_partial_index_prevents_duplicate_success() {
+        // Defence-in-depth: even if `record_attempt(.., true, ..)`
+        // is invoked twice for the same (finding, target), the
+        // second one must fail rather than silently double-count.
+        let s = Store::open_in_memory().unwrap();
+        seeded_finding(&s, "a", "1", "CRITICAL").await;
+        let tid = s
+            .register_target(target_spec("t", Severity::Low))
+            .await
+            .unwrap();
+        let pending = s.pending_deliveries(10, DEFAULT_CAP).await.unwrap();
+        let fid = pending[0].finding_id;
+        s.record_attempt(fid, tid, true, Some(200), None)
+            .await
+            .unwrap();
+        let err = s
+            .record_attempt(fid, tid, true, Some(200), None)
+            .await
+            .expect_err("second success attempt should error");
+        assert!(format!("{err:#}").to_ascii_lowercase().contains("unique"));
+    }
+
+    #[tokio::test]
+    async fn delete_target_returns_bool() {
+        let s = Store::open_in_memory().unwrap();
+        let id = s
+            .register_target(target_spec("gone", Severity::High))
+            .await
+            .unwrap();
+        assert!(s.delete_target(id).await.unwrap());
+        assert!(!s.delete_target(id).await.unwrap());
+    }
+
+    const DEFAULT_CAP: i64 = 5;
+
+    #[tokio::test]
+    async fn parallel_ingest_and_list_under_load() {
+        // Spawn several writers + a reader against the same Store
+        // and assert nothing wedges and the final count is right.
+        let s = std::sync::Arc::new(Store::open_in_memory().unwrap());
+        let mut handles = Vec::new();
+        for w in 0..4 {
+            let s = s.clone();
+            handles.push(tokio::spawn(async move {
+                for i in 0..25 {
+                    let ev = InstallEvent::new(Ecosystem::Npm, format!("p{w}"), format!("{i}"));
+                    s.insert(rec(ev)).await.unwrap();
+                }
+            }));
+        }
+        let reader = {
+            let s = s.clone();
+            tokio::spawn(async move {
+                for _ in 0..10 {
+                    let _ = s.list(ListFilter::default()).await.unwrap();
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        for h in handles {
+            h.await.unwrap();
+        }
+        reader.await.unwrap();
+        assert_eq!(s.count().await.unwrap(), 4 * 25);
+    }
+}


### PR DESCRIPTION
## Summary

New crate `sakimori-hub` — the optional self-hostable companion service called out in CLAUDE.md roadmap item #6. Operators run it on their own infra (Cloudflare Containers is the headline target; deploy artifacts included) to receive `InstallEvent` JSON from every `sakimori-proxy` across CI runners and developer laptops, JOIN those installs against an OSV advisory store, and dispatch webhooks when a past install matches a newly-disclosed vulnerability.

The crate landed across 8 internally-reviewed slices (each individually run through Codex; full review history per slice). Total surface: **~11k lines of Rust + ~150 unit/integration tests + 3 bin tests**, all green under `fmt`, `clippy -D warnings`, `cargo test --workspace`.

## What's in this PR

### Core data model (slice 7)
- SQLite via `rusqlite` (bundled), `epoch_ms INTEGER` timestamps with WAL+NORMAL.
- Numbered transactional migrations + singleton `schema_version` (currently `v9`).
- `POST /ingest` (single or atomic batch), `GET /installs` (filtered), `GET /` HTML inventory.
- `classify.rs`: Actions / Desktop / Unknown derived from `project_path` + `user_agent`.

### OSV advisories + JOIN (slice 8)
- `OsvAdvisory` parser — `versions[]` exact match + `ranges[]` SemVer 2.0 (npm + crates; PyPI/NuGet explicitly skipped).
- `MATCHING_MODE = exact_versions_and_semver_ranges` surfaced on `/healthz`, `ScanReport`, `AdvisoryImportResp`.
- Stale-findings prune on advisory upsert (shrink).
- Per-advisory caps + per-field length validation (range + version rows count toward `MAX_AFFECTED_ROWS`).

### Webhook dispatcher (slice 9)
- HMAC-SHA256 signed POSTs (`X-Sakimori-Signature: sha256=<hex>`).
- **SafeResolver** shim on `ureq::Agent` blocks RFC1918 / loopback / link-local / IMDS at *connect time* — closes the DNS-rebinding TOCTOU.
- `UNIQUE(finding_id, target_id) WHERE success=1` partial index prevents double-fire even under bug.
- Background `spawn_loop`: each tick runs **scan → dispatch** under the shared `dispatch_lock` (no race with manual `POST /dispatch/run`).

### Cloudflare Containers deploy (slice 10)
- Multi-stage `Dockerfile` (non-root UID 10001, debian:bookworm-slim runtime, `$PORT` honored).
- `wrangler.toml` with `image_build_context`, `[[migrations]] new_sqlite_classes`, persistent volume.
- `worker.js` using `@cloudflare/containers` (`Container` base + `getContainer().fetch(request)`), envVars allowlist forwards `SAKIMORI_HUB_INGEST_TOKEN` into the container process.

### Three independent auth paths (slices 11–14)

| Credential | Mint via | Carry as | Used by |
|---|---|---|---|
| **Browser session cookie** | `/auth/github/login` (OAuth + allowlist) | `Cookie:` + CSRF Origin/Referer check on unsafe methods | Operators in a browser |
| **Personal API token** (`shp_*`) | `POST /api/tokens` (session-authed) | `Authorization: Bearer shp_…` | Developer laptops / CI bootstrap |
| **Actions OIDC** (`sha_*`) | `POST /auth/actions/exchange` (JWT) | `Authorization: Bearer sha_…` | GitHub Actions workflows |
| Legacy shared secret | `--ingest-token` / `SAKIMORI_HUB_INGEST_TOKEN` | `Authorization: Bearer …` | CI bootstrap before OAuth |

Plus **Device Authorization Flow** (RFC 8628) so a CLI on a laptop without a browser can have the operator approve via `/auth/device` and the CLI's poll receives a fresh `shp_*`. Cleartext only exists at consume time inside one SQLite tx.

#### Security-relevant choices

- All token-hash columns are SHA-256 of the cleartext; cleartext never persisted.
- HMAC + comparisons use `subtle::ConstantTimeEq`.
- GitHub `allowed_github_logins` re-checked **on every request** so offboarding is immediate (incl. for long-lived `shp_` tokens).
- Actions JWKS cache: TTL respected on stale hits, fresh-cache misses throttled to 1 network call per 30s (closes attacker-driven kid spam on the unauth exchange endpoint).
- Reads default to gated. `--public-reads` is the explicit opt-in for "auth proxy in front".
- Non-loopback bind requires at least one of: bearer / OAuth bundle / Actions OIDC; `main.rs` hard-bails otherwise.
- Browser SameSite=Lax + Origin/Referer CSRF check on cookie-authenticated **unsafe** methods (GET pages stay linkable so `verification_uri_complete` from a terminal works).

## Why

This unblocks the team-wide retroactive-CVE notifier promise in CLAUDE.md item #6 — the proxy side has been logging installs locally; this PR is the server that aggregates, joins, and notifies. Cloudflare Containers + GitHub-native auth means the deploy footprint is "one wrangler deploy + an OAuth App" rather than a long ops runway.

## Things a reviewer should know

- New crate; no existing files in the workspace change behavior (just adds `crates/sakimori-hub` to `[workspace.members]`).
- Adds deps: `axum 0.7`, `rusqlite 0.32` (bundled), `hmac 0.12`, `jsonwebtoken 9`, `subtle 2`, `urlencoding 2`, `rand 0.8`, `tower 0.5`. All are common-ish.
- `axum` features chosen explicitly (`default-features=false`, then `http1`/`json`/`query`/`tokio`/`form`).
- Quirk noted in code: axum 0.7's router silently 404s parametric routes (`/api/tokens/{id}` DELETE) when merged alongside another parametric route with the same `{id}` placeholder. Worked around with `POST /api/tokens/revoke` taking the id in the body. (Mentioned inline so future readers don't repeat the trip.)
- `sakimori login` CLI is intentionally deferred to a small follow-up slice — the device flow is fully usable via curl today.
- Next planned slices (NOT in this PR): Teams + `team_id` migration + RBAC + invite (slice 11 in the broader plan), R2 per-team backup, Stripe billing (design only).

## Deploy quickstart (Cloudflare Containers)

```bash
cd crates/sakimori-hub/cloudflare
npm install
wrangler secret put SAKIMORI_HUB_INGEST_TOKEN
# (or for the OAuth path)
# wrangler secret put SAKIMORI_HUB_GITHUB_CLIENT_SECRET
# wrangler secret put SAKIMORI_HUB_SESSION_SECRET
wrangler deploy
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 152 hub-lib + 3 hub-bin tests, plus the pre-existing 208 sakimori-core / 193 sakimori-proxy / 61 sakimori-common, all green
- [ ] Smoke: `wrangler deploy` to a personal Cloudflare account, run device flow + ingest end-to-end
- [ ] Wire `sakimori-proxy` to POST to `/ingest` (next PR — proxy-side change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)