### PR TITLE
feat(proxy): lifecycle gate for PyPI sdists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,12 +631,30 @@ of value-per-implementation-cost.
     consults must match the *original* sparse-index entry — the
     proxy will also need to rewrite the packument's
     `dist.integrity` for affected versions. (b) PyPI parallel —
-    parse `pyproject.toml` `build-system.build-backend` and flag
-    non-stdlib backends; full strip there is harder because
-    `setup.py` legacy projects can't be neutered without
-    breaking install, so PyPI starts audit-only. Pairs naturally
-    with `deps watch` — the proxy is the only layer that can
-    catch the script *before* it runs.
+    ✅ first slice implemented as `inspect_pypi_sdist` in
+    `crates/sakimori-proxy/src/lifecycle.rs`. When
+    `--lifecycle-policy` is on and a request matches a pinned PyPI
+    *sdist* URL (`.tar.gz` / `.tgz` / `.zip` — wheels are skipped
+    because they carry no install-time hook surface), the proxy
+    buffers the response, walks the tarball for a top-level
+    `setup.py` and `pyproject.toml`, and decides:
+    - **Audit**: log `has_setup_py`, the declared `build-backend`
+      (`hatchling.build`, `setuptools.build_meta`,
+      `poetry.core.masonry.api`, etc.), and the declared
+      `build-requires`; pass the body through.
+    - **Block**: 403 with `x-sakimori-deny: lifecycle-script` when
+      the sdist ships `setup.py` (the legacy PEP-517-era unbounded
+      installer hook — same threat model as npm's `postinstall`).
+      Modern pyproject-only sdists pass through with the audit log
+      entry; backend-name denylisting was deliberately left out of
+      the first slice (no clean list exists and Hatch/Maturin
+      false-positives would dominate). Allow-list (`--lifecycle-allow
+      <pkg>`) honoured the same way as npm. Same fail-open
+      semantics: bytes-don't-parse-as-gzip / nested setup.py / TOML
+      garbage all yield "could not inspect; passing through" + a
+      warn log, never a fabricated 403. Pairs naturally with `deps
+      watch` — the proxy is the only layer that can catch the
+      script *before* it runs.
 16. **Persistence-write rule pack** (Shai-Hulud-class defence) —
     ✅ first slice implemented as `sakimori policy preset
     persistence`. Emits a ready-to-merge YAML block populating

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "tar",
  "time",
  "tokio",
+ "toml",
  "ureq",
 ]
 

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -41,3 +41,4 @@ base64 = "0.22"
 sha2 = "0.10"
 tar = "0.4"
 flate2 = "1"
+toml = { workspace = true }

--- a/crates/sakimori-proxy/src/lifecycle.rs
+++ b/crates/sakimori-proxy/src/lifecycle.rs
@@ -8,10 +8,19 @@
 //! proxy fetch boundary** — before npm has even seen the bytes — so we
 //! can audit-log or hard-deny the install.
 //!
-//! Scope of this first slice:
-//! - **npm tarballs only** (`*.tgz`, gzipped POSIX tar with a single
-//!   top-level `package/` directory). PyPI's `setup.py` / build-backend
-//!   surface is structurally different and lands in a follow-up.
+//! Scope of this slice:
+//! - **npm tarballs** (`*.tgz`, gzipped POSIX tar with a single
+//!   top-level `package/` directory) — full Audit + Block via
+//!   [`inspect_npm_tarball`].
+//! - **PyPI sdists** (`*.tar.gz`, gzipped POSIX tar with a single
+//!   top-level `<name>-<version>/` directory) — Audit + Block via
+//!   [`inspect_pypi_sdist`]. Block fires when the sdist ships
+//!   `setup.py` (legacy unbounded install-time hook) regardless of
+//!   what `pyproject.toml` declares; the build-backend name is
+//!   recorded for audit log triage. Wheels (`.whl`) carry no
+//!   install-time hooks (pip just file-copies them into site-packages)
+//!   so the gate deliberately doesn't touch them — wheel pinning is
+//!   the right defence shape there.
 //! - `Audit` and `Block` policies only. `Strip` (rewriting the tarball
 //!   to drop the scripts entries) is the third roadmap mode and is
 //!   genuinely larger — see the module docs roadmap note.
