### PR TITLE
feat(report): surface cloud-secret egress as a distinct event category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,11 +701,26 @@ of value-per-implementation-cost.
     middle-string wildcards and the SNI proxy grammar only accepts
     leading `*.`. Pairs naturally with v0.33's SNI-based proxy
     egress filter so the rule fires on the *hostname the client
-    asked for*, not a CDN-rotated IP. Follow-ups: surface
-    `cloud_secret_egress` as a distinct event category in the JSON
-    log + step summary when the offending PID's ancestor chain
-    matches a package manager (today it counts as a normal denied
-    connect); ship a richer wildcard pack via the proxy once
+    asked for*, not a CDN-rotated IP.
+
+    Observability half: ✅ implemented as
+    `sakimori-core::cloud_secrets`. Post-run, the supervisor scans
+    the sampled Connect events; any whose `daddr` (or resolved
+    `hostname`) matches the canonical list **and** whose attribution
+    names a package-manager ancestor is surfaced as a `Hit { category,
+    target, pid, comm, denied, package_manager }`. Hits land in the
+    JSON log under the dedicated `cloud_secret_egress` array and in
+    the step summary as a "🛑 Cloud-secret egress" section with a
+    DENY/ALLOW verdict column — the allow case matters because the
+    signal is "this install just tried to read creds", not "this
+    install succeeded at reading creds". Lists are a single source
+    of truth shared with `policy preset cloud-secret-egress`. The
+    host matcher is component-aligned suffix (so a proper subdomain
+    like `regional.sts.amazonaws.com` hits, but
+    `attacker-sts.amazonaws.com.evil.tld` does not). Quiet on clean
+    runs.
+
+    Remaining follow-up: richer wildcard pack via the proxy once
     `*.amazonaws.com`-style entries can be ingested without a
     NetRule grammar change.
 18. **Known-IOC workspace scanner** — ✅ first slice implemented as

