### PR TITLE
feat(proxy): pluggable per-ecosystem registry hosts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,73 @@ would require flipping the system-wide default-outbound to Block,
 which we won't do silently on a shared runner. `network.deny` is
 kernel-enforced; `network.default: deny` is audit-only + warn.
 
+## Custom / internal registries
+
+The proxy's per-ecosystem rewriters + lifecycle gate dispatch by
+**hostname**: traffic to `registry.npmjs.org` runs the npm packument
+rewriter, traffic to `pypi.org` runs the PyPI rewriters, etc. By
+default only the canonical public hosts are watched. Teams that route
+installs through an internal mirror (Verdaccio, GitHub Packages,
+Artifactory, Takumi Guard, JFrog, Nexus, …) need to teach the proxy
+about those hosts; otherwise traffic to e.g.
+`https://npm.flatt.tech/` passes through opaquely and none of the
+release-age / lifecycle defences fire.
+
+The configuration surface lives in `sakimori-proxy::RegistryHosts`
+(`crates/sakimori-proxy/src/registries.rs`) with three layered
+sources, applied in this order with case-insensitive dedupe:
+
+1. Built-in defaults (the canonical public host per ecosystem — always
+   in).
+2. Optional TOML config: `--registries-config <FILE>`. Schema:
+
+   ```toml
+   [registries]
+   npm           = ["registry.npmjs.org", "npm.flatt.tech"]
+   pypi_index    = ["pypi.org"]
+   pypi_files    = ["files.pythonhosted.org"]
+   crates        = ["crates.io"]
+   crates_sparse = ["index.crates.io"]
+   nuget         = ["api.nuget.org"]
+   ```
+
+3. Per-ecosystem CLI flags on `sakimori proxy start` (repeatable):
+   `--npm-registry`, `--pypi-registry`, `--pypi-files-host`,
+   `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry`.
+   Each accepts a bare hostname or a URL whose host is extracted
+   (`https://npm.flatt.tech:8443/` → `npm.flatt.tech`).
+
+The proxy then constructs parsers via
+`parser::parsers_from_hosts(&RegistryHosts)`; `classify_response`
+consults the same struct so the npm packument rewriter / PyPI index
+rewriter / NuGet registration rewriter / crates sparse-index
+rewriter / lifecycle gate fire on every configured host of the
+right ecosystem.
+
+**What does NOT switch by hostname** (yet, see Roadmap if applicable):
+
+- **URL path shape**. The custom host must serve the canonical
+  registry's URL shape (npm: `/<pkg>` packument + `/<pkg>/-/
+  <pkg>-<ver>.tgz` tarballs; PyPI Warehouse JSON / PEP 503/691
+  Simple index; NuGet v3 registration + flat-container; cargo sparse
+  index). A mirror that exposes a different shape (e.g. an
+  Artifactory repo at `/artifactory/api/npm/<repo>/`) needs a path-
+  prefix-aware variant of the parser — not implemented.
+- **Tarball pin URLs in the npm packument**. When the rewriter
+  retargets `dist-tags.latest` or surfaces strip-mode integrity
+  values, it edits the upstream's own `dist.tarball` URL byte-for-
+  byte; the URL host is whatever the upstream packument said, so
+  internal mirrors that rewrite `dist.tarball` to themselves keep
+  doing so transparently. No change required.
+- **OSV-mirror / typosquat-mirror**. These are sakimori-hosted
+  metadata feeds, not package registries; they have their own
+  `--osv-mirror-url` / `--typosquat-mirror-url` flags.
+
+Egress filtering (`--network-allow`) is orthogonal and stacks
+naturally: to lock the proxy to *only* internal mirrors and forbid
+the canonical public hosts, list the internal hosts under
+`--network-allow` and the public ones won't survive the default-deny.
+
 ## Roadmap (what to build next, in priority order)
 
 1. **`sakimori install-gate`** — ✅ implemented in v0.19. Three

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -14,6 +14,7 @@ pub mod otlp;
 pub mod parser;
 pub mod proxy;
 pub mod pypi_simple_client;
+pub mod registries;
 pub mod rewrite;
 pub mod rewrite_npm;
 pub mod rewrite_nuget;
@@ -25,9 +26,10 @@ pub mod typosquat;
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
 pub use parser::{
     CratesIoParser, CratesIoSparseParser, ParseResult, RegistryParser, default_parsers,
-    parse_for_host,
+    parse_for_host, parsers_from_hosts,
 };
 pub use proxy::{ProxyConfig, run};
+pub use registries::RegistryHosts;
 pub use rewrite::{RewriteStats, rewrite_crates_index_jsonl};
 pub use rewrite_npm::{NpmRewriteStats, rewrite_npm_packument};
 pub use rewrite_nuget::{

--- a/crates/sakimori-proxy/src/parser.rs
+++ b/crates/sakimori-proxy/src/parser.rs
@@ -1,8 +1,16 @@
 //! Parse incoming HTTPS requests into a `(ecosystem, name, version)`
 //! triple we can age-check. Unrecognised URLs return `Unknown` and the
 //! proxy passes them through untouched.
+//!
+//! Each parser carries a per-instance list of hosts it's responsible
+//! for, so the same npm-shaped logic can match `registry.npmjs.org`
+//! AND an org-internal mirror like `npm.flatt.tech` simultaneously.
+//! See [`crate::registries::RegistryHosts`] for the configuration
+//! surface (defaults + TOML file + CLI overrides).
 
 use sakimori_core::deps::Ecosystem;
+
+use crate::registries::RegistryHosts;
 
 /// Result of inspecting one registry-bound request.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,10 +30,12 @@ pub enum ParseResult {
 }
 
 pub trait RegistryParser: Send + Sync {
-    /// The authority part this parser is responsible for (for routing).
-    fn host(&self) -> &'static str;
+    /// Hosts this parser is responsible for. The proxy matches case-
+    /// insensitively. Returning an empty slice effectively disables
+    /// the parser (no host will route to it).
+    fn hosts(&self) -> &[String];
     /// Parse the path + query of a request already known to be for
-    /// [`Self::host`].
+    /// one of [`Self::hosts`].
     fn parse(&self, path: &str) -> ParseResult;
 }
 
@@ -40,11 +50,25 @@ pub trait RegistryParser: Send + Sync {
 ///   through; we'll rewrite this to omit too-young versions in a
 ///   follow-up (that's the pnpm-style auto-fallback story).
 /// - anything else → Unknown, pass through.
-pub struct CratesIoParser;
+pub struct CratesIoParser {
+    hosts: Vec<String>,
+}
+
+impl CratesIoParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for CratesIoParser {
+    fn default() -> Self {
+        Self::new(vec!["crates.io".into()])
+    }
+}
 
 impl RegistryParser for CratesIoParser {
-    fn host(&self) -> &'static str {
-        "crates.io"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, path: &str) -> ParseResult {
         // Strip query string.
@@ -72,20 +96,34 @@ impl RegistryParser for CratesIoParser {
 /// Parser for the sparse index at `index.crates.io`. Entries look
 /// like `GET /1/s/serde` (shard) → JSONL metadata. We treat these
 /// as Metadata for now.
-pub struct CratesIoSparseParser;
+pub struct CratesIoSparseParser {
+    hosts: Vec<String>,
+}
+
+impl CratesIoSparseParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for CratesIoSparseParser {
+    fn default() -> Self {
+        Self::new(vec!["index.crates.io".into()])
+    }
+}
 
 impl RegistryParser for CratesIoSparseParser {
-    fn host(&self) -> &'static str {
-        "index.crates.io"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, _path: &str) -> ParseResult {
         ParseResult::Metadata
     }
 }
 
-// ---------------- npm (registry.npmjs.org) ----------------
+// ---------------- npm ----------------
 
-/// Parser for `registry.npmjs.org`.
+/// Parser for npm registry hosts.
 ///
 /// Tarball download URL shapes we handle:
 /// - `GET /<name>/-/<basename>-<version>.tgz`
@@ -101,11 +139,25 @@ impl RegistryParser for CratesIoSparseParser {
 /// is Metadata — those describe available versions but don't actually
 /// transfer a tarball, so blocking them would only break resolution
 /// without buying security.
-pub struct NpmParser;
+pub struct NpmParser {
+    hosts: Vec<String>,
+}
+
+impl NpmParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for NpmParser {
+    fn default() -> Self {
+        Self::new(vec!["registry.npmjs.org".into()])
+    }
+}
 
 impl RegistryParser for NpmParser {
-    fn host(&self) -> &'static str {
-        "registry.npmjs.org"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, path: &str) -> ParseResult {
         let path = path.split('?').next().unwrap_or(path);
@@ -144,10 +196,11 @@ impl RegistryParser for NpmParser {
     }
 }
 
-// ---------------- PyPI (files.pythonhosted.org) ----------------
+// ---------------- PyPI artefact host ----------------
 
-/// Parser for `files.pythonhosted.org`, which is where pip / uv /
-/// poetry actually fetch sdists and wheels from.
+/// Parser for `files.pythonhosted.org` (or a mirror serving the same
+/// path shape), which is where pip / uv / poetry actually fetch
+/// sdists and wheels from.
 ///
 /// File names follow PEP 427 (wheels) / PEP 625 (sdists):
 /// - sdist: `<name>-<version>.tar.gz` (or `.zip`)
@@ -158,11 +211,25 @@ impl RegistryParser for NpmParser {
 /// "first segment starting with a digit" is the version — we use
 /// that as our delimiter. This handles names with hyphens
 /// (`my-cool-pkg-1.0.0.tar.gz`) correctly.
-pub struct PypiParser;
+pub struct PypiParser {
+    hosts: Vec<String>,
+}
+
+impl PypiParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for PypiParser {
+    fn default() -> Self {
+        Self::new(vec!["files.pythonhosted.org".into()])
+    }
+}
 
 impl RegistryParser for PypiParser {
-    fn host(&self) -> &'static str {
-        "files.pythonhosted.org"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, path: &str) -> ParseResult {
         let path = path.split('?').next().unwrap_or(path);
@@ -207,30 +274,44 @@ impl RegistryParser for PypiParser {
     }
 }
 
-// ---------------- PyPI metadata host (pypi.org) ----------------
+// ---------------- PyPI metadata host ----------------
 
-/// Parser for `pypi.org`, the PyPI **metadata** host.
+/// Parser for `pypi.org` (or a mirror serving the same paths), the
+/// PyPI **metadata** host.
 ///
-/// Every request to `pypi.org` is metadata (JSON API, Simple index
-/// HTML/JSON, project pages). The tarballs themselves live on
+/// Every request is metadata (JSON API, Simple index HTML/JSON,
+/// project pages). The tarballs themselves live on
 /// `files.pythonhosted.org` and are handled by [`PypiParser`]. This
-/// parser exists purely so `should_intercept` returns `true` for
-/// `pypi.org` and the proxy MITMs the TLS so we can rewrite metadata
-/// responses. It never produces a `Pinned` result.
-pub struct PypiOrgParser;
+/// parser exists purely so the proxy MITMs the TLS so we can rewrite
+/// metadata responses. It never produces a `Pinned` result.
+pub struct PypiOrgParser {
+    hosts: Vec<String>,
+}
+
+impl PypiOrgParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for PypiOrgParser {
+    fn default() -> Self {
+        Self::new(vec!["pypi.org".into()])
+    }
+}
 
 impl RegistryParser for PypiOrgParser {
-    fn host(&self) -> &'static str {
-        "pypi.org"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, _path: &str) -> ParseResult {
         ParseResult::Metadata
     }
 }
 
-// ---------------- NuGet (api.nuget.org) ----------------
+// ---------------- NuGet ----------------
 
-/// Parser for `api.nuget.org`. Tarball download URL:
+/// Parser for NuGet v3 endpoints. Tarball download URL:
 ///
 /// ```text
 /// GET /v3-flatcontainer/<id-lower>/<version>/<id-lower>.<version>.nupkg
