### PR TITLE
ci(macos): smoke-test the proxy install-recording path + OS support matrix

### DIFF
--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -1,0 +1,212 @@
+name: macos-smoke
+
+# Proves that the proxy-side install-recording stack works on macOS.
+# Linux has `proxy-smoke` for the rewrite-correctness path; this job is
+# the macOS counterpart focused on the cross-platform claims most likely
+# to silently break:
+#
+#   1. `sakimori proxy start` actually binds on macos-latest (TLS init,
+#      hudsucker, rustls — all of which have historically had
+#      Linux-only assumptions).
+#   2. A pinned tarball fetch through the proxy appends an
+#      `InstallEvent` to `installs.jsonl` byte-for-byte the same way
+#      Linux does (no `cfg(target_os)` gating regression in
+#      `sakimori-core::installs` or `sakimori-proxy`).
+#   3. `sakimori advisories scan` reads that log on macOS and produces
+#      a structurally-valid report (the OSV JOIN path is the user-
+#      visible payoff; if it can't parse a Mac-written log we've lost
+#      the headline feature).
+#   4. `sakimori install-gate shellenv --shell zsh` renders the
+#      snippet the user is told to `eval` in `~/.zshrc`, and the
+#      result actually parses under `zsh -n` (catches us regressing
+#      the rendered snippet into something that breaks shell startup
+#      for every Mac user).
+#
+# We *do not* re-run the per-ecosystem rewrite assertions — those are
+# OS-neutral and the Linux job already exercises them. This job is
+# specifically "the macOS-side wiring is intact", not "the rewriter is
+# correct".
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "crates/sakimori/**"
+      - "crates/sakimori-proxy/**"
+      - "crates/sakimori-core/**"
+      - ".github/workflows/macos-smoke.yml"
+
+jobs:
+  proxy-install-recording:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build sakimori (release)
+        run: cargo build --release -p sakimori
+
+      - name: Show runner identity
+        run: |
+          set -euxo pipefail
+          uname -a
+          sw_vers || true
+          which zsh
+          zsh --version
+
+      - name: Start proxy in the background
+        run: |
+          set -euo pipefail
+          export XDG_CONFIG_HOME="$RUNNER_TEMP/xdg"
+          mkdir -p "$XDG_CONFIG_HOME"
+          echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" >>"$GITHUB_ENV"
+          # 365d so the proxy always has something to filter out;
+          # the assertion in this job is *recording*, not rewriting,
+          # but a realistic min-age keeps the run shaped like a real
+          # one.
+          ./target/release/sakimori proxy start \
+              --listen 127.0.0.1:18910 \
+              --min-age 365d \
+              --install-log "$RUNNER_TEMP/installs.jsonl" \
+              > "$RUNNER_TEMP/proxy.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/proxy.pid"
+          # macOS doesn't ship `ss`; use `lsof` or fall back to a
+          # connect probe with `nc`. We use `nc -z` because it's
+          # in the base system and behaves the same on every macOS
+          # version we'll see in CI.
+          for i in $(seq 1 60); do
+            if nc -z 127.0.0.1 18910 2>/dev/null; then
+              echo "proxy up after ${i}00ms"
+              break
+            fi
+            sleep 0.1
+          done
+          if ! nc -z 127.0.0.1 18910 2>/dev/null; then
+            echo "::error::proxy never opened 127.0.0.1:18910"
+            echo "--- proxy.log ---"
+            cat "$RUNNER_TEMP/proxy.log"
+            exit 1
+          fi
+          # Locate the CA the proxy just minted so the curl probe can
+          # validate the MITM leaf without touching the system keychain.
+          ca="$XDG_CONFIG_HOME/sakimori/ca.pem"
+          test -f "$ca" || { echo "::error::CA not generated at $ca"; ls -la "$XDG_CONFIG_HOME/sakimori" || true; exit 1; }
+          echo "CA=$ca" >>"$GITHUB_ENV"
+
+      - name: Pinned tarball fetch — proxy records an InstallEvent
+        run: |
+          set -euo pipefail
+          # Same fixture as the Linux proxy-smoke: lodash@4.17.21 is
+          # old enough to clear the --min-age 365d filter on any
+          # plausible run date.
+          curl -fsS --cacert "$CA" -x http://127.0.0.1:18910 \
+            -o /dev/null \
+            -A 'npm/10.0.0 node/20.0.0 ci/true' \
+            https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz
+          test -f "$RUNNER_TEMP/installs.jsonl"
+          echo "--- installs.jsonl ---"
+          cat "$RUNNER_TEMP/installs.jsonl"
+          python3 - <<'PY'
+          import json, os
+          path = os.path.join(os.environ["RUNNER_TEMP"], "installs.jsonl")
+          rows = [json.loads(l) for l in open(path) if l.strip()]
+          hits = [r for r in rows
+                  if r["ecosystem"] == "npm"
+                  and r["name"] == "lodash"
+                  and r["version"] == "4.17.21"]
+          assert hits, f"no install event recorded for lodash@4.17.21 on macOS: {rows}"
+          # The npm/10.x UA we sent should classify as `persistent`.
+          assert hits[0]["execution_mode"] == "persistent", hits[0]
+          assert "user_agent" in hits[0]
+          assert "resolved_at" in hits[0]
+          print(f"✓ macOS proxy recorded {len(hits)} install event(s) for lodash@4.17.21")
+          PY
+
+      - name: advisories scan consumes the Mac-written log
+        # End-to-end: prove the JSONL we just wrote on macOS round-trips
+        # through `advisories scan`. We accept 0 (no hits) or 1 (hits
+        # found) — OSV may or may not list anything for lodash@4.17.21
+        # on a given day. Anything else means we broke the JSON shape.
+        run: |
+          set -uxo pipefail
+          set +e
+          ./target/release/sakimori advisories scan \
+              --install-log "$RUNNER_TEMP/installs.jsonl" \
+              --json > "$RUNNER_TEMP/scan.json"
+          rc=$?
+          set -e
+          if [ "$rc" != "0" ] && [ "$rc" != "1" ]; then
+            echo "::error::advisories scan exited unexpectedly on macOS (rc=$rc)"
+            cat "$RUNNER_TEMP/scan.json" || true
+            exit 1
+          fi
+          python3 - <<'PY'
+          import json, os
+          r = json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "scan.json")))
+          assert r["installs_scanned"] >= 1, r
+          assert "hits" in r and isinstance(r["hits"], list), r
+          print(f"ok macOS scan: scanned={r['installs_scanned']} hits={len(r['hits'])}")
+          PY
+
+      - name: install-gate shellenv (zsh) renders + parses under zsh -n
+        # Two things at once: prove `install-gate shellenv` runs at all
+        # on macOS, and that what it emits is syntactically valid zsh
+        # (so a Mac user evaling it in ~/.zshrc doesn't break their
+        # shell). We don't actually `source` it — we don't want to
+        # mutate the runner's env — just `zsh -n` syntax-check.
+        run: |
+          set -euxo pipefail
+          snippet="$RUNNER_TEMP/shellenv.zsh"
+          ./target/release/sakimori install-gate shellenv \
+              --shell zsh \
+              --listen 127.0.0.1:18910 \
+              > "$snippet"
+          echo "--- shellenv (zsh) ---"
+          cat "$snippet"
+          # Hard-fail if the proxy URL doesn't appear — catches us
+          # accidentally rendering an empty / placeholder snippet.
+          grep -q "HTTPS_PROXY='http://127.0.0.1:18910'" "$snippet"
+          grep -q "CARGO_HTTP_CAINFO" "$snippet"
+          grep -q "NODE_EXTRA_CA_CERTS" "$snippet"
+          # `zsh -n` is "syntax check only, do not execute". This is
+          # the cheapest way to catch the rendered snippet becoming
+          # unsourceable.
+          zsh -n "$snippet"
+          echo "✓ shellenv renders and parses under zsh -n on macOS"
+
+      - name: install-gate shellenv (bash) parses under bash -n
+        run: |
+          set -euxo pipefail
+          snippet="$RUNNER_TEMP/shellenv.bash"
+          ./target/release/sakimori install-gate shellenv \
+              --shell bash \
+              --listen 127.0.0.1:18910 \
+              > "$snippet"
+          bash -n "$snippet"
+          echo "✓ shellenv (bash) parses on macOS"
+
+      - name: Show proxy log
+        if: always()
+        run: tail -80 "$RUNNER_TEMP/proxy.log" || true
+
+      - name: Upload artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-smoke-artefacts
+          path: |
+            ${{ runner.temp }}/installs.jsonl
+            ${{ runner.temp }}/scan.json
+            ${{ runner.temp }}/shellenv.zsh
+            ${{ runner.temp }}/shellenv.bash
+            ${{ runner.temp }}/proxy.log
+
+      - name: Stop proxy
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/proxy.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/proxy.pid")" 2>/dev/null || true
+          fi

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -38,13 +38,24 @@ on:
       - "crates/sakimori-core/**"
       - ".github/workflows/macos-smoke.yml"
 