@@ -217,6 +226,140 @@ fn parse_package_json(body: &[u8]) -> Inspection {
     Inspection { scripts: found }
 }
 
+// --- PyPI sdist inspection ------------------------------------------------
+
+/// Outcome of inspecting a PyPI source distribution.
+///
+/// `has_setup_py` is the high-signal field — a legacy `setup.py`
+/// runs arbitrary Python at install time with the user's privileges
+/// and is the closest analogue to npm's `postinstall`. `build_backend`
+/// records what `pyproject.toml` declared (`setuptools.build_meta`,
+/// `hatchling.build`, `poetry.core.masonry.api`, `flit_core.buildapi`,
+/// `pdm.backend`, `maturin`, `scikit_build_core.build`, …) so the
+/// audit log can rank "boring build-backend, no setup.py" against
+/// "unfamiliar build-backend, also setup.py present" without a
+/// human re-running inspection.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PypiInspection {
+    pub has_setup_py: bool,
+    /// `None` means no `pyproject.toml` (legacy-only project) or one
+    /// without a `[build-system]` table; we don't try to guess the
+    /// implicit default (`setuptools.build_meta:__legacy__`) here.
+    pub build_backend: Option<String>,
+    pub build_requires: Vec<String>,
+}
+
+impl PypiInspection {
+    /// Sdist is "definitely going to run code from this package at
+    /// install time". Today that's anchored to `setup.py` presence;
+    /// modern PEP 517 / 518 backends still execute the backend's
+    /// `build_*` hooks, but those run in an isolated environment with
+    /// only the declared `build-requires` available, which is a much
+    /// smaller attack surface than `setup.py`'s "anything on
+    /// sys.path".
+    pub fn is_legacy_install_hook(&self) -> bool {
+        self.has_setup_py
+    }
+
+    pub fn is_clean(&self) -> bool {
+        !self.has_setup_py && self.build_backend.is_none()
+    }
+}
+
+/// Inspect a PyPI source distribution. Same fail-open contract as
+/// [`inspect_npm_tarball`]: a tarball we can't decode returns `Err`,
+/// a decodable tarball without the markers we care about returns an
+/// empty `PypiInspection` (caller should pass-through the bytes
+/// rather than invent a denial).
+///
+/// We walk the tar entries looking for:
+/// - any `<root>/setup.py` (legacy installer hook → `has_setup_py`)
+/// - any `<root>/pyproject.toml` (parsed for the build backend)
+///
+/// `<root>` is the single top-level directory PyPI sdists carry,
+/// typically `<name>-<version>/` — we don't enforce that exact form
+/// because legitimate sdists from `flit`, `hatch`, etc. occasionally
+/// trim the version suffix, but we do require a single leading path
+/// component so a `node_modules/`-style nested file can't poison
+/// the inspection.
+pub fn inspect_pypi_sdist(body: &[u8]) -> Result<PypiInspection, InspectError> {
+    if !looks_like_gzip(body) {
+        return Err(InspectError::NotGzip);
+    }
+    let mut archive = Archive::new(GzDecoder::new(body));
+    let entries = archive
+        .entries()
+        .map_err(|e| InspectError::Tar(e.to_string()))?;
+    let mut out = PypiInspection::default();
+    for entry in entries {
+        let mut entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                log::debug!("lifecycle(pypi): skipping malformed tar entry: {e}");
+                continue;
+            }
+        };
+        let path = match entry.path() {
+            Ok(p) => p.into_owned(),
+            Err(_) => continue,
+        };
+        // Same single-top-level-dir guard as the npm inspector: the
+        // file must live exactly one directory below the root, so
+        // `<pkg>/setup.py` matches but `<pkg>/vendor/foo/setup.py`
+        // doesn't. Vendored installer hooks aren't a real attack
+        // shape today — pip only runs the top-level one — and
+        // matching them would inflate false positives.
+        let is_root_child = path.components().count() == 2;
+        if !is_root_child {
+            continue;
+        }
+        match path.file_name().and_then(|n| n.to_str()) {
+            Some("setup.py") => {
+                out.has_setup_py = true;
+            }
+            Some("pyproject.toml") => {
+                let mut buf = Vec::new();
+                if let Err(e) = entry.read_to_end(&mut buf) {
+                    return Err(InspectError::Read(e.to_string()));
+                }
+                if let Some((backend, requires)) = parse_pyproject(&buf) {
+                    out.build_backend = backend;
+                    out.build_requires = requires;
+                }
+            }
+            _ => continue,
+        }
+        // Early exit if we've seen everything we care about.
+        if out.has_setup_py && out.build_backend.is_some() {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Parse `pyproject.toml` and return `(build-backend, requires)` from
+/// the `[build-system]` table. Returns `None` if the file doesn't
+/// parse as TOML — fail-open same as the npm side.
+fn parse_pyproject(body: &[u8]) -> Option<(Option<String>, Vec<String>)> {
+    let text = std::str::from_utf8(body).ok()?;
+    let doc: toml::Value = toml::from_str(text).ok()?;
+    let build_system = doc.get("build-system")?.as_table()?;
+    let backend = build_system
+        .get("build-backend")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let requires = build_system
+        .get("requires")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Some((backend, requires))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,6 +498,130 @@ mod tests {
         let tgz = gz.finish().unwrap();
         let out = inspect_npm_tarball(&tgz).unwrap();
         assert!(!out.has_scripts());
+    }
+
+    // --- PyPI sdist tests -------------------------------------------------
+
+    /// Build a PyPI-shaped sdist tarball with the given `<root>/`
+    /// directory and an iterable of `(relative_path, bytes)` entries.
+    fn pack_sdist(root: &str, files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_bytes);
+            for (rel, body) in files {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(body.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                let path = format!("{root}/{rel}");
+                builder.append_data(&mut header, &path, *body).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+        gz.write_all(&tar_bytes).unwrap();
+        gz.finish().unwrap()
+    }
+
+    #[test]
+    fn pypi_detects_setup_py() {
+        let tgz = pack_sdist(
+            "foo-1.0.0",
+            &[("setup.py", b"from setuptools import setup\n")],
+        );
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert!(out.has_setup_py);
+        assert!(out.is_legacy_install_hook());
+        assert!(!out.is_clean());
+        assert!(out.build_backend.is_none());
+    }
+
+    #[test]
+    fn pypi_extracts_build_backend_from_pyproject() {
+        let pyproject = br#"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+"#;
+        let tgz = pack_sdist("foo-1.0.0", &[("pyproject.toml", pyproject)]);
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert_eq!(out.build_backend.as_deref(), Some("hatchling.build"));
+        assert_eq!(out.build_requires, vec!["hatchling".to_string()]);
+        // No setup.py → not "legacy install hook" even though the build
+        // backend will still execute. Block mode deliberately doesn't
+        // fire here in the first slice.
+        assert!(!out.is_legacy_install_hook());
+        assert!(!out.is_clean());
+    }
+
+    #[test]
+    fn pypi_modern_project_with_both_setup_and_pyproject() {
+        // Real-world: scientific packages often ship both for compat
+        // with older pip versions. setup.py presence still pokes the
+        // legacy hook so we should flag it.
+        let pyproject = br#"
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+"#;
+        let tgz = pack_sdist(
+            "numpy-2.0.0",
+            &[
+                ("setup.py", b"import setuptools; setuptools.setup()\n"),
+                ("pyproject.toml", pyproject),
+            ],
+        );
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert!(out.has_setup_py);
+        assert_eq!(out.build_backend.as_deref(), Some("setuptools.build_meta"));
+    }
+
+    #[test]
+    fn pypi_clean_modern_sdist_is_clean() {
+        // pyproject-only project with no build-system table — perfectly
+        // possible (flit's old default). Should return clean.
+        let tgz = pack_sdist(
+            "foo-1.0.0",
+            &[("pyproject.toml", b"[project]\nname = \"foo\"\n")],
+        );
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert!(out.is_clean(), "got: {out:?}");
+    }
+
+    #[test]
+    fn pypi_ignores_nested_setup_py_in_vendored_tree() {
+        // Vendored installer hook inside a subdirectory must not be
+        // mistaken for the root one — only the top-level setup.py
+        // actually runs at install time.
+        let tgz = pack_sdist(
+            "foo-1.0.0",
+            &[("vendor/bar/setup.py", b"raise RuntimeError('pwned')\n")],
+        );
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert!(!out.has_setup_py, "nested setup.py must not trip the gate");
+        assert!(out.is_clean());
+    }
+
+    #[test]
+    fn pypi_malformed_pyproject_fails_open_to_no_backend() {
+        // Garbage TOML → no backend reported; rest of inspection
+        // proceeds. We never fail-closed on parse errors.
+        let tgz = pack_sdist(
+            "foo-1.0.0",
+            &[
+                ("setup.py", b"setup()\n"),
+                ("pyproject.toml", b"not [ valid toml ]\n"),
+            ],
+        );
+        let out = inspect_pypi_sdist(&tgz).unwrap();
+        assert!(out.has_setup_py);
+        assert!(out.build_backend.is_none());
+    }
+
+    #[test]
+    fn pypi_inspect_rejects_non_gzip() {
+        let err = inspect_pypi_sdist(b"this is not gzipped").unwrap_err();
+        assert!(matches!(err, InspectError::NotGzip));
     }
 
     #[test]

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -296,6 +296,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         last_host: None,
         last_path: None,
         last_npm_tarball: None,
+        last_pypi_sdist: None,
         require_provenance: cfg.require_provenance,
         nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
@@ -415,6 +416,10 @@ struct SakimoriHandler {
     /// whether to run the lifecycle gate. Reset to `None` on every
     /// request so an earlier tarball's identity can't bleed across.
     last_npm_tarball: Option<(String, String)>,
+    /// As above for pinned PyPI source distributions (`.tar.gz` /
+    /// `.zip` ending). Wheels (`.whl`) are not tagged — they carry
+    /// no install-time hook surface to inspect.
+    last_pypi_sdist: Option<(String, String)>,
     /// Forwarded from [`ProxyConfig::lifecycle_policy`]. `None`
     /// disables the gate entirely (no tarball buffering, no inspect).
     lifecycle_policy: Option<crate::lifecycle::LifecyclePolicy>,
@@ -510,6 +515,112 @@ impl SakimoriHandler {
             }
         }
     }
+
+    /// PyPI counterpart to [`Self::lifecycle_inspect_npm_tarball`].
+    /// Block mode fires on `setup.py` presence — that's the
+    /// PEP-517-era legacy unbounded install hook with the same threat
+    /// model as npm's `postinstall`. Modern `pyproject.toml`-only
+    /// projects still execute the declared build backend, but the
+    /// scope is bounded by the backend's `build-requires` and the
+    /// audit log records what backend ran so a human can triage.
+    async fn lifecycle_inspect_pypi_sdist(
+        &self,
+        res: Response<Body>,
+        policy: crate::lifecycle::LifecyclePolicy,
+        name: &str,
+        version: &str,
+    ) -> Response<Body> {
+        use http_body_util::BodyExt;
+        let (mut parts, body) = res.into_parts();
+        let collected = match body.collect().await {
+            Ok(c) => c.to_bytes(),
+            Err(e) => {
+                log::warn!(
+                    "lifecycle(pypi): failed to buffer sdist body for {name}@{version}: {e}"
+                );
+                return Response::from_parts(parts, Body::empty());
+            }
+        };
+        let pass_through = || -> Response<Body> {
+            let mut parts2 = parts.clone();
+            parts2.headers.remove(http::header::CONTENT_LENGTH);
+            Response::from_parts(
+                parts2,
+                Body::from(http_body_util::Full::new(collected.clone())),
+            )
+        };
+        let inspection = match crate::lifecycle::inspect_pypi_sdist(&collected) {
+            Ok(i) => i,
+            Err(e) => {
+                log::warn!(
+                    "lifecycle(pypi): fail-open on {name}@{version} — could not inspect sdist: {e}"
+                );
+                return pass_through();
+            }
+        };
+        if inspection.is_clean() {
+            log::debug!(
+                "lifecycle(pypi): {name}@{version} — no setup.py and no declared build backend"
+            );
+            return pass_through();
+        }
+        // Audit always records what we found so the log captures the
+        // backend even on a pass-through.
+        let backend_desc = inspection.build_backend.as_deref().unwrap_or("<none>");
+        log::warn!(
+            "lifecycle(pypi,{mode:?}): {name}@{version} — setup.py={setup}, build-backend={backend}",
+            mode = policy,
+            setup = inspection.has_setup_py,
+            backend = backend_desc,
+        );
+        if !inspection.build_requires.is_empty() {
+            log::info!(
+                "lifecycle(pypi): {name}@{version} declared build-requires: {}",
+                inspection.build_requires.join(", "),
+            );
+        }
+        match policy {
+            crate::lifecycle::LifecyclePolicy::Audit => pass_through(),
+            crate::lifecycle::LifecyclePolicy::Block => {
+                if !inspection.is_legacy_install_hook() {
+                    // Modern PEP 517 backends only — audit-log and let
+                    // it through. We deliberately don't extend Block
+                    // to backend-name matching in the first slice;
+                    // there's no clean denylist and the false-positive
+                    // cost would be high (every Hatch-built scientific
+                    // package would 403).
+                    return pass_through();
+                }
+                let reason = format!(
+                    "lifecycle(pypi): blocking {name}@{version} — sdist ships `setup.py`, a \
+                     legacy installer hook that runs arbitrary Python with the user's privileges. \
+                     Prefer a wheel (`pip install --only-binary=:all:`) if upstream publishes \
+                     one, add `{name}` to the lifecycle allow-list if this install is expected, \
+                     or relax to `--lifecycle-policy audit` to log without blocking."
+                );
+                log::warn!("{reason}");
+                parts.headers.remove(http::header::CONTENT_LENGTH);
+                Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header("content-type", "text/plain; charset=utf-8")
+                    .header("x-sakimori-deny", "lifecycle-script")
+                    .body(Body::from(format!("{reason}\n")))
+                    .expect("static lifecycle deny response")
+            }
+        }
+    }
+}
+
+/// Recognise PyPI source distribution URLs by file extension. We
+/// only gate sdists because wheels carry no install-time hooks —
+/// pip's wheel installer is a deterministic file-copy + RECORD update.
+/// `.zip` sdists are rare (almost all of PyPI is `.tar.gz` now) but
+/// included for completeness; the inspector still requires a gzip
+/// magic byte so a real `.zip` will fail-open as "not gzip" and
+/// pass through with a warn log.
+fn path_is_pypi_sdist(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.ends_with(".tar.gz") || lower.ends_with(".tgz") || lower.ends_with(".zip")
 }
 
 impl HttpHandler for SakimoriHandler {
@@ -543,11 +654,13 @@ impl HttpHandler for SakimoriHandler {
             self.last_host = None;
             self.last_path = None;
             self.last_npm_tarball = None;
+            self.last_pypi_sdist = None;
             return RequestOrResponse::Request(req);
         }
         self.last_host = Some(host.clone());
         // Reset per-request; the `Pinned` branch below may set it back.
         self.last_npm_tarball = None;
+        self.last_pypi_sdist = None;
         let path: String = req
             .uri()
             .path_and_query()
@@ -585,6 +698,18 @@ impl HttpHandler for SakimoriHandler {
                     && !self.lifecycle_allow.contains(&name)
                 {
                     self.last_npm_tarball = Some((name.clone(), version.clone()));
+                }
+                // Same tagging for PyPI, but only for source
+                // distributions — wheels (`.whl`) are install-time
+                // hook-free, so subjecting them to the gate would
+                // burn cycles and risk false positives without any
+                // defensive value.
+                if self.lifecycle_policy.is_some()
+                    && matches!(ecosystem, sakimori_core::deps::Ecosystem::Pypi)
+                    && !self.lifecycle_allow.contains(&name)
+                    && path_is_pypi_sdist(&path)
+                {
+                    self.last_pypi_sdist = Some((name.clone(), version.clone()));
                 }
                 let now = Utc::now();
                 match self.decider.decide(ecosystem, &name, &version, now) {
@@ -632,6 +757,14 @@ impl HttpHandler for SakimoriHandler {
         {
             return self
                 .lifecycle_inspect_npm_tarball(res, policy, &name, &version)
+                .await;
+        }
+        if let Some(policy) = self.lifecycle_policy
+            && let Some((name, version)) = self.last_pypi_sdist.take()
+            && res.status().is_success()
+        {
+            return self
+                .lifecycle_inspect_pypi_sdist(res, policy, &name, &version)
                 .await;
         }
 


### PR DESCRIPTION
## Summary

Closes the PyPI half of CLAUDE.md §15 (lifecycle-script gate). The npm side has been live for a while; this PR extends the same \"buffer + inspect at fetch boundary\" pattern to PyPI source distributions.

When \`--lifecycle-policy\` is set and a request matches a pinned PyPI sdist (\`.tar.gz\` / \`.tgz\` / \`.zip\` under \`files.pythonhosted.org\`):

- **Audit**: walks the tarball, logs \`has_setup_py\`, declared \`build-backend\` (\`hatchling.build\`, \`setuptools.build_meta\`, \`poetry.core.masonry.api\`, \`maturin\`, \`scikit_build_core.build\`, …) and \`build-requires\`. Passes the body through.
- **Block**: 403s with \`x-sakimori-deny: lifecycle-script\` when the sdist ships \`setup.py\` — the legacy PEP-517-era unbounded installer hook with the same threat model as npm's \`postinstall\`. Modern pyproject-only sdists pass through with the audit entry; backend-name denylisting was left out of the first slice because there's no clean list (Hatch / Maturin / scikit-build false positives would dominate).

Wheels (\`.whl\`) are deliberately skipped — pip's wheel installer is a deterministic file copy, no install-time hooks. Same fail-open semantics as the npm side (bytes-don't-parse-as-gzip / nested setup.py / TOML garbage → log + pass through, never a fabricated 403). \`--lifecycle-allow <pkg>\` honoured the same way.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` — 200 proxy tests pass, including 7 new \`inspect_pypi_sdist\` cases:
  - \`pypi_detects_setup_py\`
  - \`pypi_extracts_build_backend_from_pyproject\`
  - \`pypi_modern_project_with_both_setup_and_pyproject\`
  - \`pypi_clean_modern_sdist_is_clean\`
  - \`pypi_ignores_nested_setup_py_in_vendored_tree\`
  - \`pypi_malformed_pyproject_fails_open_to_no_backend\`
  - \`pypi_inspect_rejects_non_gzip\`