@@ -238,11 +319,25 @@ impl RegistryParser for PypiOrgParser {
 ///
 /// Name and version are cleanly in the path as separate segments,
 /// so no filename-splitting heuristics needed.
-pub struct NugetParser;
+pub struct NugetParser {
+    hosts: Vec<String>,
+}
+
+impl NugetParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl Default for NugetParser {
+    fn default() -> Self {
+        Self::new(vec!["api.nuget.org".into()])
+    }
+}
 
 impl RegistryParser for NugetParser {
-    fn host(&self) -> &'static str {
-        "api.nuget.org"
+    fn hosts(&self) -> &[String] {
+        &self.hosts
     }
     fn parse(&self, path: &str) -> ParseResult {
         let path = path.split('?').next().unwrap_or(path);
@@ -264,20 +359,31 @@ impl RegistryParser for NugetParser {
     }
 }
 
+/// Build the canonical default parser set (single canonical public
+/// host per ecosystem). Kept for callers that don't need custom
+/// registries — equivalent to `parsers_from_hosts(&RegistryHosts::default())`.
 pub fn default_parsers() -> Vec<Box<dyn RegistryParser>> {
+    parsers_from_hosts(&RegistryHosts::default())
+}
+
+/// Build the parser set from a [`RegistryHosts`] configuration.
+/// Parsers with an empty host list are still constructed but never
+/// match anything — keeping the slice index stable means
+/// `parse_for_host` doesn't have to special-case missing ecosystems.
+pub fn parsers_from_hosts(h: &RegistryHosts) -> Vec<Box<dyn RegistryParser>> {
     vec![
-        Box::new(CratesIoParser),
-        Box::new(CratesIoSparseParser),
-        Box::new(NpmParser),
-        Box::new(PypiParser),
-        Box::new(PypiOrgParser),
-        Box::new(NugetParser),
+        Box::new(CratesIoParser::new(h.crates.clone())),
+        Box::new(CratesIoSparseParser::new(h.crates_sparse.clone())),
+        Box::new(NpmParser::new(h.npm.clone())),
+        Box::new(PypiParser::new(h.pypi_files.clone())),
+        Box::new(PypiOrgParser::new(h.pypi_index.clone())),
+        Box::new(NugetParser::new(h.nuget.clone())),
     ]
 }
 
 pub fn parse_for_host(parsers: &[Box<dyn RegistryParser>], host: &str, path: &str) -> ParseResult {
     for p in parsers {
-        if host.eq_ignore_ascii_case(p.host()) {
+        if p.hosts().iter().any(|h| host.eq_ignore_ascii_case(h)) {
             return p.parse(path);
         }
     }
@@ -290,7 +396,7 @@ mod tests {
 
     #[test]
     fn crates_download_url_is_pinned() {
-        let p = CratesIoParser;
+        let p = CratesIoParser::default();
         let r = p.parse("/api/v1/crates/serde/1.0.0/download");
         assert_eq!(
             r,
@@ -304,7 +410,7 @@ mod tests {
 
     #[test]
     fn crates_download_strips_query() {
-        let p = CratesIoParser;
+        let p = CratesIoParser::default();
         let r = p.parse("/api/v1/crates/tokio/1.35.0/download?token=abc");
         if let ParseResult::Pinned { name, version, .. } = r {
             assert_eq!(name, "tokio");
@@ -316,7 +422,7 @@ mod tests {
 
     #[test]
     fn crates_non_download_paths_are_metadata() {
-        let p = CratesIoParser;
+        let p = CratesIoParser::default();
         assert_eq!(p.parse("/api/v1/crates/serde"), ParseResult::Metadata);
         assert_eq!(p.parse("/api/v1/crates"), ParseResult::Metadata);
         assert_eq!(p.parse("/api/v1/crates/serde/1.0.0"), ParseResult::Metadata);
@@ -324,14 +430,14 @@ mod tests {
 
     #[test]
     fn unknown_paths_are_unknown() {
-        let p = CratesIoParser;
+        let p = CratesIoParser::default();
         assert_eq!(p.parse("/"), ParseResult::Unknown);
         assert_eq!(p.parse("/api/v2/whatever"), ParseResult::Unknown);
     }
 
     #[test]
     fn sparse_index_is_metadata_for_now() {
-        let p = CratesIoSparseParser;
+        let p = CratesIoSparseParser::default();
         assert_eq!(p.parse("/1/s/serde"), ParseResult::Metadata);
         assert_eq!(p.parse("/3/t/tokio"), ParseResult::Metadata);
     }
@@ -345,11 +451,9 @@ mod tests {
         assert_eq!(r, ParseResult::Unknown);
     }
 
-    // ---------------- npm tests ----------------
-
     #[test]
     fn npm_unscoped_tarball_is_pinned() {
-        let p = NpmParser;
+        let p = NpmParser::default();
         assert_eq!(
             p.parse("/lodash/-/lodash-4.17.21.tgz"),
             ParseResult::Pinned {
@@ -362,7 +466,7 @@ mod tests {
 
     #[test]
     fn npm_scoped_tarball_is_pinned_with_full_name() {
-        let p = NpmParser;
+        let p = NpmParser::default();
         assert_eq!(
             p.parse("/@types/node/-/node-20.0.0.tgz"),
             ParseResult::Pinned {
@@ -375,8 +479,7 @@ mod tests {
 
     #[test]
     fn npm_prerelease_version_with_hyphens_preserved() {
-        let p = NpmParser;
-        // react 18.0.0-rc.0 style: tarball is "react-18.0.0-rc.0.tgz"
+        let p = NpmParser::default();
         assert_eq!(
             p.parse("/react/-/react-18.0.0-rc.0.tgz"),
             ParseResult::Pinned {
@@ -389,7 +492,7 @@ mod tests {
 
     #[test]
     fn npm_metadata_paths_are_not_pinned() {
-        let p = NpmParser;
+        let p = NpmParser::default();
         assert_eq!(p.parse("/lodash"), ParseResult::Metadata);
         assert_eq!(p.parse("/lodash/4.17.21"), ParseResult::Metadata);
         assert_eq!(p.parse("/@types/node"), ParseResult::Metadata);
@@ -398,18 +501,14 @@ mod tests {
 
     #[test]
     fn npm_malformed_tarball_is_metadata() {
-        let p = NpmParser;
-        // Wrong basename in filename.
+        let p = NpmParser::default();
         assert_eq!(p.parse("/foo/-/bar-1.0.0.tgz"), ParseResult::Metadata);
-        // Missing extension.
         assert_eq!(p.parse("/foo/-/foo-1.0.0"), ParseResult::Metadata);
     }
 
-    // ---------------- pypi tests ----------------
-
     #[test]
     fn pypi_sdist_tar_gz_is_pinned() {
-        let p = PypiParser;
+        let p = PypiParser::default();
         assert_eq!(
             p.parse("/packages/aa/bb/cc/requests-2.31.0.tar.gz"),
             ParseResult::Pinned {
@@ -422,7 +521,7 @@ mod tests {
 
     #[test]
     fn pypi_wheel_is_pinned() {
-        let p = PypiParser;
+        let p = PypiParser::default();
         assert_eq!(
             p.parse("/packages/aa/bb/cc/numpy-1.26.0-cp311-cp311-macosx_11_0_arm64.whl"),
             ParseResult::Pinned {
@@ -435,7 +534,7 @@ mod tests {
 
     #[test]
     fn pypi_hyphenated_name_splits_at_first_digit_segment() {
-        let p = PypiParser;
+        let p = PypiParser::default();
         assert_eq!(
             p.parse("/packages/x/y/z/python-dateutil-2.8.2.tar.gz"),
             ParseResult::Pinned {
@@ -448,16 +547,14 @@ mod tests {
 
     #[test]
     fn pypi_unknown_extension_is_metadata() {
-        let p = PypiParser;
+        let p = PypiParser::default();
         assert_eq!(p.parse("/packages/x/y/z/foo.txt"), ParseResult::Metadata);
         assert_eq!(p.parse("/"), ParseResult::Metadata);
     }
 
-    // ---------------- nuget tests ----------------
-
     #[test]
     fn nuget_nupkg_is_pinned() {
-        let p = NugetParser;
+        let p = NugetParser::default();
         assert_eq!(
             p.parse("/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg"),
             ParseResult::Pinned {
@@ -470,7 +567,7 @@ mod tests {
 
     #[test]
     fn nuget_non_flatcontainer_paths_are_metadata() {
-        let p = NugetParser;
+        let p = NugetParser::default();
         assert_eq!(
             p.parse("/v3/registration5-semver1/newtonsoft.json/index.json"),
             ParseResult::Metadata
@@ -511,5 +608,154 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn custom_npm_host_routes_to_npm_parser() {
+        let mut h = RegistryHosts::default();
+        h.npm.push("npm.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(&ps, "npm.flatt.tech", "/lodash/-/lodash-4.17.21.tgz");
+        assert_eq!(
+            r,
+            ParseResult::Pinned {
+                ecosystem: Ecosystem::Npm,
+                name: "lodash".into(),
+                version: "4.17.21".into(),
+            }
+        );
+        // Original canonical host still works alongside.
+        let r = parse_for_host(&ps, "registry.npmjs.org", "/lodash/-/lodash-4.17.21.tgz");
+        assert!(matches!(r, ParseResult::Pinned { .. }));
+    }
+
+    #[test]
+    fn empty_host_list_disables_an_ecosystem() {
+        let h = RegistryHosts {
+            npm: vec![],
+            ..RegistryHosts::default()
+        };
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(&ps, "registry.npmjs.org", "/lodash/-/lodash-4.17.21.tgz");
+        assert_eq!(r, ParseResult::Unknown);
+    }
+
+    #[test]
+    fn custom_host_with_pypi_shape_path_routes_via_host_not_path_shape() {
+        // Routing is host-first: a PyPI-shaped path under an npm
+        // host is consulted by the npm parser, which doesn't match
+        // and returns Metadata. The PyPI parser never sees it.
+        let mut h = RegistryHosts::default();
+        h.npm.push("npm.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(
+            &ps,
+            "npm.flatt.tech",
+            "/packages/aa/bb/cc/requests-2.31.0.tar.gz",
+        );
+        assert_eq!(r, ParseResult::Metadata);
+    }
+
+    #[test]
+    fn custom_pypi_files_host_pins_a_wheel() {
+        let mut h = RegistryHosts::default();
+        h.pypi_files.push("files.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(
+            &ps,
+            "files.flatt.tech",
+            "/packages/aa/bb/cc/numpy-1.26.0-cp311-cp311-macosx_11_0_arm64.whl",
+        );
+        assert_eq!(
+            r,
+            ParseResult::Pinned {
+                ecosystem: Ecosystem::Pypi,
+                name: "numpy".into(),
+                version: "1.26.0".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn custom_nuget_host_pins_a_nupkg() {
+        let mut h = RegistryHosts::default();
+        h.nuget.push("nuget.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(
+            &ps,
+            "nuget.flatt.tech",
+            "/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+        );
+        assert_eq!(
+            r,
+            ParseResult::Pinned {
+                ecosystem: Ecosystem::Nuget,
+                name: "newtonsoft.json".into(),
+                version: "13.0.1".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn custom_crates_host_pins_a_download() {
+        let mut h = RegistryHosts::default();
+        h.crates.push("crates.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(
+            &ps,
+            "crates.flatt.tech",
+            "/api/v1/crates/serde/1.0.0/download",
+        );
+        assert_eq!(
+            r,
+            ParseResult::Pinned {
+                ecosystem: Ecosystem::Crates,
+                name: "serde".into(),
+                version: "1.0.0".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn host_match_is_case_insensitive_for_custom_hosts() {
+        let mut h = RegistryHosts::default();
+        h.npm.push("npm.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        let r = parse_for_host(&ps, "NPM.FLATT.TECH", "/lodash/-/lodash-4.17.21.tgz");
+        assert!(matches!(r, ParseResult::Pinned { .. }));
+    }
+
+    #[test]
+    fn unrelated_host_is_unknown_even_with_known_ecosystem_path() {
+        let ps = parsers_from_hosts(&RegistryHosts::default());
+        let r = parse_for_host(&ps, "evil.example", "/lodash/-/lodash-4.17.21.tgz");
+        assert_eq!(r, ParseResult::Unknown);
+    }
+
+    #[test]
+    fn full_disable_yields_unknown_for_every_canonical_host() {
+        let h = RegistryHosts {
+            npm: vec![],
+            pypi_index: vec![],
+            pypi_files: vec![],
+            crates: vec![],
+            crates_sparse: vec![],
+            nuget: vec![],
+        };
+        let ps = parsers_from_hosts(&h);
+        for host in [
+            "registry.npmjs.org",
+            "pypi.org",
+            "files.pythonhosted.org",
+            "crates.io",
+            "index.crates.io",
+            "api.nuget.org",
+        ] {
+            assert_eq!(
+                parse_for_host(&ps, host, "/"),
+                ParseResult::Unknown,
+                "{host} should be Unknown when all hosts are disabled",
+            );
+        }
     }
 }

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -23,8 +23,11 @@ use sakimori_core::installs::{ExecutionMode, InstallEvent, InstallLogger};
 use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
 use crate::nuget_flatcontainer_client::NugetFlatContainerClient;
-use crate::parser::{ParseResult, RegistryParser, default_parsers, parse_for_host};
+#[cfg(test)]
+use crate::parser::default_parsers;
+use crate::parser::{ParseResult, RegistryParser, parse_for_host, parsers_from_hosts};
 use crate::pypi_simple_client::PypiSimpleClient;
+use crate::registries::RegistryHosts;
 use crate::rewrite::rewrite_crates_index_jsonl;
 use crate::rewrite_npm::{NpmRewriteOptions, rewrite_npm_packument_with};
 use crate::rewrite_nuget::{rewrite_nuget_flatcontainer, rewrite_nuget_registration};
@@ -131,6 +134,14 @@ pub struct ProxyConfig {
     /// CLI default is `~/.sakimori/strip-cache/` when strip policy
     /// is active; pass `--lifecycle-no-strip-cache` to disable.
     pub lifecycle_strip_cache_dir: Option<std::path::PathBuf>,
+    /// Per-ecosystem registry hosts. Defaults cover the canonical
+    /// public registries (`registry.npmjs.org`, `pypi.org` +
+    /// `files.pythonhosted.org`, `crates.io` + `index.crates.io`,
+    /// `api.nuget.org`). Append additional hosts (Verdaccio, GitHub
+    /// Packages, Artifactory, Takumi Guard, …) here so the same
+    /// rewriters / lifecycle gate fire on internal-mirror traffic.
+    /// See [`RegistryHosts`].
+    pub registries: RegistryHosts,
 }
 
 impl ProxyConfig {
@@ -159,6 +170,7 @@ impl ProxyConfig {
             lifecycle_strip_on_failure: crate::lifecycle::StripFailurePolicy::Block,
             lifecycle_strip_limits: crate::lifecycle::StripLimits::default(),
             lifecycle_strip_cache_dir: None,
+            registries: RegistryHosts::default(),
         })
     }
 }
@@ -313,8 +325,10 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
             cfg.user_agent.clone(),
         ))
     });
+    let registries = Arc::new(cfg.registries.clone());
     let handler = SakimoriHandler {
-        parsers: Arc::new(default_parsers()),
+        parsers: Arc::new(parsers_from_hosts(&cfg.registries)),
+        registries: registries.clone(),
         decider,
         last_host: None,
         last_path: None,
@@ -370,7 +384,9 @@ fn rcgen_cert_from_pem(pem: &[u8]) -> Result<rcgen::Certificate> {
 /// Only MITM traffic bound for hosts we care about. Everything else
 /// gets passed through as an opaque TCP tunnel.
 fn should_intercept(host: &str, parsers: &[Box<dyn RegistryParser>]) -> bool {
-    parsers.iter().any(|p| host.eq_ignore_ascii_case(p.host()))
+    parsers
+        .iter()
+        .any(|p| p.hosts().iter().any(|h| host.eq_ignore_ascii_case(h)))
 }
 
 /// Decide whether an incoming request should be denied by the
@@ -417,6 +433,10 @@ fn egress_deny_reason(
 #[derive(Clone)]
 struct SakimoriHandler {
     parsers: Arc<Vec<Box<dyn RegistryParser>>>,
+    /// Same host configuration the parsers were built from; consulted
+    /// by `classify_response` so the rewriters fire on user-configured
+    /// internal mirrors and not only the canonical public hosts.
+    registries: Arc<RegistryHosts>,
     decider: Arc<Decider<dyn AgeOracle>>,
     /// Host of the in-flight request, captured in `handle_request` so
     /// `handle_response` knows whether to rewrite the body. hudsucker
@@ -925,8 +945,11 @@ impl HttpHandler for SakimoriHandler {
         // Decide whether and how to rewrite based on host + path. Only
         // endpoints we specifically understand get touched; everything
         // else flows through byte-for-byte.
-        let Some(target) = classify_response(self.last_host.as_deref(), self.last_path.as_deref())
-        else {
+        let Some(target) = classify_response(
+            self.last_host.as_deref(),
+            self.last_path.as_deref(),
+            &self.registries,
+        ) else {
             return res;
         };
         // 2xx only — preserve 404 / 304 / etc. as-is.
@@ -1346,16 +1369,20 @@ enum RewriteTarget {
 /// `/@scope/<pkg>`. Per-version manifests (`/<pkg>/<version>`) and
 /// tarballs (`/<pkg>/-/<tgz>`) are not packuments and would be
 /// corrupted by packument-shaped filtering.
-fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTarget> {
+fn classify_response(
+    host: Option<&str>,
+    path: Option<&str>,
+    registries: &RegistryHosts,
+) -> Option<RewriteTarget> {
     let host = host?;
     let path = path?;
-    if host.eq_ignore_ascii_case("index.crates.io") {
+    if host_in(&registries.crates_sparse, host) {
         return Some(RewriteTarget::CratesSparse);
     }
-    if host.eq_ignore_ascii_case("registry.npmjs.org") && is_npm_packument_path(path) {
+    if host_in(&registries.npm, host) && is_npm_packument_path(path) {
         return Some(RewriteTarget::NpmPackument);
     }
-    if host.eq_ignore_ascii_case("pypi.org") {
+    if host_in(&registries.pypi_index, host) {
         if is_pypi_json_api_path(path) {
             return Some(RewriteTarget::PypiJsonApi);
         }
@@ -1368,7 +1395,7 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
             return Some(RewriteTarget::PypiSimpleIndex(pkg));
         }
     }
-    if host.eq_ignore_ascii_case("api.nuget.org") {
+    if host_in(&registries.nuget, host) {
         if is_nuget_registration_path(path) {
             return Some(RewriteTarget::NugetRegistration);
         }
@@ -1377,6 +1404,10 @@ fn classify_response(host: Option<&str>, path: Option<&str>) -> Option<RewriteTa
         }
     }
     None
+}
+
+fn host_in(set: &[String], host: &str) -> bool {
+    set.iter().any(|h| host.eq_ignore_ascii_case(h))
 }
 
 /// NuGet flat-container index: `/v3-flatcontainer/<id>/index.json`.
@@ -1654,37 +1685,40 @@ mod tests {
 
     #[test]
     fn classify_response_routes_to_correct_rewriter() {
+        let r = RegistryHosts::default();
         assert_eq!(
-            classify_response(Some("index.crates.io"), Some("/anything")),
+            classify_response(Some("index.crates.io"), Some("/anything"), &r),
             Some(RewriteTarget::CratesSparse)
         );
         assert_eq!(
-            classify_response(Some("registry.npmjs.org"), Some("/lodash")),
+            classify_response(Some("registry.npmjs.org"), Some("/lodash"), &r),
             Some(RewriteTarget::NpmPackument)
         );
         // tarball path — npm but not a packument
         assert_eq!(
             classify_response(
                 Some("registry.npmjs.org"),
-                Some("/lodash/-/lodash-4.17.21.tgz")
+                Some("/lodash/-/lodash-4.17.21.tgz"),
+                &r,
             ),
             None
         );
         // PyPI endpoints
         assert_eq!(
-            classify_response(Some("pypi.org"), Some("/pypi/requests/json")),
+            classify_response(Some("pypi.org"), Some("/pypi/requests/json"), &r),
             Some(RewriteTarget::PypiJsonApi)
         );
         assert_eq!(
-            classify_response(Some("pypi.org"), Some("/simple/requests/")),
+            classify_response(Some("pypi.org"), Some("/simple/requests/"), &r),
             Some(RewriteTarget::PypiSimpleIndex("requests".into()))
         );
-        assert_eq!(classify_response(Some("pypi.org"), Some("/")), None);
+        assert_eq!(classify_response(Some("pypi.org"), Some("/"), &r), None);
         // NuGet registration.
         assert_eq!(
             classify_response(
                 Some("api.nuget.org"),
-                Some("/v3/registration5-semver1/newtonsoft.json/index.json")
+                Some("/v3/registration5-semver1/newtonsoft.json/index.json"),
+                &r,
             ),
             Some(RewriteTarget::NugetRegistration)
         );
@@ -1692,7 +1726,8 @@ mod tests {
         assert_eq!(
             classify_response(
                 Some("api.nuget.org"),
-                Some("/v3-flatcontainer/newtonsoft.json/index.json")
+                Some("/v3-flatcontainer/newtonsoft.json/index.json"),
+                &r,
             ),
             Some(RewriteTarget::NugetFlatContainerIndex(
                 "newtonsoft.json".into()
@@ -1703,16 +1738,114 @@ mod tests {
         assert_eq!(
             classify_response(
                 Some("api.nuget.org"),
-                Some("/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg")
+                Some("/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg"),
+                &r,
             ),
             None
         );
         // unrecognised host
         assert_eq!(
-            classify_response(Some("evil.example.com"), Some("/foo")),
+            classify_response(Some("evil.example.com"), Some("/foo"), &r),
             None
         );
-        assert_eq!(classify_response(None, Some("/foo")), None);
+        assert_eq!(classify_response(None, Some("/foo"), &r), None);
+    }
+
+    #[test]
+    fn classify_response_honours_custom_npm_host() {
+        let mut r = RegistryHosts::default();
+        r.npm.push("npm.flatt.tech".into());
+        assert_eq!(
+            classify_response(Some("npm.flatt.tech"), Some("/lodash"), &r),
+            Some(RewriteTarget::NpmPackument)
+        );
+        // Original canonical host still works.
+        assert_eq!(
+            classify_response(Some("registry.npmjs.org"), Some("/lodash"), &r),
+            Some(RewriteTarget::NpmPackument)
+        );
+    }
+
+    #[test]
+    fn classify_response_honours_custom_pypi_index_host() {
+        let mut r = RegistryHosts::default();
+        r.pypi_index.push("pypi.flatt.tech".into());
+        assert_eq!(
+            classify_response(Some("pypi.flatt.tech"), Some("/pypi/requests/json"), &r),
+            Some(RewriteTarget::PypiJsonApi)
+        );
+        assert_eq!(
+            classify_response(Some("pypi.flatt.tech"), Some("/simple/requests/"), &r),
+            Some(RewriteTarget::PypiSimpleIndex("requests".into()))
+        );
+    }
+
+    #[test]
+    fn classify_response_honours_custom_nuget_host() {
+        let mut r = RegistryHosts::default();
+        r.nuget.push("nuget.flatt.tech".into());
+        assert_eq!(
+            classify_response(
+                Some("nuget.flatt.tech"),
+                Some("/v3/registration5-semver1/newtonsoft.json/index.json"),
+                &r,
+            ),
+            Some(RewriteTarget::NugetRegistration)
+        );
+        assert_eq!(
+            classify_response(
+                Some("nuget.flatt.tech"),
+                Some("/v3-flatcontainer/newtonsoft.json/index.json"),
+                &r,
+            ),
+            Some(RewriteTarget::NugetFlatContainerIndex(
+                "newtonsoft.json".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn classify_response_honours_custom_crates_sparse_host() {
+        let mut r = RegistryHosts::default();
+        r.crates_sparse.push("crates.flatt.tech".into());
+        assert_eq!(
+            classify_response(Some("crates.flatt.tech"), Some("/1/s/serde"), &r),
+            Some(RewriteTarget::CratesSparse)
+        );
+    }
+
+    #[test]
+    fn classify_response_with_empty_ecosystem_yields_none() {
+        // Disabling an ecosystem (empty host list) must also prevent
+        // its rewriter from firing on the canonical host.
+        let r = RegistryHosts {
+            npm: vec![],
+            ..RegistryHosts::default()
+        };
+        assert_eq!(
+            classify_response(Some("registry.npmjs.org"), Some("/lodash"), &r),
+            None
+        );
+    }
+
+    #[test]
+    fn should_intercept_picks_up_custom_hosts() {
+        let mut h = RegistryHosts::default();
+        h.npm.push("npm.flatt.tech".into());
+        h.pypi_index.push("pypi.flatt.tech".into());
+        h.nuget.push("nuget.flatt.tech".into());
+        let ps = parsers_from_hosts(&h);
+        for host in [
+            "npm.flatt.tech",
+            "NPM.FLATT.TECH",
+            "pypi.flatt.tech",
+            "nuget.flatt.tech",
+        ] {
+            assert!(should_intercept(host, &ps), "should intercept {host}");
+        }
+        for host in ["evil.example", "registry.npmjs.com"] {
+            assert!(!should_intercept(host, &ps), "should NOT intercept {host}");
+        }
     }
 
     #[test]

--- a/crates/sakimori-proxy/src/registries.rs
+++ b/crates/sakimori-proxy/src/registries.rs
@@ -1,0 +1,398 @@
+//! Per-ecosystem registry-host configuration.
+//!
+//! By default the proxy MITMs the canonical public hosts
+//! (`registry.npmjs.org`, `pypi.org`, `files.pythonhosted.org`,
+//! `api.nuget.org`, `crates.io`, `index.crates.io`). Teams that route
+//! installs through an internal mirror (Verdaccio, GitHub Packages,
+//! Artifactory, Takumi Guard, etc.) need to teach the proxy about
+//! those hosts so the same rewriters / lifecycle gate fire. This
+//! struct is the single source of truth for that mapping.
+//!
+//! Resolution order for the final list of hosts the proxy watches:
+//! built-in defaults → optional TOML config file → CLI flags. Each
+//! step *appends* (with case-insensitive dedupe). To exclude a
+//! default upstream entirely, layer in a `network_allow` list — the
+//! egress filter then 403s every host that isn't on it.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Per-ecosystem host lists. Empty vectors mean "no hosts for this
+/// ecosystem"; the proxy simply skips that parser. The fields are
+/// `pub` so the caller can append before constructing parsers.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct RegistryHosts {
+    /// npm packument + tarball host(s). Default: `registry.npmjs.org`.
+    pub npm: Vec<String>,
+    /// PyPI metadata host(s) (Warehouse JSON, PEP 503 / 691 Simple
+    /// index). Default: `pypi.org`.
+    pub pypi_index: Vec<String>,
+    /// PyPI artefact host(s) (sdist / wheel downloads). Default:
+    /// `files.pythonhosted.org`.
+    pub pypi_files: Vec<String>,
+    /// crates.io API host(s) — the `api/v1/crates/<n>/<v>/download`
+    /// endpoint. Default: `crates.io`.
+    pub crates: Vec<String>,
+    /// crates.io sparse-index host(s). Default: `index.crates.io`.
+    pub crates_sparse: Vec<String>,
+    /// NuGet v3 host(s) (registration + flat-container endpoints).
+    /// Default: `api.nuget.org`.
+    pub nuget: Vec<String>,
+}
+
+impl Default for RegistryHosts {
+    fn default() -> Self {
+        Self {
+            npm: vec!["registry.npmjs.org".into()],
+            pypi_index: vec!["pypi.org".into()],
+            pypi_files: vec!["files.pythonhosted.org".into()],
+            crates: vec!["crates.io".into()],
+            crates_sparse: vec!["index.crates.io".into()],
+            nuget: vec!["api.nuget.org".into()],
+        }
+    }
+}
+
+/// Wrapper matching the on-disk TOML layout:
+///
+/// ```toml
+/// [registries]
+/// npm = ["registry.npmjs.org", "npm.flatt.tech"]
+/// pypi_index = ["pypi.org"]
+/// pypi_files = ["files.pythonhosted.org"]
+/// crates = ["crates.io"]
+/// crates_sparse = ["index.crates.io"]
+/// nuget = ["api.nuget.org"]
+/// ```
+///
+/// Keeping the `[registries]` wrapper means future versions can grow
+/// other sections in the same file without a migration.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct ConfigFile {
+    #[serde(default)]
+    registries: RegistryHosts,
+}
+
+impl RegistryHosts {
+    /// Load a `RegistryHosts` from a TOML file. The file's contents
+    /// fully populate the struct; merge with defaults / CLI happens
+    /// in the caller (use [`Self::extend_from`] or [`Self::merge`]).
+    pub fn load_toml(path: &Path) -> anyhow::Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading registries config {}: {e}", path.display()))?;
+        let cfg: ConfigFile = toml::from_str(&text)
+            .map_err(|e| anyhow::anyhow!("parsing registries config {}: {e}", path.display()))?;
+        Ok(cfg.registries)
+    }
+
+    /// Append every host in `other` into `self`, normalising and
+    /// deduping case-insensitively. Order is preserved (first
+    /// occurrence wins).
+    pub fn extend_from(&mut self, other: &Self) {
+        extend(&mut self.npm, &other.npm);
+        extend(&mut self.pypi_index, &other.pypi_index);
+        extend(&mut self.pypi_files, &other.pypi_files);
+        extend(&mut self.crates, &other.crates);
+        extend(&mut self.crates_sparse, &other.crates_sparse);
+        extend(&mut self.nuget, &other.nuget);
+    }
+
+    /// Convenience: start from `Default::default()`, then layer in
+    /// `file` (if any), then `extra`. Each step deduplicates against
+    /// what's already there.
+    pub fn merge(file: Option<Self>, extra: Self) -> Self {
+        let mut out = Self::default();
+        if let Some(f) = file {
+            out.extend_from(&f);
+        }
+        out.extend_from(&extra);
+        out
+    }
+
+    /// Normalise a single user-supplied entry to a bare hostname.
+    /// Accepts:
+    /// - `registry.npmjs.org`             — bare host, passed through
+    ///   (lowercased)
+    /// - `https://npm.flatt.tech/`        — URL form, host extracted
+    /// - `https://npm.flatt.tech:8443/x`  — port is stripped (the
+    ///   proxy matches by hostname; CONNECT carries the port
+    ///   separately)
+    ///
+    /// Rejects empty input. Anything else (e.g. embedded `*`) is
+    /// considered a bare host and passed through lowercased — the
+    /// validation cost of stricter parsing isn't worth it; bad hosts
+    /// simply won't match incoming traffic.
+    pub fn normalize_host(input: &str) -> anyhow::Result<String> {
+        let input = input.trim();
+        if input.is_empty() {
+            anyhow::bail!("empty registry host");
+        }
+        // Strip an optional scheme + path.
+        let rest = if let Some(after) = input.split_once("://").map(|(_, r)| r) {
+            after
+        } else {
+            input
+        };
+        // Drop path / query.
+        let host_port = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+        // Drop port.
+        let host = host_port.split(':').next().unwrap_or(host_port);
+        if host.is_empty() {
+            anyhow::bail!("could not extract host from `{input}`");
+        }
+        Ok(host.to_ascii_lowercase())
+    }
+}
+
+fn extend(dst: &mut Vec<String>, src: &[String]) {
+    for h in src {
+        let lowered = h.to_ascii_lowercase();
+        if !dst.iter().any(|x| x.eq_ignore_ascii_case(&lowered)) {
+            dst.push(lowered);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_cover_canonical_public_hosts() {
+        let d = RegistryHosts::default();
+        assert!(d.npm.iter().any(|h| h == "registry.npmjs.org"));
+        assert!(d.pypi_index.iter().any(|h| h == "pypi.org"));
+        assert!(d.pypi_files.iter().any(|h| h == "files.pythonhosted.org"));
+        assert!(d.crates.iter().any(|h| h == "crates.io"));
+        assert!(d.crates_sparse.iter().any(|h| h == "index.crates.io"));
+        assert!(d.nuget.iter().any(|h| h == "api.nuget.org"));
+    }
+
+    #[test]
+    fn extend_dedupes_case_insensitively() {
+        let mut a = RegistryHosts::default();
+        let b = RegistryHosts {
+            npm: vec!["REGISTRY.NPMJS.ORG".into(), "npm.flatt.tech".into()],
+            ..RegistryHosts::default()
+        };
+        a.extend_from(&b);
+        // The default `registry.npmjs.org` should still be a single
+        // entry (case-insensitive dedupe); flatt should be appended.
+        let count = a
+            .npm
+            .iter()
+            .filter(|h| h.eq_ignore_ascii_case("registry.npmjs.org"))
+            .count();
+        assert_eq!(count, 1, "duplicate canonical host: {:?}", a.npm);
+        assert!(a.npm.iter().any(|h| h == "npm.flatt.tech"));
+    }
+
+    #[test]
+    fn merge_layers_file_then_cli() {
+        let file = RegistryHosts {
+            npm: vec!["npm.flatt.tech".into()],
+            ..RegistryHosts::default()
+        };
+        let cli = RegistryHosts {
+            npm: vec!["npm.internal".into()],
+            ..RegistryHosts::default()
+        };
+        let out = RegistryHosts::merge(Some(file), cli);
+        assert!(out.npm.iter().any(|h| h == "registry.npmjs.org"));
+        assert!(out.npm.iter().any(|h| h == "npm.flatt.tech"));
+        assert!(out.npm.iter().any(|h| h == "npm.internal"));
+    }
+
+    #[test]
+    fn normalize_host_accepts_bare_host_and_url() {
+        assert_eq!(
+            RegistryHosts::normalize_host("registry.npmjs.org").unwrap(),
+            "registry.npmjs.org"
+        );
+        assert_eq!(
+            RegistryHosts::normalize_host("https://npm.flatt.tech/").unwrap(),
+            "npm.flatt.tech"
+        );
+        assert_eq!(
+            RegistryHosts::normalize_host("https://npm.flatt.tech:8443/path").unwrap(),
+            "npm.flatt.tech"
+        );
+        assert_eq!(
+            RegistryHosts::normalize_host("NPM.Flatt.Tech").unwrap(),
+            "npm.flatt.tech"
+        );
+        assert!(RegistryHosts::normalize_host("").is_err());
+        assert!(RegistryHosts::normalize_host("   ").is_err());
+    }
+
+    fn tmp_path(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "sakimori-registries-{tag}-{}-{nanos}.toml",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn load_toml_parses_full_file() {
+        let p = tmp_path("full");
+        std::fs::write(
+            &p,
+            r#"
+[registries]
+npm = ["registry.npmjs.org", "npm.flatt.tech"]
+pypi_index = ["pypi.org"]
+pypi_files = ["files.pythonhosted.org"]
+crates = ["crates.io"]
+crates_sparse = ["index.crates.io"]
+nuget = ["api.nuget.org"]
+"#,
+        )
+        .unwrap();
+        let cfg = RegistryHosts::load_toml(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert!(cfg.npm.iter().any(|h| h == "npm.flatt.tech"));
+        assert_eq!(cfg.pypi_index, vec!["pypi.org".to_string()]);
+    }
+
+    #[test]
+    fn load_toml_accepts_partial_file() {
+        let p = tmp_path("partial");
+        std::fs::write(
+            &p,
+            r#"
+[registries]
+npm = ["npm.flatt.tech"]
+"#,
+        )
+        .unwrap();
+        let cfg = RegistryHosts::load_toml(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert_eq!(cfg.npm, vec!["npm.flatt.tech".to_string()]);
+        // Unset sections fall back to RegistryHosts::default() via
+        // #[serde(default)] on each field — same canonical hosts.
+        assert!(cfg.pypi_index.iter().any(|h| h == "pypi.org"));
+    }
+
+    #[test]
+    fn extend_preserves_first_occurrence_order() {
+        let mut a = RegistryHosts {
+            npm: vec!["a.example".into()],
+            ..RegistryHosts::default()
+        };
+        let b = RegistryHosts {
+            npm: vec!["A.EXAMPLE".into(), "b.example".into()],
+            ..RegistryHosts::default()
+        };
+        a.extend_from(&b);
+        assert_eq!(a.npm, vec!["a.example".to_string(), "b.example".into()]);
+    }
+
+    #[test]
+    fn merge_layers_in_order_defaults_then_file_then_cli() {
+        let file = RegistryHosts {
+            npm: vec!["mid.example".into()],
+            ..RegistryHosts::default()
+        };
+        let cli = RegistryHosts {
+            npm: vec!["late.example".into()],
+            ..RegistryHosts::default()
+        };
+        let out = RegistryHosts::merge(Some(file), cli);
+        let positions: Vec<usize> = ["registry.npmjs.org", "mid.example", "late.example"]
+            .iter()
+            .map(|target| out.npm.iter().position(|h| h == target).expect("present"))
+            .collect();
+        assert!(
+            positions.windows(2).all(|w| w[0] < w[1]),
+            "expected defaults < file < cli, got {positions:?} from {:?}",
+            out.npm
+        );
+    }
+
+    #[test]
+    fn merge_with_no_file_yields_defaults_plus_cli() {
+        let cli = RegistryHosts {
+            npm: vec!["only-cli.example".into()],
+            ..RegistryHosts::default()
+        };
+        let out = RegistryHosts::merge(None, cli);
+        assert!(out.npm.iter().any(|h| h == "registry.npmjs.org"));
+        assert!(out.npm.iter().any(|h| h == "only-cli.example"));
+    }
+
+    #[test]
+    fn normalize_host_rejects_inputs_that_become_empty() {
+        assert!(RegistryHosts::normalize_host("https://").is_err());
+        assert!(RegistryHosts::normalize_host(":443").is_err());
+    }
+
+    #[test]
+    fn normalize_host_passes_through_weird_but_nonempty_input() {
+        // We deliberately don't validate hostname syntax — a bogus
+        // entry simply never matches incoming traffic, which is
+        // cheaper than maintaining a parser for every edge of RFC
+        // 1123 / IDN.
+        let h = RegistryHosts::normalize_host("not_a_valid_host!").unwrap();
+        assert_eq!(h, "not_a_valid_host!");
+    }
+
+    #[test]
+    fn load_toml_rejects_unknown_fields() {
+        // `deny_unknown_fields` is the early-warning system for
+        // typos like `npmjs = [...]` (should be `npm`).
+        let p = tmp_path("unknown");
+        std::fs::write(
+            &p,
+            r#"
+[registries]
+npmjs = ["wrong-key.example"]
+"#,
+        )
+        .unwrap();
+        let err = RegistryHosts::load_toml(&p).unwrap_err();
+        let _ = std::fs::remove_file(&p);
+        let msg = format!("{err:#}");
+        assert!(msg.contains("npmjs"), "{msg}");
+    }
+
+    #[test]
+    fn load_toml_reports_missing_file_with_path() {
+        let missing = std::env::temp_dir().join(format!(
+            "sakimori-registries-missing-{}.toml",
+            std::process::id()
+        ));
+        let err = RegistryHosts::load_toml(&missing).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains(&missing.display().to_string()), "{msg}");
+    }
+
+    #[test]
+    fn load_toml_empty_file_yields_defaults() {
+        let p = tmp_path("empty");
+        std::fs::write(&p, "").unwrap();
+        let cfg = RegistryHosts::load_toml(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert_eq!(cfg, RegistryHosts::default());
+    }
+
+    #[test]
+    fn load_toml_top_level_table_missing_is_defaults() {
+        // The wrapping `[registries]` table itself can be omitted —
+        // useful when a host might later grow other sections in the
+        // same file. With no `[registries]` table we still want the
+        // canonical defaults back.
+        let p = tmp_path("no-section");
+        std::fs::write(&p, "# just a comment\n").unwrap();
+        let cfg = RegistryHosts::load_toml(&p).unwrap();
+        let _ = std::fs::remove_file(&p);
+        assert_eq!(cfg, RegistryHosts::default());
+    }
+}

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -22,6 +22,39 @@ fn ca_files_for(dir: Option<PathBuf>) -> anyhow::Result<sakimori_proxy::ca::CaFi
 /// plus an optional file. Returns `None` (= "feature off") when no
 /// patterns came from either source — `Some(empty)` would also work
 /// but `None` lets the proxy skip the per-request check entirely.
+/// Normalise a CLI-provided list of registry hosts (URL or bare
+/// host) into bare lowercased hostnames. Bad inputs error out with
+/// `--flag-name` context so the user sees which flag was rejected.
+fn normalize_hosts(flag: &str, raw: &[String]) -> Result<Vec<String>> {
+    raw.iter()
+        .map(|s| {
+            sakimori_proxy::RegistryHosts::normalize_host(s)
+                .map_err(|e| anyhow::anyhow!("{flag} `{s}`: {e}"))
+        })
+        .collect()
+}
+
+/// Build the `RegistryHosts` for `proxy start` from the optional
+/// config file plus the per-ecosystem CLI flags. Built-in defaults
+/// (`registry.npmjs.org` etc.) are always included; the file +
+/// flags append + dedupe on top.
+fn build_registries(args: &ProxyStartArgs) -> Result<sakimori_proxy::RegistryHosts> {
+    let file = args
+        .registries_config
+        .as_deref()
+        .map(sakimori_proxy::RegistryHosts::load_toml)
+        .transpose()?;
+    let cli = sakimori_proxy::RegistryHosts {
+        npm: normalize_hosts("--npm-registry", &args.npm_registry)?,
+        pypi_index: normalize_hosts("--pypi-registry", &args.pypi_registry)?,
+        pypi_files: normalize_hosts("--pypi-files-host", &args.pypi_files_host)?,
+        crates: normalize_hosts("--cargo-registry-host", &args.cargo_registry_host)?,
+        crates_sparse: normalize_hosts("--cargo-sparse-host", &args.cargo_sparse_host)?,
+        nuget: normalize_hosts("--nuget-registry", &args.nuget_registry)?,
+    };
+    Ok(sakimori_proxy::RegistryHosts::merge(file, cli))
+}
+
 fn build_network_allow(
     flags: &[String],
     file: &Option<PathBuf>,
@@ -771,6 +804,52 @@ pub struct ProxyStartArgs {
     /// only) keeps working.
     #[arg(long = "lifecycle-no-strip-cache")]
     pub lifecycle_no_strip_cache: bool,
+    /// Additional npm registry host to watch (repeatable). The
+    /// canonical `registry.npmjs.org` is always watched too; this
+    /// flag teaches the proxy about internal mirrors / replacement
+    /// registries (Verdaccio, GitHub Packages, Artifactory, Takumi
+    /// Guard, etc.) so the same packument rewriter + lifecycle gate
+    /// fire on their traffic. Accepts a bare host
+    /// (`npm.flatt.tech`) or a URL whose host is extracted
+    /// (`https://npm.flatt.tech/`).
+    #[arg(long = "npm-registry", value_name = "HOST")]
+    pub npm_registry: Vec<String>,
+    /// Additional PyPI **metadata** host to watch (repeatable). The
+    /// canonical `pypi.org` is always watched.
+    #[arg(long = "pypi-registry", value_name = "HOST")]
+    pub pypi_registry: Vec<String>,
+    /// Additional PyPI **artefact** host to watch (repeatable). The
+    /// canonical `files.pythonhosted.org` is always watched.
+    #[arg(long = "pypi-files-host", value_name = "HOST")]
+    pub pypi_files_host: Vec<String>,
+    /// Additional crates.io API host to watch (repeatable). The
+    /// canonical `crates.io` is always watched.
+    #[arg(long = "cargo-registry-host", value_name = "HOST")]
+    pub cargo_registry_host: Vec<String>,
+    /// Additional crates.io sparse-index host to watch (repeatable).
+    /// The canonical `index.crates.io` is always watched.
+    #[arg(long = "cargo-sparse-host", value_name = "HOST")]
+    pub cargo_sparse_host: Vec<String>,
+    /// Additional NuGet v3 host to watch (repeatable). The canonical
+    /// `api.nuget.org` is always watched.
+    #[arg(long = "nuget-registry", value_name = "HOST")]
+    pub nuget_registry: Vec<String>,
+    /// TOML file describing the same per-ecosystem host lists.
+    /// Layered after the built-in defaults and before the `--*-
+    /// registry` CLI flags; all three sources are appended + deduped
+    /// case-insensitively. Schema:
+    ///
+    /// ```toml
+    /// [registries]
+    /// npm = ["registry.npmjs.org", "npm.flatt.tech"]
+    /// pypi_index = ["pypi.org"]
+    /// pypi_files = ["files.pythonhosted.org"]
+    /// crates = ["crates.io"]
+    /// crates_sparse = ["index.crates.io"]
+    /// nuget = ["api.nuget.org"]
+    /// ```
+    #[arg(long = "registries-config", value_name = "FILE")]
+    pub registries_config: Option<PathBuf>,
 }
 
 fn parse_kv(s: &str) -> std::result::Result<(String, String), String> {
@@ -1053,7 +1132,8 @@ pub async fn run(cli: Cli) -> Result<()> {
             cmd: ProxyCommand::Start(args),
         } => {
             let min_age = parse_simple_duration(&args.min_age)?;
-            let ca_files = ca_files_for(args.config_dir)?;
+            let registries = build_registries(&args)?;
+            let ca_files = ca_files_for(args.config_dir.clone())?;
             let network_allow = build_network_allow(&args.network_allow, &args.network_allow_file)?;
             let lifecycle_policy = args
                 .lifecycle_policy
@@ -1105,6 +1185,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 lifecycle_strip_on_failure,
                 lifecycle_strip_limits: sakimori_proxy::lifecycle::StripLimits::default(),
                 lifecycle_strip_cache_dir,
+                registries,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())
@@ -2351,4 +2432,135 @@ fn run_doctor(args: DoctorArgs) -> Result<()> {
     let results = crate::doctor::run_checks(&inputs);
     print!("{}", crate::doctor::render_report(&results));
     std::process::exit(crate::doctor::exit_code(&results));
+}
+
+#[cfg(test)]
+mod proxy_start_registries_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse_start(args: &[&str]) -> ProxyStartArgs {
+        let mut argv = vec!["sakimori", "proxy", "start"];
+        argv.extend_from_slice(args);
+        let cli = Cli::parse_from(argv);
+        match cli.command {
+            Command::Proxy {
+                cmd: ProxyCommand::Start(a),
+            } => *a,
+            other => panic!("expected proxy start, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn registries_defaults_apply_with_no_flags() {
+        let args = parse_start(&[]);
+        let r = build_registries(&args).unwrap();
+        assert_eq!(r, sakimori_proxy::RegistryHosts::default());
+    }
+
+    #[test]
+    fn npm_registry_flag_appends_one_host() {
+        let args = parse_start(&["--npm-registry", "https://npm.flatt.tech/"]);
+        let r = build_registries(&args).unwrap();
+        assert!(r.npm.iter().any(|h| h == "npm.flatt.tech"));
+        // Default kept too.
+        assert!(r.npm.iter().any(|h| h == "registry.npmjs.org"));
+    }
+
+    #[test]
+    fn npm_registry_flag_is_repeatable_and_normalises_each_value() {
+        let args = parse_start(&[
+            "--npm-registry",
+            "NPM.A.EXAMPLE",
+            "--npm-registry",
+            "https://npm.b.example:8443/path",
+        ]);
+        let r = build_registries(&args).unwrap();
+        assert!(r.npm.iter().any(|h| h == "npm.a.example"));
+        assert!(r.npm.iter().any(|h| h == "npm.b.example"));
+    }
+
+    #[test]
+    fn every_ecosystem_flag_targets_the_right_field() {
+        let args = parse_start(&[
+            "--npm-registry",
+            "npm.x",
+            "--pypi-registry",
+            "pypi.x",
+            "--pypi-files-host",
+            "files.x",
+            "--cargo-registry-host",
+            "crates.x",
+            "--cargo-sparse-host",
+            "sparse.x",
+            "--nuget-registry",
+            "nuget.x",
+        ]);
+        let r = build_registries(&args).unwrap();
+        assert!(r.npm.iter().any(|h| h == "npm.x"));
+        assert!(r.pypi_index.iter().any(|h| h == "pypi.x"));
+        assert!(r.pypi_files.iter().any(|h| h == "files.x"));
+        assert!(r.crates.iter().any(|h| h == "crates.x"));
+        assert!(r.crates_sparse.iter().any(|h| h == "sparse.x"));
+        assert!(r.nuget.iter().any(|h| h == "nuget.x"));
+    }
+
+    #[test]
+    fn registries_config_file_merges_before_cli_flags() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!(
+            "sakimori-cli-registries-{}-{nanos}.toml",
+            std::process::id()
+        ));
+        std::fs::write(
+            &p,
+            r#"
+[registries]
+npm = ["npm.from-file"]
+"#,
+        )
+        .unwrap();
+
+        let args = parse_start(&[
+            "--registries-config",
+            p.to_str().unwrap(),
+            "--npm-registry",
+            "npm.from-cli",
+        ]);
+        let r = build_registries(&args).unwrap();
+        let _ = std::fs::remove_file(&p);
+
+        let pos_default = r
+            .npm
+            .iter()
+            .position(|h| h == "registry.npmjs.org")
+            .expect("default present");
+        let pos_file = r
+            .npm
+            .iter()
+            .position(|h| h == "npm.from-file")
+            .expect("file present");
+        let pos_cli = r
+            .npm
+            .iter()
+            .position(|h| h == "npm.from-cli")
+            .expect("cli present");
+        assert!(
+            pos_default < pos_file && pos_file < pos_cli,
+            "want defaults < file < cli, got {pos_default} < {pos_file} < {pos_cli} from {:?}",
+            r.npm
+        );
+    }
+
+    #[test]
+    fn invalid_registry_url_is_reported_with_flag_name() {
+        let args = parse_start(&["--npm-registry", ""]);
+        let err = build_registries(&args).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("--npm-registry"), "{msg}");
+    }
 }


### PR DESCRIPTION
## Summary

- Until now the proxy's rewriters + lifecycle gate dispatched off a hardcoded set of canonical public hosts (`registry.npmjs.org`, `pypi.org`, `files.pythonhosted.org`, `api.nuget.org`, `crates.io`, `index.crates.io`). Traffic to internal mirrors / replacement registries — Verdaccio, GitHub Packages, Artifactory, **Takumi Guard**, JFrog, Nexus, etc. — passed through opaquely, so none of the release-age / silent fallback / lifecycle-script defences fired on those installs.
- Introduce `sakimori-proxy::RegistryHosts` as the single source of truth for per-ecosystem host membership. Parsers carry a `Vec<String>` of hosts (trait method: `hosts() -> &[String]`); `ProxyConfig.registries` is plumbed through `SakimoriHandler`; `classify_response` consults the same struct so the npm packument / PyPI Warehouse+Simple / NuGet registration+flat-container / crates sparse-index rewriters all fire on every configured host of the right ecosystem.
- Configuration sources are layered: built-in defaults → optional TOML file (`--registries-config <FILE>`) → repeatable CLI flags (`--npm-registry`, `--pypi-registry`, `--pypi-files-host`, `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry`). Each step appends + dedupes case-insensitively; bare hosts and URLs (`https://npm.flatt.tech:8443/`) are both accepted and normalised to the bare hostname.

### TOML schema

```toml
[registries]
npm           = [\"registry.npmjs.org\", \"npm.flatt.tech\"]
pypi_index    = [\"pypi.org\"]
pypi_files    = [\"files.pythonhosted.org\"]
crates        = [\"crates.io\"]
crates_sparse = [\"index.crates.io\"]
nuget         = [\"api.nuget.org\"]
```

### CLAUDE.md

New \"Custom / internal registries\" section documents the schema, the resolution order, and the explicit non-goals (URL-path-shape rewriting for Artifactory-prefix repos remains a follow-up; `dist.tarball` URLs in the packument are still passed through byte-for-byte).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\` — all green (sakimori-proxy 250 / sakimori bin 67 / sakimori-core 258)
- New tests (+21):
  - \`registries::tests\` — defaults, dedupe, ordered merge, normalize_host edges, deny_unknown_fields, empty/partial TOML, missing-file error format
  - \`parser::tests\` — custom host per ecosystem (npm/pypi-files/nuget/crates), case-insensitive routing, host-first dispatch (PyPI-shaped path under an npm host stays npm/Metadata), full-disable yields Unknown for every canonical host
  - \`proxy::tests\` — \`classify_response\` on custom hosts for every ecosystem, empty-list disables canonical, \`should_intercept\` picks up custom hosts
  - \`cli::proxy_start_registries_tests\` — flag wiring per ecosystem, URL→host normalisation, file-then-CLI merge order, error reporting names the offending flag