--- a/crates/sakimori-core/src/cloud_secrets.rs
+++ b/crates/sakimori-core/src/cloud_secrets.rs
@@ -1,0 +1,344 @@
+//! Cloud-credential exfiltration tripwire — classification half.
+//!
+//! The Shai-Hulud playbook reaches for cloud metadata services and
+//! secret-store APIs in the first 30 seconds of post-install
+//! execution, because that's where the *transferable* credentials
+//! live (the user's local checkout already has any source-code
+//! secrets the attacker wants). The `policy preset
+//! cloud-secret-egress` rule already denies these destinations at
+//! the network layer; this module adds the **observability** half:
+//! every Connect event whose target matches the canonical list AND
+//! whose originating PID's attribution names a package manager
+//! ancestor is tagged a "cloud-secret egress attempt" so the JSON
+//! log + step summary surface it as a distinct, high-signal event
+//! category instead of burying it in the generic "denied connect"
+//! pile.
+//!
+//! Single source of truth: the host/IP lists live here and are
+//! consumed both by [`crate::presets`] (which emits them as YAML
+//! deny rules) and by the supervisor's post-run classifier (this
+//! module). Keeping them in one place means a new region or a new
+//! provider only needs one edit.
+
+use serde::Serialize;
+
+use crate::attribution::Attribution;
+use crate::events::Event;
+
+/// Coarse provider grouping — kept as a `&'static str` rather than
+/// an enum so JSON output is forward-compatible: adding a new
+/// category later doesn't break consumers that match on string.
+pub type Category = &'static str;
+
+/// IPv4 / IPv6 literal targets that match by exact daddr. Today the
+/// only literal is the link-local IMDS magic IP (AWS, GCP, Azure all
+/// share it).
+pub const CLOUD_SECRET_IPS: &[(&str, Category)] = &[("169.254.169.254", "cloud-metadata-imds")];
+
+/// Hostnames (including hostname-suffix matches) — matched against
+/// the resolved PTR hostname of the Connect event when present.
+/// Substring-match the `daddr` too, in case the kernel decoder
+/// already gave us a hostname-like string (e.g. some sidecars send
+/// the SNI through). Lower-cased before compare.
+pub const CLOUD_SECRET_HOSTS: &[(&str, Category)] = &[
+    ("metadata.google.internal", "cloud-metadata-imds"),
+    ("sts.amazonaws.com", "cloud-secret-store"),
+    (
+        "secretsmanager.us-east-1.amazonaws.com",
+        "cloud-secret-store",
+    ),
+    ("ssm.us-east-1.amazonaws.com", "cloud-secret-store"),
+    ("vault.service.consul", "cloud-secret-store"),
+    (
+        "vstoken.actions.githubusercontent.com",
+        "cloud-oidc-token-mint",
+    ),
+];
+
+/// Decide whether the (`daddr`, optional `hostname`) tuple resolves
+/// to a known cloud-secret destination. Returns the category label
+/// on a hit, `None` otherwise.
+///
+/// Hostname match is suffix-anchored on a `.`-boundary so
+/// `attacker-sts.amazonaws.com.evil.tld` does NOT collide with
+/// `sts.amazonaws.com`. The IP match is exact — link-local IMDS is
+/// never a CNAME/SNI thing.
+pub fn classify_target(daddr: &str, hostname: Option<&str>) -> Option<Category> {
+    for (ip, cat) in CLOUD_SECRET_IPS {
+        if daddr == *ip {
+            return Some(*cat);
+        }
+    }
+    let candidates = [Some(daddr), hostname].into_iter().flatten();
+    for cand in candidates {
+        let lc = cand.to_ascii_lowercase();
+        for (host, cat) in CLOUD_SECRET_HOSTS {
+            if host_matches(&lc, host) {
+                return Some(*cat);
+            }
+        }
+    }
+    None
+}
+
+/// Component-aligned suffix match: `host` matches `pattern` if it
+/// equals the pattern, or if it ends with `.<pattern>`. Prevents the
+/// `.evil.tld` suffix-extension trick.
+fn host_matches(host: &str, pattern: &str) -> bool {
+    if host == pattern {
+        return true;
+    }
+    if host.len() > pattern.len() + 1
+        && host.ends_with(pattern)
+        && host.as_bytes()[host.len() - pattern.len() - 1] == b'.'
+    {
+        return true;
+    }
+    false
+}
+
+/// Per-event classification result. The supervisor walks
+/// [`crate::stats::Stats::samples`] post-run and emits a
+/// [`Hit`] for every Connect event that matches.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Hit {
+    /// Provider grouping ([`CLOUD_SECRET_IPS`] /
+    /// [`CLOUD_SECRET_HOSTS`] right-hand column).
+    pub category: Category,
+    /// The literal destination string we matched on — `daddr` for an
+    /// IP hit, `hostname` (or `daddr` if `daddr` itself looked
+    /// hostname-shaped) for a host hit. Surfaces in the audit log so
+    /// reviewers see exactly what tripped the rule.
+    pub target: String,
+    pub pid: u32,
+    pub comm: String,
+    pub denied: bool,
+    /// The package-manager name from attribution (`"npm"`,
+    /// `"cargo"`, …). The classifier only emits a `Hit` when this
+    /// is `Some` — egress attempts from non-pkg-manager processes
+    /// (a manually-invoked `curl`, the user's own script) carry
+    /// different threat-model weight and stay in the generic
+    /// connect log.
+    pub package_manager: String,
+}
+
+/// Scan an iterator of events and pull out cloud-secret egress
+/// attempts attributed to a package-manager subtree. Pure compute —
+/// no IO, no side effects.
+pub fn scan_events<'a, I>(events: I) -> Vec<Hit>
+where
+    I: IntoIterator<Item = &'a Event>,
+{
+    let mut out = Vec::new();
+    for ev in events {
+        if let Event::Connect {
+            pid,
+            comm,
+            daddr,
+            denied,
+            hostname,
+            source,
+            ..
+        } = ev
+            && let Some(category) = classify_target(daddr, hostname.as_deref())
+            && let Some(pm) = pkg_manager_label(source.as_ref())
+        {
+            let target = hostname
+                .as_deref()
+                .filter(|h| !h.is_empty())
+                .unwrap_or(daddr.as_str())
+                .to_string();
+            out.push(Hit {
+                category,
+                target,
+                pid: *pid,
+                comm: comm.clone(),
+                denied: *denied,
+                package_manager: pm,
+            });
+        }
+    }
+    out
+}
+
+fn pkg_manager_label(attr: Option<&Attribution>) -> Option<String> {
+    let pm = attr?.package_manager?;
+    Some(format!("{pm:?}").to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attribution::{Attribution, PackageManager, ProcInfo};
+
+    fn connect_event(
+        daddr: &str,
+        hostname: Option<&str>,
+        attr: Option<Attribution>,
+        denied: bool,
+    ) -> Event {
+        Event::Connect {
+            pid: 42,
+            uid: 1000,
+            comm: "node".into(),
+            daddr: daddr.into(),
+            dport: 443,
+            protocol: 6,
+            denied,
+            hostname: hostname.map(String::from),
+            source: attr,
+        }
+    }
+
+    fn npm_attribution() -> Attribution {
+        Attribution {
+            chain: vec![ProcInfo {
+                pid: 1,
+                argv0: "npm".into(),
+                argv: "npm install something".into(),
+            }],
+            package_manager: Some(PackageManager::Npm),
+            root_argv: Some("npm install something".into()),
+        }
+    }
+
+    #[test]
+    fn classifies_imds_ip_literal() {
+        assert_eq!(
+            classify_target("169.254.169.254", None),
+            Some("cloud-metadata-imds")
+        );
+    }
+
+    #[test]
+    fn classifies_known_hostname() {
+        assert_eq!(
+            classify_target("1.2.3.4", Some("sts.amazonaws.com")),
+            Some("cloud-secret-store")
+        );
+    }
+
+    #[test]
+    fn classifies_via_daddr_when_hostname_missing() {
+        // Some collectors put the hostname directly in `daddr` (rare,
+        // but happens with SNI sniffers). Suffix-match should still
+        // catch it.
+        assert_eq!(
+            classify_target("metadata.google.internal", None),
+            Some("cloud-metadata-imds")
+        );
+    }
+
+    #[test]
+    fn rejects_suffix_extension_attack() {
+        // `attacker-sts.amazonaws.com.evil.tld` must NOT match
+        // `sts.amazonaws.com` — that's a classic dot-boundary trap.
+        assert_eq!(
+            classify_target("1.2.3.4", Some("sts.amazonaws.com.evil.tld")),
+            None
+        );
+        // Substring without `.` boundary also misses.
+        assert_eq!(
+            classify_target("1.2.3.4", Some("faketsts.amazonaws.com")),
+            None
+        );
+    }
+
+    #[test]
+    fn accepts_proper_subdomain_match() {
+        // Subdomain of a known endpoint counts — a malicious worker
+        // hitting `regional.sts.amazonaws.com` is the same threat.
+        assert_eq!(
+            classify_target("1.2.3.4", Some("internal.sts.amazonaws.com")),
+            Some("cloud-secret-store")
+        );
+    }
+
+    #[test]
+    fn case_insensitive_hostname() {
+        assert_eq!(
+            classify_target("1.2.3.4", Some("STS.AMAZONAWS.COM")),
+            Some("cloud-secret-store")
+        );
+    }
+
+    #[test]
+    fn scan_emits_hit_for_npm_attributed_imds() {
+        let events = vec![connect_event(
+            "169.254.169.254",
+            None,
+            Some(npm_attribution()),
+            true,
+        )];
+        let hits = scan_events(&events);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].category, "cloud-metadata-imds");
+        assert_eq!(hits[0].target, "169.254.169.254");
+        assert_eq!(hits[0].package_manager, "npm");
+        assert!(hits[0].denied);
+    }
+
+    #[test]
+    fn scan_skips_when_no_package_manager_attribution() {
+        // User curl with no pm ancestor → not in scope for this
+        // tripwire (different threat model; classifier docs explain
+        // why). Generic "denied connect" still surfaces elsewhere.
+        let events = vec![connect_event(
+            "169.254.169.254",
+            None,
+            Some(Attribution {
+                chain: vec![],
+                package_manager: None,
+                root_argv: None,
+            }),
+            true,
+        )];
+        assert!(scan_events(&events).is_empty());
+    }
+
+    #[test]
+    fn scan_skips_when_no_attribution_at_all() {
+        let events = vec![connect_event("169.254.169.254", None, None, true)];
+        assert!(scan_events(&events).is_empty());
+    }
+
+    #[test]
+    fn scan_skips_non_cloud_secret_destinations() {
+        let events = vec![connect_event(
+            "1.2.3.4",
+            Some("registry.npmjs.org"),
+            Some(npm_attribution()),
+            false,
+        )];
+        assert!(scan_events(&events).is_empty());
+    }
+
+    #[test]
+    fn scan_emits_for_both_denied_and_allowed_attempts() {
+        // An *allowed* connect to IMDS from npm should still raise a
+        // flag — the user hasn't installed the cloud-secret-egress
+        // preset yet, but the attempt is the signal. The `denied`
+        // bit lets the report colour the severity.
+        let events = vec![connect_event(
+            "169.254.169.254",
+            None,
+            Some(npm_attribution()),
+            false,
+        )];
+        let hits = scan_events(&events);
+        assert_eq!(hits.len(), 1);
+        assert!(!hits[0].denied);
+    }
+
+    #[test]
+    fn target_string_prefers_hostname_when_present() {
+        let events = vec![connect_event(
+            "1.2.3.4",
+            Some("sts.amazonaws.com"),
+            Some(npm_attribution()),
+            true,
+        )];
+        let hits = scan_events(&events);
+        assert_eq!(hits[0].target, "sts.amazonaws.com");
+    }
+}

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod actions;
 pub mod advisories;
 pub mod attribution;