+# Read-only token: this workflow only checks out the repo and runs the
+# binary; it never writes back to GitHub. Explicit so CodeQL's
+# "workflow-without-permissions" rule stays green and so any future
+# step accidentally needing write has to opt in visibly.
+permissions:
+  contents: read
+
 jobs:
   proxy-install-recording:
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to the same SHA used by `security.yml` (stable channel
+      # as of the pin date) — see CodeQL "Unpinned tag for a
+      # non-immutable Action". Update via the same workflow that
+      # bumps `security.yml`.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build sakimori (release)
         run: cargo build --release -p sakimori

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,45 @@ kernel-enforced; `network.default: deny` is audit-only + warn.
    next slice.
 5. **macOS live block** — either a Network Extension (heavy, needs
    signing) or an HTTPS proxy (see #2).
+5b. **macOS supervised mode (exec + file attribution via Endpoint
+    Security)** — Linux has eBPF tracepoints + PPid-walk attribution
+    (v0.23) and Windows has ETW, but macOS today only sees installs
+    via the proxy. The matching primitive on macOS is the
+    **Endpoint Security framework** (`<EndpointSecurity/
+    EndpointSecurity.h>`), which delivers `ES_EVENT_TYPE_NOTIFY_EXEC`
+    / `..._FORK` / `..._OPEN` / `..._WRITE` with full
+    `audit_token_t` + parent pid + signing info — i.e. the same
+    "npm → sh → node postinstall → curl" chain sakimori currently
+    reconstructs from `/proc` on Linux, available natively without a
+    PPid walk. Required pieces:
+    - A separate signed binary with the
+      `com.apple.developer.endpoint-security.client` entitlement
+      (Apple-issued, gated approval — non-trivial onboarding cost,
+      same gate Jamf / CrowdStrike / SentinelOne pass through).
+      Notarised + Developer ID signed; the SystemExtension lives
+      under `/Library/SystemExtensions/` and the user has to approve
+      it once in System Settings → Privacy & Security.
+    - ES client subscribes to NOTIFY-class events for the
+      audit/observability path; AUTH-class events
+      (`ES_EVENT_TYPE_AUTH_EXEC`, `..._AUTH_OPEN`) are what would let
+      us *block* (the macOS analogue of `bpf_override_return`),
+      paralleling roadmap #4. AUTH responses are deadline-bound
+      (~tens of ms) so the policy match has to stay hot-path-cheap.
+    - Bridge into `sakimori-core::events` so JSON-log + step-summary
+      + HTML report reuse the existing shapes; attribution becomes
+      "read the responsible/parent audit_token directly" rather than
+      walking `/proc`.
+    - Packaging: ship as a separate `sakimori-mac` crate (mirrors
+      `sakimori-win`'s split) so ES bindings + Objective-C runtime
+      deps don't leak into the Linux build.
+    - Out of scope for the first slice: AUTH-mode pre-syscall block
+      (start with NOTIFY-only audit, same staging Linux did before
+      `bpf_send_signal`); container/VM-hosted installs (ES sees only
+      the host); per-script *content* inspection (proxy-side
+      lifecycle gate #15 already covers that and is OS-agnostic).
+    Pairs with #5 (HTTPS proxy live block) the way Linux pairs
+    network eBPF with file/exec eBPF — proxy handles "what was
+    fetched", ES handles "what ran and what it touched".
 6. **Retroactive CVE notification for past installs** — local-first
    half landed: the proxy's pinned-install path now appends every
    resolved fetch to `~/.sakimori/installs.jsonl`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -886,6 +886,34 @@ is genuinely flaky (e.g. nanos-based tmpdir collisions under
 parallel runs) re-run once and, if it still fails, fix the flake
 in a separate commit rather than ignoring it.
 
+## DCO sign-off (every commit, no exceptions)
+
+This repo runs a DCO check (`.github/workflows/dco.yml`) that fails
+any push whose commits lack a `Signed-off-by:` trailer. **Always
+pass `-s` / `--signoff` to `git commit`** — including amends,
+cherry-picks, and rebases. Agents have repeatedly tripped on this
+because the default Claude Code commit flow does not add `-s`.
+
+```bash
+git commit -s -m "fix(thing): ..."
+# or, retroactively, on the current branch:
+git rebase --signoff <merge-base> && git push --force-with-lease
+```
+
+Two practical rules so this stops costing a round-trip:
+
+1. **First commit on a branch**: always `git commit -s`. If you
+   forget, the DCO job in CI is your reminder — fix with
+   `git rebase --signoff origin/main` then `--force-with-lease`.
+2. **Do not add `Co-Authored-By: Claude ...` trailers.** This
+   repo's auto-mode classifier blocks them as misrepresented
+   authorship. The author identity is whatever `git config user.*`
+   resolves to; the `Signed-off-by:` line is the only attribution
+   trailer the project wants.
+
+The detailed DCO text lives in [CONTRIBUTING.md](CONTRIBUTING.md);
+this section is the operational shorthand so you don't forget.
+
 ## Testing conventions
 
 - **Test-first whenever possible.** Handler traits are specifically

--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ from then on, every HTTPS request your package managers make through
 All four ecosystems' metadata paths now rewrite silently — pnpm-style
 `minimumReleaseAge` across the board, no fail-hard in the common case.
 
+### OS support matrix
+
+sakimori has two layers, and they have **different** OS coverage. Read
+this carefully before assuming "macOS isn't supported" or "Linux gets
+everything":
+
+| capability | Linux | macOS | Windows |
+|---|---|---|---|
+| **Fetch-layer** (proxy + install-gate) | | | |
+| ↳ `sakimori proxy start` (MITM + age filter + auto-fallback) | ✅ | ✅ | ✅ |
+| ↳ `sakimori install-gate install` (shell wiring) | ✅ zsh / bash / fish | ✅ zsh / bash / fish | ✅ PowerShell |
+| ↳ `~/.sakimori/installs.jsonl` recording — *who installed what, when* | ✅ | ✅ | ✅ |
+| ↳ `sakimori advisories scan` (OSV JOIN over the install log) | ✅ | ✅ | ✅ |
+| ↳ Lifecycle-script inspection (`--lifecycle-policy audit|block`) | ✅ | ✅ | ✅ |
+| ↳ `sakimori deps check` / `verify-cache` / `watch` | ✅ | ✅ | ✅ |
+| **Supervisor-layer** (`sakimori run` / `daemon`) | | | |
+| ↳ exec / open / connect events | ✅ eBPF | ❌ planned ([roadmap 5b](CLAUDE.md)) | ✅ ETW |
+| ↳ PPid attribution → package-manager origin | ✅ | ❌ | partial |
+| ↳ `--snapshot-workspace` (drift + known-IOC scan at shutdown) | ✅ | ❌ | partial |
+| ↳ Live network block | ✅ eBPF cgroup hooks | ❌ planned (#5) | ✅ Defender Firewall |
+| ↳ Live file/exec block | tripwire (SIGKILL); pre-syscall in progress (#4) | ❌ | audit-only |
+
+**Headline**: *if you only care about "tell me which packages I
+installed and warn me when one of them gets a CVE next week", macOS is
+a first-class platform.* That's the part most users want. The
+supervisor (live blocking, exec attribution, workspace drift) is where
+the Mac gap is — tracked as roadmap item 5b in CLAUDE.md (Apple's
+Endpoint Security framework, requires Apple-issued entitlement +
+SystemExtension signing).
+
+CI coverage matches: the [`macos-smoke` workflow](.github/workflows/macos-smoke.yml)
+exercises proxy start → pinned-tarball fetch → `installs.jsonl` →
+`advisories scan` → `install-gate shellenv` end-to-end on every PR
+that touches the relevant crates, so the cells marked ✅ for macOS
+above don't silently regress.
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary

- **`macos-smoke` workflow** that runs on `macos-latest` and exercises proxy → pinned-tarball fetch → `installs.jsonl` → `advisories scan` → `install-gate shellenv` end-to-end. Linux has `proxy-smoke` for rewrite correctness; macOS had no equivalent despite the entire fetch layer being cross-platform, so a `cfg(target_os)` regression in `sakimori-proxy` / `sakimori-core::installs` / `install-gate` would silently break Mac users.
- **README §"OS support matrix"** splitting fetch-layer (3 OS ✅) from supervisor-layer (Linux/Windows only). The previous docs left "does macOS work?" ambiguous, which led to repeated confusion about whether install-recording is supported on Mac (it is, and has been).
- **CLAUDE.md roadmap 5b**: macOS supervised mode via Apple's Endpoint Security framework — captures the Apple-entitlement cost, NOTIFY vs AUTH staging, and where it slots next to roadmap #5 (HTTPS proxy live block).

## What `macos-smoke` actually proves

| step | failure means |
|---|---|
| `sakimori proxy start` binds on macos-latest | TLS / hudsucker / rustls init regressed to Linux-only |
| pinned `.tgz` fetch produces an `InstallEvent` (UA → `execution_mode: persistent`) | recording path gained `cfg(target_os)` gating |
| `advisories scan` reads the Mac-written JSONL | OSV JOIN can't parse Mac-produced logs |
| `install-gate shellenv --shell zsh\|bash` parses under `{zsh,bash} -n` | rendered snippet would break shell startup for every Mac user who runs `install-gate install` |

Per-ecosystem rewrite assertions are intentionally not re-run — they're OS-neutral and already covered by `proxy-smoke`. This job is scoped to "the macOS-side wiring is intact."

## Test plan

- [ ] `macos-smoke` workflow passes on this PR
- [ ] `proxy-smoke` and `advisories-smoke` still pass (no Linux regression)
- [ ] README renders correctly on GitHub (matrix table layout, link to `macos-smoke.yml` and `CLAUDE.md`)