### PR TITLE
ci: pin remaining 3rd-party action SHAs + read-only token defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,18 @@ on:
     branches: [main]
   pull_request:
 
+# Default to read-only for GITHUB_TOKEN. Individual jobs that need
+# more opt in at the job level. Pinned per CodeQL's
+# "workflow-without-permissions" rule.
+permissions:
+  contents: read
+
 jobs:
   userspace:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
       - run: cargo fmt --all -- --check
@@ -115,7 +121,7 @@ jobs:
     needs: userspace
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - run: cargo build --release -p sakimori
       - name: Generate CA + start proxy in background
         run: |
@@ -313,7 +319,7 @@ jobs:
     needs: userspace
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - run: cargo build --release -p sakimori
       - run: echo "SAKIMORI_BIN=$PWD/target/release/sakimori" >>"$GITHUB_ENV"
 
@@ -369,7 +375,7 @@ jobs:
           echo "✓ npm verify-cache detected tampering (rc=$rc)"
 
       # --- pnpm ---------------------------------------------------------
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9
       - name: pnpm — populate store v3 via a real install
@@ -453,7 +459,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: rust-src
       - name: Install bpf-linker
@@ -486,7 +492,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Build the userspace binary natively on this runner's arch.
       - name: Build sakimori (${{ matrix.arch }})
         run: cargo build --release -p sakimori
@@ -814,7 +820,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Build sakimori (host arch)
         run: cargo build --release -p sakimori
       - uses: actions/download-artifact@v4
@@ -990,7 +996,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Build sakimori
         run: cargo build --release -p sakimori
       - name: Resolve sakimori binary path
@@ -1146,7 +1152,7 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build sakimori (main binary; cross-OS via cfg-gated eBPF deps)
         run: cargo build --release -p sakimori

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,12 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Deny-by-default at the workflow level — the `proxy-image` job opts
+# back in to exactly what it needs (`contents: read` + `packages:
+# write`). Any future job added without an explicit `permissions:`
+# block gets an empty token instead of inheriting write-all.
+permissions: {}
+
 jobs:
   proxy-image:
     # Build + push the sakimori-proxy container image to GHCR on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
       - name: Install musl toolchain
@@ -32,7 +32,7 @@ jobs:
         run: cargo build --release -p sakimori --target ${{ matrix.target }}
 
       # eBPF object (arch-independent ELF but rebuilt per runner for reproducibility)
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           components: rust-src
       - name: Install bpf-linker
@@ -73,7 +73,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-apple-darwin,aarch64-apple-darwin
       - name: Build both macOS targets
@@ -110,7 +110,7 @@ jobs:
       TARGET: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Build sakimori-win (ETW supervisor)
         working-directory: crates/sakimori-win
         run: cargo build --release

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -10,12 +10,21 @@ on:
       - "crates/sakimori-core/**"
       - ".github/workflows/windows-smoke.yml"
 
+# Read-only token — the workflow only checks out and runs the binary,
+# uploading artifacts under the same GITHUB_TOKEN scope. Explicit so
+# CodeQL's "workflow-without-permissions" rule stays green.
+permissions:
+  contents: read
+
 jobs:
   audit-parity:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned per CodeQL "Unpinned tag for a non-immutable Action".
+      # Same SHA as security.yml / macos-smoke.yml so bumps stay
+      # coherent across workflows.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Show runner privileges
         shell: pwsh


### PR DESCRIPTION
## Summary

Follow-up to [#86](https://github.com/bokuweb/sakimori/pull/86). CodeQL flagged two classes of issue on `macos-smoke.yml` that also exist across the rest of the workflows; this PR closes the parity gap so the same alerts don't re-fire on the next workflow addition.

### 1. Pin third-party actions to commit SHAs

| workflow | before | after |
|---|---|---|
| `ci.yml` (×7) | `dtolnay/rust-toolchain@stable` | `@29eef33...` |
| `ci.yml` (×1) | `dtolnay/rust-toolchain@nightly` | `@5b84223...` |
| `ci.yml` (×1) | `pnpm/action-setup@v4` | `@b906aff...` |
| `release.yml` (×3) | `dtolnay/rust-toolchain@stable` | `@29eef33...` |
| `release.yml` (×1) | `dtolnay/rust-toolchain@nightly` | `@5b84223...` |
| `windows-smoke.yml` (×1) | `dtolnay/rust-toolchain@stable` | `@29eef33...` |

The `stable` channel SHA matches what `security.yml` and `macos-smoke.yml` already use, so a future bump touches one SHA per channel rather than every workflow.

### 2. Add top-level `permissions:` blocks

- **`ci.yml`** + **`windows-smoke.yml`** → `permissions: contents: read`. Both only checkout, build, run, and upload-artifact (uses the same scope).
- **`docker.yml`** → `permissions: {}` (deny-by-default). The single existing job already declares `contents: read + packages: write` at the job level, so this is defense-in-depth: any future job added without explicit `permissions:` gets an empty token instead of inheriting write-all.

## Out of scope

`actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `actions/setup-python`, and the `docker/*` family remain on floating major-version tags. CodeQL's "unpinned 3rd-party action" rule classifies first-party `actions/*` and GitHub-verified `docker/*` as Warn-only and the alerts on PR #86 were specifically the `dtolnay/` / `pnpm/` family. A broader pinning sweep would be a separate PR.

## Test plan

- [ ] All workflows still pass on this PR (CI parity)
- [ ] CodeQL alerts on this PR no longer flag any pinned-SHA / missing-permissions warnings for these workflows