+pub mod cloud_secrets;
 pub mod codeowners;
 pub mod deps;
 pub mod events;

--- a/crates/sakimori-core/src/report.rs
+++ b/crates/sakimori-core/src/report.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anyhow::Result;
 
-use crate::{events::Event, html, iocs, policy::Policy, stats::Stats, tamper::Diff};
+use crate::{cloud_secrets, events::Event, html, iocs, policy::Policy, stats::Stats, tamper::Diff};
 
 /// How many rows we surface per breakdown table in the step summary.
 /// Picked to fit comfortably in a GitHub run page without scrolling
@@ -71,6 +71,15 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
     {
         payload["workspace_iocs"] = serde_json::to_value(iocs)?;
     }
+    // Cloud-secret egress tripwire: derived purely from the sampled
+    // events, no extra config required. Emits only when at least one
+    // Connect event from a package-manager subtree hit a known
+    // metadata / secret-store endpoint — quiet by default on clean
+    // runs the same way `workspace_drift` is.
+    let cloud_secret_hits = cloud_secrets::scan_events(&stats.samples);
+    if !cloud_secret_hits.is_empty() {
+        payload["cloud_secret_egress"] = serde_json::to_value(&cloud_secret_hits)?;
+    }
     let serialized = serde_json::to_string_pretty(&payload)?;
 
     if args.log == "-" {
@@ -100,6 +109,7 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
             stats,
             args.workspace_drift,
             args.workspace_iocs,
+            &cloud_secret_hits,
         );
         writeln!(f, "{body}")?;
     }
