### PR TITLE
feat(actions): add audit-repo with CODEOWNERS .github/ lint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,18 +515,27 @@ of value-per-implementation-cost.
     cache key is provably untouchable from the PR side — all
     follow-ups.
 
-    **Follow-ups surfaced by the TanStack post-mortem** (open):
-    - **CODEOWNERS-for-`.github/` lint** — new repo-scoped
-      `sakimori actions audit-repo <root>` (or a `--repo` flag on
-      the existing command) that reads `CODEOWNERS` at the three
-      canonical locations (`.github/CODEOWNERS`, `CODEOWNERS`,
-      `docs/CODEOWNERS`) and emits a Warn-level finding if no
-      pattern covers `.github/workflows/` (or `.github/` broadly).
-      Reason: without owner gating, any maintainer push can ship a
-      workflow change that introduces the very rules this lint
-      catches. Different from the per-file `audit` because it
-      needs the repo structure, not just YAML — own subcommand
-      keeps the file-scoped invocation cheap.
+    **Follow-ups surfaced by the TanStack post-mortem**:
+    - **CODEOWNERS-for-`.github/` lint** — ✅ implemented as
+      `sakimori actions audit-repo <root>`. Walks the three
+      canonical CODEOWNERS locations (`.github/CODEOWNERS`,
+      `CODEOWNERS`, `docs/CODEOWNERS`) in GitHub's documented order,
+      parses pattern + owner rules, and reports whether any rule
+      with at least one owner token (`@user`, `@org/team`, or an
+      email) covers `.github/workflows/foo.yml` and
+      `.github/dependabot.yml`. Surfaces the matched rule (pattern,
+      owners, line number) so reviewers can jump straight to the
+      gate. The subcommand also walks `.github/workflows/*.{yml,
+      yaml}` and runs the per-file `audit` checks for free — one
+      repo-level invocation covers SHA-pinning, cache-poisoning,
+      untrusted-checkout, and ownership in a single report. Default
+      severity for a missing CODEOWNERS rule is Warn (most repos
+      historically didn't gate `.github/`; we don't want to break
+      their first audit run); `--strict-codeowners` escalates to
+      Error / non-zero exit. The matcher implements enough of
+      gitignore semantics for `.github/` gating (`*`, `**`, leading
+      `/` anchoring, trailing `/` directory-only) — character
+      classes and `?` are deliberately out of scope.
     - **`zizmor` parity surface** — sakimori's two rules cover the
       cache-poisoning + dangerous-checkout slices; zizmor catches
       a wider set (`template-injection`, `excessive-permissions`,

--- a/crates/sakimori-core/src/codeowners.rs
+++ b/crates/sakimori-core/src/codeowners.rs
@@ -1,0 +1,512 @@
+//! CODEOWNERS auditor — checks whether `.github/workflows/` (and the
+//! wider `.github/` tree) is covered by an owner pattern.
+//!
+//! Motivation: the TanStack 2025 npm compromise was made possible by
+//! a workflow change merged into the base repo. CODEOWNERS gating on
+//! `.github/` would have forced a security-aware reviewer onto every
+//! PR that touched workflow code, including the one that introduced
+//! the dangerous `pull_request_target` pattern in the first place.
+//!
+//! GitHub looks for CODEOWNERS at three canonical paths (first hit
+//! wins):
+//! - `.github/CODEOWNERS`
+//! - `CODEOWNERS`
+//! - `docs/CODEOWNERS`
+//!
+//! Pattern syntax is gitignore-derived. We implement enough of it to
+//! answer "would this pattern match `.github/workflows/foo.yml`?" —
+//! `*` (single-segment wildcard), `**` (zero-or-more segments),
+//! leading `/` (anchored to repo root), trailing `/` (directory).
+//! Character classes (`[...]`) and `?` are out of scope; if a real
+//! repo ever needs them we can grow the matcher.
+//!
+//! The check is **structural**: any rule with at least one owner
+//! token (`@user`, `@org/team`, or an `<email>`) whose pattern
+//! covers `.github/workflows/` is enough to satisfy the lint. We
+//! don't try to validate that the owners actually exist or have
+//! review authority — that's the GitHub server's job.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+/// One parsed line of a CODEOWNERS file.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Rule {
+    pub pattern: String,
+    /// Raw owner tokens (`@user`, `@org/team`, `user@example.com`).
+    /// Empty means "explicitly unowned" — GitHub treats that as
+    /// "no required reviewer", which for this lint counts as
+    /// **not** owned.
+    pub owners: Vec<String>,
+    /// 1-indexed line number in the source file. Surfaced in
+    /// findings so reviewers can jump straight to the rule.
+    pub line_no: usize,
+}
+
+/// Where the CODEOWNERS file we used was found, plus the rules it
+/// contained. `source = None` means none of the three canonical
+/// locations existed.
+#[derive(Debug, Clone, Serialize)]
+pub struct CodeownersFile {
+    pub source: Option<PathBuf>,
+    pub rules: Vec<Rule>,
+}
+
+/// Result of auditing a repo root for `.github/`-coverage owners.
+#[derive(Debug, Clone, Serialize)]
+pub struct Coverage {
+    /// The CODEOWNERS source we read (relative to the repo root if
+    /// possible). `None` means no CODEOWNERS existed.
+    pub source: Option<PathBuf>,
+    /// First rule (in CODEOWNERS order) whose pattern covers
+    /// `.github/workflows/foo.yml`. We surface the *first* rather
+    /// than "last wins" because the lint question is "is there any
+    /// owner gating at all" — order-of-precedence within the file
+    /// matters only when you want to know who'll actually be
+    /// requested as reviewer.
+    pub workflows_rule: Option<Rule>,
+    /// As above for `.github/dependabot.yml` — a file in `.github/`
+    /// outside `workflows/`. Lets the report distinguish "covered
+    /// because the rule was `.github/`" from "covered only because
+    /// of a workflows-specific rule".
+    pub github_rule: Option<Rule>,
+}
+
+impl Coverage {
+    pub fn workflows_covered(&self) -> bool {
+        self.workflows_rule.is_some()
+    }
+    pub fn github_covered(&self) -> bool {
+        self.github_rule.is_some()
+    }
+}
+
+/// Walk the three canonical CODEOWNERS locations under `root` in
+/// GitHub's documented order and return the first one that exists.
+/// Returns `Ok(CodeownersFile { source: None, rules: vec![] })` when
+/// none are present — distinguishable from "exists but empty".
+pub fn load(root: &Path) -> Result<CodeownersFile> {
+    for rel in [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"] {
+        let p = root.join(rel);
+        if p.exists() {
+            let text =
+                std::fs::read_to_string(&p).with_context(|| format!("reading {}", p.display()))?;
+            return Ok(CodeownersFile {
+                source: Some(PathBuf::from(rel)),
+                rules: parse(&text),
+            });
+        }
+    }
+    Ok(CodeownersFile {
+        source: None,
+        rules: Vec::new(),
+    })
+}
+
+/// Convenience wrapper: load + classify in one call. Pure I/O for the
+/// load, pure compute for the classify — same `Coverage` shape either
+/// way.
+pub fn audit_repo(root: &Path) -> Result<Coverage> {
+    let file = load(root)?;
+    Ok(classify(&file))
+}
+
+/// Compute coverage from already-parsed rules — extracted so tests
+/// can exercise the matching logic without touching the filesystem.
+pub fn classify(file: &CodeownersFile) -> Coverage {
+    let workflows_rule = first_owning_rule(&file.rules, ".github/workflows/example.yml");
+    let github_rule = first_owning_rule(&file.rules, ".github/dependabot.yml");
+    Coverage {
+        source: file.source.clone(),
+        workflows_rule,
+        github_rule,
+    }
+}
+
+fn first_owning_rule(rules: &[Rule], path: &str) -> Option<Rule> {
+    rules
+        .iter()
+        .find(|r| !r.owners.is_empty() && pattern_matches(&r.pattern, path))
+        .cloned()
+}
+
+/// Parse a CODEOWNERS file. Tolerant — invalid lines are silently
+/// skipped rather than failing the audit, since GitHub itself is
+/// lenient and we'd rather surface coverage gaps than punt on parsing.
+pub fn parse(text: &str) -> Vec<Rule> {
+    let mut out = Vec::new();
+    for (idx, raw) in text.lines().enumerate() {
+        let line_no = idx + 1;
+        // Strip inline comments. CODEOWNERS doesn't formally support
+        // mid-line `#`, but GitHub's parser does — treat anything from
+        // an unescaped `#` to EOL as comment.
+        let no_comment = match raw.find('#') {
+            Some(i) => &raw[..i],
+            None => raw,
+        };
+        let trimmed = no_comment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let mut parts = trimmed.split_whitespace();
+        let Some(pattern) = parts.next() else {
+            continue;
+        };
+        let owners: Vec<String> = parts
+            .filter(|s| is_owner_token(s))
+            .map(String::from)
+            .collect();
+        out.push(Rule {
+            pattern: pattern.to_string(),
+            owners,
+            line_no,
+        });
+    }
+    out
+}
+
+fn is_owner_token(s: &str) -> bool {
+    // `@user`, `@org/team`, or an email — anything else is junk we
+    // shouldn't count as ownership.
+    s.starts_with('@') || s.contains('@')
+}
+
+/// Does `pattern` match `path` under CODEOWNERS semantics?
+///
+/// Implemented features:
+/// - leading `/` anchors to repo root; without it the pattern matches
+///   anywhere in the tree.
+/// - trailing `/` requires the matched name to be (or be under) a
+///   directory of that name.
+/// - `*` matches any run of non-`/` characters within one segment.
+/// - `**` matches zero or more segments (including empty).
+/// - bare `*` (no other segments) is treated as "everything", which
+///   is how GitHub treats it.
+///
+/// Out of scope: `?`, `[abc]`, escape sequences. None of those appear
+/// in any CODEOWNERS file we'd reasonably encounter for `.github/`
+/// gating, and growing the matcher would just expand the surface
+/// area without changing the lint's verdict.
+pub fn pattern_matches(pattern: &str, path: &str) -> bool {
+    let p = pattern.trim();
+    if p.is_empty() {
+        return false;
+    }
+    // Bare `*` — GitHub treats this as the catch-all "owns everything".
+    if p == "*" {
+        return true;
+    }
+    let dir_only = p.ends_with('/');
+    let body = p.trim_end_matches('/');
+    // gitignore semantics: a pattern is anchored to the repo root if
+    // it contains a `/` anywhere except as a trailing directory
+    // marker. So `.github/workflows/` is anchored even without a
+    // leading `/`, but `workflows/` (single segment) floats.
+    let anchored_leading = body.starts_with('/');
+    let core = body.trim_start_matches('/');
+    let anchored = anchored_leading || core.contains('/');
+    let pat_segs: Vec<&str> = core.split('/').collect();
+    let path_segs: Vec<&str> = path.split('/').collect();
+
+    if anchored {
+        match match_prefix(&pat_segs, &path_segs) {
+            Some(consumed) => {
+                if dir_only {
+                    // Directory pattern: need at least one descendant
+                    // segment in the path beyond what the pattern
+                    // consumed.
+                    consumed < path_segs.len()
+                } else {
+                    // File pattern: must consume the whole path
+                    // exactly, OR match a prefix when the last pattern
+                    // segment is `**` (zero-or-more under that prefix).
+                    consumed == path_segs.len() || pat_segs.last() == Some(&"**")
+                }
+            }
+            None => false,
+        }
+    } else {
+        // Floating single-segment pattern: try every start offset.
+        // `**` cannot appear in this branch in practice (would imply
+        // a multi-segment pattern, which is anchored).
+        for start in 0..path_segs.len() {
+            if let Some(consumed) = match_prefix(&pat_segs, &path_segs[start..]) {
+                let total = start + consumed;
+                let ok = if dir_only {
+                    total < path_segs.len()
+                } else {
+                    total == path_segs.len()
+                };
+                if ok {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Try to match `pat` against the beginning of `path`. Returns the
+/// number of *path* segments consumed on success, or `None` on
+/// failure. `**` greedily consumes zero or more path segments.
+fn match_prefix(pat: &[&str], path: &[&str]) -> Option<usize> {
+    if pat.is_empty() {
+        return Some(0);
+    }
+    if pat[0] == "**" {
+        // Try the longest consumption first — slightly cheaper for
+        // the common `prefix/**` case where we want to swallow the
+        // rest. Either direction is correct.
+        for take in (0..=path.len()).rev() {
+            if let Some(rest) = match_prefix(&pat[1..], &path[take..]) {
+                return Some(take + rest);
+            }
+        }
+        return None;
+    }
+    if path.is_empty() {
+        return None;
+    }
+    if !segment_matches(pat[0], path[0]) {
+        return None;
+    }
+    match_prefix(&pat[1..], &path[1..]).map(|r| 1 + r)
+}
+
+/// Single-segment match with `*` glob support.
+fn segment_matches(pat: &str, seg: &str) -> bool {
+    if pat == "*" {
+        return true;
+    }
+    if !pat.contains('*') {
+        return pat == seg;
+    }
+    // Split on `*` and check the literal parts appear in order, with
+    // anchors at the ends.
+    let parts: Vec<&str> = pat.split('*').collect();
+    let mut rest = seg;
+    for (i, p) in parts.iter().enumerate() {
+        if i == 0 {
+            if !rest.starts_with(p) {
+                return false;
+            }
+            rest = &rest[p.len()..];
+        } else if i == parts.len() - 1 {
+            if !rest.ends_with(p) {
+                return false;
+            }
+        } else {
+            let Some(idx) = rest.find(p) else {
+                return false;
+            };
+            rest = &rest[idx + p.len()..];
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_skips_comments_and_blanks() {
+        let text = "\
+# top comment
+
+.github/ @org/security  # inline comment
+*.rs @rustlang
+";
+        let rules = parse(text);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, ".github/");
+        assert_eq!(rules[0].owners, vec!["@org/security".to_string()]);
+        assert_eq!(rules[1].pattern, "*.rs");
+        assert_eq!(rules[1].owners, vec!["@rustlang".to_string()]);
+    }
+
+    #[test]
+    fn parse_recognises_email_owners() {
+        let rules = parse("README.md security@example.com\n");
+        assert_eq!(rules[0].owners, vec!["security@example.com".to_string()]);
+    }
+
+    #[test]
+    fn parse_filters_garbage_owner_tokens() {
+        // Tokens that aren't `@…` or an email are dropped — gives a
+        // sharper "explicitly unowned" signal.
+        let rules = parse("path foobar @real\n");
+        assert_eq!(rules[0].owners, vec!["@real".to_string()]);
+    }
+
+    #[test]
+    fn pattern_star_matches_anything() {
+        assert!(pattern_matches("*", ".github/workflows/foo.yml"));
+        assert!(pattern_matches("*", "src/main.rs"));
+    }
+
+    #[test]
+    fn pattern_double_star_directory_covers_subtree() {
+        assert!(pattern_matches(".github/**", ".github/workflows/foo.yml"));
+        assert!(pattern_matches(".github/**", ".github/dependabot.yml"));
+        // Doesn't match unrelated paths.
+        assert!(!pattern_matches(".github/**", "src/main.rs"));
+    }
+
+    #[test]
+    fn pattern_directory_trailing_slash_matches_subtree() {
+        assert!(pattern_matches(".github/", ".github/workflows/foo.yml"));
+        assert!(pattern_matches(
+            ".github/workflows/",
+            ".github/workflows/foo.yml"
+        ));
+        // Trailing-slash patterns require children — don't match the
+        // bare directory name.
+        assert!(!pattern_matches(".github/workflows/", ".github/workflows"));
+    }
+
+    #[test]
+    fn pattern_anchored_vs_floating() {
+        // Anchored: only matches from repo root.
+        assert!(pattern_matches(
+            "/.github/workflows/",
+            ".github/workflows/x"
+        ));
+        // Floating single segment: matches anywhere.
+        assert!(pattern_matches("workflows/", "deep/nested/workflows/x"));
+        // Multi-segment unanchored is treated as anchored per
+        // gitignore semantics — no match at depth.
+        assert!(!pattern_matches(
+            ".github/workflows/",
+            "nested/.github/workflows/x"
+        ));
+    }
+
+    #[test]
+    fn pattern_specific_file_does_not_cover_siblings() {
+        let p = ".github/workflows/release.yml";
+        assert!(pattern_matches(p, ".github/workflows/release.yml"));
+        assert!(!pattern_matches(p, ".github/workflows/ci.yml"));
+    }
+
+    #[test]
+    fn pattern_wildcard_in_segment() {
+        assert!(pattern_matches(
+            ".github/workflows/*.yml",
+            ".github/workflows/ci.yml"
+        ));
+        assert!(!pattern_matches(
+            ".github/workflows/*.yml",
+            ".github/workflows/sub/ci.yml"
+        ));
+    }
+
+    #[test]
+    fn classify_finds_workflows_owner() {
+        let file = CodeownersFile {
+            source: Some(PathBuf::from(".github/CODEOWNERS")),
+            rules: parse(".github/ @org/security\n"),
+        };
+        let c = classify(&file);
+        assert!(c.workflows_covered());
+        assert!(c.github_covered());
+        assert_eq!(
+            c.workflows_rule.as_ref().unwrap().owners,
+            vec!["@org/security".to_string()]
+        );
+    }
+
+    #[test]
+    fn classify_distinguishes_workflows_only_coverage() {
+        let file = CodeownersFile {
+            source: Some(PathBuf::from(".github/CODEOWNERS")),
+            rules: parse(".github/workflows/ @ci-team\n"),
+        };
+        let c = classify(&file);
+        assert!(c.workflows_covered());
+        assert!(
+            !c.github_covered(),
+            "workflows-only rule must not also cover .github/dependabot.yml"
+        );
+    }
+
+    #[test]
+    fn classify_treats_unowned_rule_as_uncovered() {
+        // An owner-less rule (`path` with no `@user`) is an explicit
+        // "no required reviewer" — GitHub blocks the merge on it
+        // only if branch protection is configured that way, and for
+        // our lint we want to flag this as "not actually gated".
+        let file = CodeownersFile {
+            source: Some(PathBuf::from(".github/CODEOWNERS")),
+            rules: parse(".github/\n"),
+        };
+        let c = classify(&file);
+        assert!(!c.workflows_covered());
+    }
+
+    #[test]
+    fn classify_returns_no_rule_when_codeowners_missing() {
+        let file = CodeownersFile {
+            source: None,
+            rules: Vec::new(),
+        };
+        let c = classify(&file);
+        assert!(!c.workflows_covered());
+        assert!(!c.github_covered());
+        assert!(c.source.is_none());
+    }
+
+    #[test]
+    fn load_walks_three_canonical_locations_in_order() {
+        let tmp = std::env::temp_dir().join(format!(
+            "sakimori-codeowners-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(tmp.join(".github")).unwrap();
+        std::fs::create_dir_all(tmp.join("docs")).unwrap();
+        std::fs::write(tmp.join(".github/CODEOWNERS"), ".github/ @first\n").unwrap();
+        std::fs::write(tmp.join("CODEOWNERS"), "* @second\n").unwrap();
+        std::fs::write(tmp.join("docs/CODEOWNERS"), "* @third\n").unwrap();
+        let f = load(&tmp).unwrap();
+        assert_eq!(f.source.as_deref(), Some(Path::new(".github/CODEOWNERS")));
+        assert_eq!(f.rules[0].owners, vec!["@first".to_string()]);
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn load_falls_back_to_root_and_docs() {
+        let tmp = std::env::temp_dir().join(format!(
+            "sakimori-codeowners-fall-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(tmp.join("docs")).unwrap();
+        std::fs::write(tmp.join("docs/CODEOWNERS"), "* @docs-team\n").unwrap();
+        let f = load(&tmp).unwrap();
+        assert_eq!(f.source.as_deref(), Some(Path::new("docs/CODEOWNERS")));
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn load_returns_none_source_when_no_codeowners() {
+        let tmp = std::env::temp_dir().join(format!(
+            "sakimori-codeowners-none-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let f = load(&tmp).unwrap();
+        assert!(f.source.is_none());
+        assert!(f.rules.is_empty());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+}

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod actions;
 pub mod advisories;
 pub mod attribution;
+pub mod codeowners;
 pub mod deps;
 pub mod events;
 pub mod html;

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -379,6 +379,12 @@ pub enum ActionsCommand {
     /// is present (third-party `@v1` style); first-party warnings
     /// don't fail by default — pass `--strict` to escalate them.
     Audit(ActionsAuditArgs),
+    /// Repo-scoped audit: walks `.github/workflows/*.{yml,yaml}` and
+    /// runs the same per-file checks as `audit`, plus a CODEOWNERS
+    /// coverage lint that fires when no owner pattern protects the
+    /// `.github/` tree (the gate that would have caught the TanStack
+    /// 2025 workflow change before merge).
+    AuditRepo(ActionsAuditRepoArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -410,6 +416,24 @@ pub struct ActionsAuditArgs {
 pub enum ActionsFormat {
     Text,
     Json,
+}
+
+#[derive(Debug, Parser)]
+pub struct ActionsAuditRepoArgs {
+    /// Repo root. Defaults to the current directory.
+    #[arg(default_value = ".")]
+    pub root: PathBuf,
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: ActionsFormat,
+    /// Treat first-party (`actions/*`, `github/*`) mutable refs as
+    /// blocking too. Same semantics as on `audit`.
+    #[arg(long)]
+    pub strict: bool,
+    /// Escalate the CODEOWNERS-coverage warning to a blocking error.
+    /// Default is Warn — many repos historically didn't gate
+    /// `.github/` and we don't want to break their first audit run.
+    #[arg(long)]
+    pub strict_codeowners: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1090,6 +1114,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Actions {
             cmd: ActionsCommand::Audit(args),
         } => run_actions_audit(args),
+        Command::Actions {
+            cmd: ActionsCommand::AuditRepo(args),
+        } => run_actions_audit_repo(args),
         Command::Workspace {
             cmd: WorkspaceCommand::Snapshot(args),
         } => run_workspace_snapshot(args),
@@ -1684,6 +1711,219 @@ fn run_actions_audit(args: ActionsAuditArgs) -> Result<()> {
         std::process::exit(1);
     }
     Ok(())
+}
+
+fn run_actions_audit_repo(args: ActionsAuditRepoArgs) -> Result<()> {
+    use sakimori_core::actions::{
+        Finding, Severity, Summary, WorkflowFinding, audit_workflow_yaml, audit_yaml,
+    };
+    use sakimori_core::codeowners;
+    use serde::Serialize;
+    use std::path::Path;
+
+    let workflows_dir = args.root.join(".github").join("workflows");
+    let mut files: Vec<PathBuf> = Vec::new();
+    if workflows_dir.is_dir() {
+        for entry in std::fs::read_dir(&workflows_dir)
+            .with_context(|| format!("reading {}", workflows_dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+            if matches!(ext.to_ascii_lowercase().as_str(), "yml" | "yaml") {
+                files.push(path);
+            }
+        }
+        files.sort();
+    }
+
+    let mut per_file: Vec<(PathBuf, Vec<Finding>, Vec<WorkflowFinding>)> = Vec::new();
+    for path in &files {
+        let yaml =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let mut findings =
+            audit_yaml(&yaml).with_context(|| format!("auditing {}", path.display()))?;
+        let workflow_findings = audit_workflow_yaml(&yaml)
+            .with_context(|| format!("auditing workflow rules in {}", path.display()))?;
+        if args.strict {
+            for f in &mut findings {
+                if f.severity == Severity::Warn {
+                    f.severity = Severity::Error;
+                }
+            }
+        }
+        per_file.push((path.clone(), findings, workflow_findings));
+    }
+
+    let coverage = codeowners::audit_repo(&args.root)?;
+
+    // The CODEOWNERS finding is a singleton — either the rule is
+    // satisfied (Ok), satisfied at the broader `.github/` level only
+    // (Warn-ish "fine but consider tightening to workflows/" — we
+    // collapse this into Ok for the lint), or unsatisfied (Warn /
+    // Error per `--strict-codeowners`).
+    let codeowners_status = if coverage.workflows_covered() {
+        CoStatus::Ok
+    } else if args.strict_codeowners {
+        CoStatus::Error
+    } else {
+        CoStatus::Warn
+    };
+
+    #[derive(Serialize)]
+    struct PerFile<'a> {
+        file: &'a Path,
+        findings: &'a [Finding],
+        workflow_findings: &'a [WorkflowFinding],
+        summary: Summary,
+    }
+    #[derive(Serialize)]
+    struct CodeownersReport<'a> {
+        source: Option<&'a Path>,
+        workflows_covered: bool,
+        github_covered: bool,
+        workflows_rule: Option<&'a codeowners::Rule>,
+        github_rule: Option<&'a codeowners::Rule>,
+        status: &'static str,
+        message: String,
+    }
+    #[derive(Serialize)]
+    struct RepoReport<'a> {
+        root: &'a Path,
+        files: Vec<PerFile<'a>>,
+        codeowners: CodeownersReport<'a>,
+    }
+
+    let co_message = describe_codeowners(&coverage);
+    let report = RepoReport {
+        root: &args.root,
+        files: per_file
+            .iter()
+            .map(|(p, f, wf)| PerFile {
+                file: p.as_path(),
+                findings: f,
+                workflow_findings: wf,
+                summary: Summary::from_findings(f),
+            })
+            .collect(),
+        codeowners: CodeownersReport {
+            source: coverage.source.as_deref(),
+            workflows_covered: coverage.workflows_covered(),
+            github_covered: coverage.github_covered(),
+            workflows_rule: coverage.workflows_rule.as_ref(),
+            github_rule: coverage.github_rule.as_ref(),
+            status: codeowners_status.label(),
+            message: co_message.clone(),
+        },
+    };
+
+    let mut blocking = 0usize;
+    match args.format {
+        ActionsFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        ActionsFormat::Text => {
+            for (path, findings, wfs) in &per_file {
+                let summary = Summary::from_findings(findings);
+                println!(
+                    "{}  ({} ok, {} warn, {} error)",
+                    path.display(),
+                    summary.ok,
+                    summary.warn,
+                    summary.error
+                );
+                for f in findings {
+                    if matches!(f.severity, Severity::Ok) {
+                        continue;
+                    }
+                    let tag = match f.severity {
+                        Severity::Error => "ERROR",
+                        Severity::Warn => "warn ",
+                        Severity::Ok => "ok   ",
+                    };
+                    let where_ = match &f.step {
+                        Some(name) => format!("{}/{name}", f.job),
+                        None => f.job.clone(),
+                    };
+                    println!("  {tag}  {where_}: {}", f.message);
+                }
+                for wf in wfs {
+                    let tag = match wf.severity {
+                        Severity::Error => "ERROR",
+                        Severity::Warn => "warn ",
+                        Severity::Ok => "ok   ",
+                    };
+                    println!("  {tag}  [{rule}] {msg}", rule = wf.rule, msg = wf.message);
+                }
+            }
+            let co_tag = match codeowners_status {
+                CoStatus::Ok => "ok   ",
+                CoStatus::Warn => "warn ",
+                CoStatus::Error => "ERROR",
+            };
+            println!("CODEOWNERS  {co_tag}  {co_message}");
+        }
+    }
+
+    for (_, findings, wfs) in &per_file {
+        blocking += findings.iter().filter(|f| f.is_blocking()).count();
+        blocking += wfs
+            .iter()
+            .filter(|w| matches!(w.severity, Severity::Error))
+            .count();
+    }
+    if matches!(codeowners_status, CoStatus::Error) {
+        blocking += 1;
+    }
+
+    if blocking > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CoStatus {
+    Ok,
+    Warn,
+    Error,
+}
+
+impl CoStatus {
+    fn label(&self) -> &'static str {
+        match self {
+            CoStatus::Ok => "ok",
+            CoStatus::Warn => "warn",
+            CoStatus::Error => "error",
+        }
+    }
+}
+
+fn describe_codeowners(c: &sakimori_core::codeowners::Coverage) -> String {
+    match (&c.source, c.workflows_covered(), c.github_covered()) {
+        (None, _, _) => "no CODEOWNERS file found at .github/CODEOWNERS, CODEOWNERS, or \
+             docs/CODEOWNERS — add one with a rule like `.github/ @your-org/security` to require \
+             a reviewer on every workflow change"
+            .to_string(),
+        (Some(src), false, _) => format!(
+            "{} exists but no rule with owners covers `.github/workflows/` — any maintainer can \
+             merge a workflow change unreviewed. Add e.g. `.github/ @your-org/security`.",
+            src.display()
+        ),
+        (Some(src), true, _) => {
+            let rule = c.workflows_rule.as_ref().unwrap();
+            format!(
+                "{} covers `.github/workflows/` via `{}` (line {}) → {}",
+                src.display(),
+                rule.pattern,
+                rule.line_no,
+                rule.owners.join(" ")
+            )
+        }
+    }
 }
 
 fn run_policy_suggest(args: PolicySuggestArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

Continues the TanStack post-mortem follow-up from #79. Adds the second open item from CLAUDE.md §13 ("CODEOWNERS-for-\`.github/\` lint").

New subcommand **\`sakimori actions audit-repo <root>\`**:
- Walks \`.github/workflows/*.{yml,yaml}\` and runs the existing per-file checks (SHA pinning, cache poisoning, untrusted checkout). One repo-level invocation now covers everything.
- Loads CODEOWNERS from the three GitHub-canonical paths in order (\`.github/CODEOWNERS\`, \`CODEOWNERS\`, \`docs/CODEOWNERS\`) and reports whether any rule with at least one owner token covers \`.github/workflows/\` and \`.github/\` broadly. Surfaces the matched rule (pattern, owners, line number) so reviewers can jump straight to the gate.
- Default severity for missing CODEOWNERS coverage is **Warn**; \`--strict-codeowners\` escalates to non-zero exit. Most repos historically didn't gate \`.github/\` — failing their first run would be hostile.

New \`codeowners\` module ships a small gitignore-style matcher (\`*\`, \`**\`, leading \`/\` anchor, trailing \`/\` directory-only). Character classes and \`?\` are deliberately out of scope and documented — they don't appear in any CODEOWNERS we'd realistically encounter for \`.github/\` gating.

Smoke-tested on sakimori's own repo:
\`\`\`
CODEOWNERS  warn   no CODEOWNERS file found at .github/CODEOWNERS, CODEOWNERS, or docs/CODEOWNERS — add one with a rule like \`.github/ @your-org/security\` to require a reviewer on every workflow change
\`\`\`

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` (16 new \`codeowners\` tests covering parse, classify, matcher, and load fallback)
- [x] Smoke run against this repo