### PR TITLE
docs: roll back source enum to {actions, desktop} + record Actions-bias rationale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,9 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
    `InstallEvent` that hits `/ingest` is durably stored
    (`(ecosystem, name, version, resolved_at, execution_mode,
    user_agent, project_path, source)` with `source` ∈
-   `{actions, desktop, unknown}` (the `unknown` lane exists so
-   ambiguous events aren't mis-routed — see the hub repo's
+   `{actions, desktop}` (hub-side derived; ambiguous events bias
+   toward `actions` so a compromised CI runner can't dodge
+   CI-scoped alerts by spoofing `desktop` — see the hub repo's
    `docs/port-from-sakimori-pr76.md` §2.1) derived from a
    hub-side classifier on `user_agent` / `project_path`), and a small read API
    (`GET /installs?ecosystem=&name=&since=&source=`) plus a


### PR DESCRIPTION
## Summary

PR #77 added `unknown` to the `source` enum description in CLAUDE.md based on the original port plan ([`docs/port-from-sakimori-pr76.md`](https://github.com/bokuweb/sakimori-hub/blob/main/docs/port-from-sakimori-pr76.md) §2.1 first revision).

When actually implementing §2.1, the hub team kept the existing binary `{actions, desktop}` classifier with explicit Actions-bias — that bias is the security property (a compromised CI runner can't dodge CI-scoped alert channels by spoofing `source=desktop`). Adding an `unknown` lane that operators may forget to subscribe to would trade that property for "judgment honesty" — wrong trade for this product.

This PR aligns CLAUDE.md with the implemented design: `{actions, desktop}` + a one-line rationale pointing at the hub PR.

See [sakimori-hub#17](https://github.com/bokuweb/sakimori-hub/pull/17) for the implementation + codex review (the round-1 review caught a non-ASCII path DoS in the existing classifier as a bonus).

## Test plan

- [x] Doc-only change, no code impact
- [ ] CI green