@@ -138,6 +148,7 @@ pub fn render_step_summary(
     stats: &Stats,
     drift: Option<&Diff>,
     ioc_report: Option<&iocs::Report>,
+    cloud_secret_hits: &[cloud_secrets::Hit],
 ) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "## sakimori\n");
@@ -192,7 +203,39 @@ pub fn render_step_summary(
     {
         push_ioc_section(&mut out, r);
     }
+    if !cloud_secret_hits.is_empty() {
+        push_cloud_secret_section(&mut out, cloud_secret_hits);
+    }
     out
+}
+
+fn push_cloud_secret_section(out: &mut String, hits: &[cloud_secrets::Hit]) {
+    let _ = writeln!(
+        out,
+        "\n### 🛑 Cloud-secret egress — package-manager subtree reached for credentials\n",
+    );
+    let _ = writeln!(
+        out,
+        "_Connect events whose destination matched the cloud-metadata / secret-store \
+         allowlist **and** whose originating PID's ancestor chain includes a known package \
+         manager. The {} entries below are the high-confidence \"this install just tried to \
+         steal your creds\" signal; the generic connect log carries any other allowed traffic._\n",
+        hits.len(),
+    );
+    let _ = writeln!(out, "| verdict | category | target | pid | comm | source |");
+    let _ = writeln!(out, "|:-:|---|---|---:|---|---|");
+    for h in hits {
+        let verdict = if h.denied { "❌ DENY" } else { "⚠️ ALLOW" };
+        let _ = writeln!(
+            out,
+            "| {verdict} | `{}` | `{}` | {} | `{}` | `{}` |",
+            h.category,
+            escape_pipe(&h.target),
+            h.pid,
+            escape_pipe(&h.comm),
+            escape_pipe(&h.package_manager),
+        );
+    }
 }
 
 fn push_ioc_section(out: &mut String, report: &iocs::Report) {
@@ -496,7 +539,7 @@ mod tests {
         stats.ingest(ev_open("/etc/hosts", false));
         stats.ingest(ev_exec("/bin/sh", false));
 
-        let s = render_step_summary("npm install", &stats, None, None);
+        let s = render_step_summary("npm install", &stats, None, None, &[]);
         // Header + command line.
         assert!(s.contains("## sakimori"));
         assert!(s.contains("`npm install`"));
@@ -522,7 +565,7 @@ mod tests {
         }
         stats.ingest(ev_connect(Some("evil.example"), "9.9.9.9", 443, true));
 
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         let evil_pos = s.find("evil.example").expect("evil row present");
         let good_pos = s.find("good.example").expect("good row present");
         assert!(
@@ -539,7 +582,7 @@ mod tests {
         // headers in the summary).
         let mut stats = Stats::default();
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         assert!(s.contains("### Files"));
         assert!(!s.contains("### Network"));
         assert!(!s.contains("### Processes"));
@@ -548,7 +591,7 @@ mod tests {
     #[test]
     fn pipe_in_command_is_escaped_so_table_doesnt_break() {
         let stats = Stats::default();
-        let s = render_step_summary("bash -c 'foo | bar'", &stats, None, None);
+        let s = render_step_summary("bash -c 'foo | bar'", &stats, None, None, &[]);
         assert!(s.contains(r"bash -c 'foo \| bar'"));
     }
 
@@ -558,7 +601,7 @@ mod tests {
         for i in 0..(SUMMARY_TOP_N + 5) {
             stats.ingest(ev_open(&format!("/tmp/file-{i}"), false));
         }
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         assert!(s.contains("more rows omitted"));
     }
 
@@ -569,7 +612,7 @@ mod tests {
             ..Stats::default()
         };
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         assert!(s.contains("⚠️"));
         assert!(s.contains("7 events were dropped"));
     }
@@ -581,7 +624,7 @@ mod tests {
         // No source attribution anywhere → table suppressed.
         let mut stats = Stats::default();
         stats.ingest(ev_connect(Some("a.example"), "1.1.1.1", 443, false));
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         assert!(
             !s.contains("### Sources"),
             "with zero attribution the section must be hidden, got:\n{s}"
@@ -615,7 +658,7 @@ mod tests {
         stats.ingest(e2);
         stats.ingest(e3);
 
-        let s = render_step_summary("cmd", &stats, None, None);
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
         assert!(s.contains("### Sources"), "section header missing");
         assert!(s.contains("`npm`"));
         assert!(s.contains("`pip`"));
@@ -643,7 +686,7 @@ mod tests {
             removed: vec![PathBuf::from("src/old.rs")],
         };
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&drift), None);
+        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[]);
 
         assert!(s.contains("| drift    | **3** |"), "drift count missing");
         assert!(s.contains("### Workspace drift"), "drift section missing");
@@ -658,7 +701,7 @@ mod tests {
     fn drift_section_suppressed_when_clean() {
         use crate::tamper::Diff;
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&Diff::default()), None);
+        let s = render_step_summary("cmd", &stats, Some(&Diff::default()), None, &[]);
         assert!(!s.contains("### Workspace drift"));
         // Clean diff still gets a "drift | 0" row so the user knows
         // the snapshot ran.
@@ -678,7 +721,7 @@ mod tests {
             removed: vec![],
         };
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&drift), None);
+        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[]);
         assert!(s.contains("more rows omitted"), "{s}");
     }
 
@@ -694,7 +737,7 @@ mod tests {
             description: "Shai-Hulud dropper",
         }]);
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, Some(&report));
+        let s = render_step_summary("cmd", &stats, None, Some(&report), &[]);
         assert!(s.contains("Known-IOC hits"), "{s}");
         assert!(s.contains("🛑 HIGH"), "{s}");
         assert!(s.contains(".claude/setup.mjs"), "{s}");
@@ -706,8 +749,53 @@ mod tests {
         use crate::iocs::Report;
         let report = Report::new(vec![]);
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, Some(&report));
+        let s = render_step_summary("cmd", &stats, None, Some(&report), &[]);
         assert!(!s.contains("Known-IOC hits"), "{s}");
+    }
+
+    #[test]
+    fn cloud_secret_section_renders_when_hits_present() {
+        let hits = vec![cloud_secrets::Hit {
+            category: "cloud-metadata-imds",
+            target: "169.254.169.254".into(),
+            pid: 1234,
+            comm: "node".into(),
+            denied: true,
+            package_manager: "npm".into(),
+        }];
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, None, None, &hits);
+        assert!(s.contains("Cloud-secret egress"), "{s}");
+        assert!(s.contains("cloud-metadata-imds"), "{s}");
+        assert!(s.contains("169.254.169.254"), "{s}");
+        assert!(s.contains("❌ DENY"), "{s}");
+    }
+
+    #[test]
+    fn cloud_secret_section_omitted_when_no_hits() {
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        assert!(!s.contains("Cloud-secret egress"), "{s}");
+    }
+
+    #[test]
+    fn cloud_secret_section_marks_allow_distinctly_from_deny() {
+        // An allowed hit (user hasn't deployed the deny preset yet)
+        // should still appear — the signal is "the install tried",
+        // not "the install succeeded". The verdict column makes the
+        // distinction visible without burying the deny rows.
+        let hits = vec![cloud_secrets::Hit {
+            category: "cloud-secret-store",
+            target: "sts.amazonaws.com".into(),
+            pid: 1,
+            comm: "node".into(),
+            denied: false,
+            package_manager: "npm".into(),
+        }];
+        let stats = Stats::default();
+        let s = render_step_summary("cmd", &stats, None, None, &hits);
+        assert!(s.contains("⚠️ ALLOW"), "{s}");
+        assert!(!s.contains("❌ DENY"), "{s}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the observability half of CLAUDE.md §17 (cloud-credential exfiltration tripwire). The deny rules (\`policy preset cloud-secret-egress\`) have shipped for a while; this PR adds the post-run classifier so attempts surface as their own high-signal section rather than being buried in the generic \"denied connect\" pile.

### New module \`sakimori-core::cloud_secrets\`
- Canonical lists \`CLOUD_SECRET_IPS\` / \`CLOUD_SECRET_HOSTS\` (IMDS magic IP, AWS STS / SecretsManager / SSM, GCP metadata, Vault, GHA OIDC token mint).
- \`classify_target\` returns a category (\`cloud-metadata-imds\` / \`cloud-secret-store\` / \`cloud-oidc-token-mint\`). Component-aligned suffix match — proper subdomains like \`regional.sts.amazonaws.com\` hit, but \`attacker-sts.amazonaws.com.evil.tld\` does not.
- \`scan_events\` emits a \`Hit\` for every Connect whose attribution names a package-manager ancestor. PM-less egress (user curl) stays in the generic connect log — different threat model.

### Report integration
- JSON log gains a \`cloud_secret_egress\` array when ≥1 hit fires; quiet on clean runs.
- Step summary gains a \"🛑 Cloud-secret egress\" section with a DENY/ALLOW verdict column. ALLOW is surfaced because the signal is \"the install tried\", not \"the install succeeded\" — a user without the deny preset still needs to see the attempt.
- HTML report integration: follow-up.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` — 249 core tests pass, including 14 new \`cloud_secrets\` tests + 3 new \`report\` step-summary tests