### PR TITLE
test: proptest invariants + cargo-fuzz harnesses for proxy parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +661,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -859,7 +886,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -880,7 +907,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.6",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -948,7 +975,7 @@ dependencies = [
  "hyper-tungstenite",
  "hyper-util",
  "moka",
- "rand",
+ "rand 0.8.6",
  "rcgen",
  "thiserror 1.0.69",
  "time",
@@ -1703,6 +1730,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,8 +1782,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1741,7 +1803,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1751,6 +1823,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1915,6 +2005,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +2068,7 @@ dependencies = [
  "chrono",
  "log",
  "notify",
+ "proptest",
  "sakimori-common",
  "serde",
  "serde_json",
@@ -1988,6 +2091,7 @@ dependencies = [
  "http-body-util",
  "hudsucker",
  "log",
+ "proptest",
  "rcgen",
  "rustls 0.23.40",
  "sakimori-core",
@@ -2226,6 +2330,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2527,7 +2644,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
  "sha1",
@@ -2541,6 +2658,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -2635,6 +2758,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,14 @@ members = [
 ]
 # NOTE: crates/sakimori-ebpf is built separately with a bpf target via xtask.
 # crates/sakimori-win is Windows-only; has its own workspace.
-exclude = ["crates/sakimori-ebpf", "crates/sakimori-win"]
+exclude = [
+    "crates/sakimori-ebpf",
+    "crates/sakimori-win",
+    # libFuzzer harnesses; require nightly and pull libfuzzer-sys.
+    # Built via `cargo +nightly fuzz run <target>` from inside
+    # `crates/sakimori-proxy/fuzz/`. See that crate's README.
+    "crates/sakimori-proxy/fuzz",
+]
 resolver = "2"
 
 [workspace.package]
@@ -41,3 +48,9 @@ uuid = { version = "1", features = ["v4"] }
 nix = { version = "0.29", features = ["sched", "process", "user", "fs"] }
 bytes = "1"
 futures = "0.3"
+
+# Dev-only: property-based testing. Used inline in `#[cfg(test)] mod`
+# blocks across the workspace to harden parsers / rewriters / matchers
+# against adversarial inputs. Kept on the stable proptest 1.x line so
+# `cargo test` works without nightly.
+proptest = "1"

--- a/crates/sakimori-core/Cargo.toml
+++ b/crates/sakimori-core/Cargo.toml
@@ -22,3 +22,6 @@ notify = { workspace = true }
 sha2 = "0.10"
 base64 = "0.22"
 sakimori-common = { path = "../sakimori-common", features = ["user"] }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/sakimori-core/src/codeowners.rs
+++ b/crates/sakimori-core/src/codeowners.rs
@@ -509,4 +509,78 @@ mod tests {
         assert!(f.rules.is_empty());
         std::fs::remove_dir_all(&tmp).ok();
     }
+
+    // --- proptest: invariants on the parser + matcher -------------------
+
+    use proptest::prelude::*;
+
+    fn path_segment() -> impl Strategy<Value = String> {
+        "[a-z][a-z0-9_.-]{0,8}"
+    }
+
+    fn repo_path() -> impl Strategy<Value = String> {
+        proptest::collection::vec(path_segment(), 1..6).prop_map(|segs| segs.join("/"))
+    }
+
+    proptest! {
+        /// `parse` must never panic on arbitrary input. Garbage lines
+        /// are dropped — the parser is explicitly tolerant.
+        #[test]
+        fn parse_never_panics(text in ".{0,512}") {
+            let _ = parse(&text);
+        }
+
+        /// `pattern_matches` must never panic on arbitrary inputs.
+        /// (It's called from the audit path which sees both
+        /// user-authored patterns and real paths.)
+        #[test]
+        fn pattern_matches_never_panics(
+            pat in ".{0,64}",
+            path in ".{0,64}",
+        ) {
+            let _ = pattern_matches(&pat, &path);
+        }
+
+        /// Bare `*` is the documented catch-all — must match every
+        /// non-empty path.
+        #[test]
+        fn bare_star_matches_everything(path in repo_path()) {
+            prop_assert!(pattern_matches("*", &path));
+        }
+
+        /// `.github/**` must cover every path under `.github/`.
+        /// Hardcodes the rule sakimori's audit-repo command relies on.
+        #[test]
+        fn double_star_directory_covers_subtree(
+            depth in 1usize..=4,
+            tail in proptest::collection::vec(path_segment(), 1..4),
+        ) {
+            let _ = depth; // breadth is captured via `tail.len()`
+            let path = format!(".github/{}", tail.join("/"));
+            prop_assert!(pattern_matches(".github/**", &path));
+        }
+
+        /// A trailing-slash pattern must NOT match the bare directory
+        /// name (only descendants). Regressing this would cause the
+        /// audit to wrongly claim `.github/` covers itself with no
+        /// children, which is gibberish.
+        #[test]
+        fn trailing_slash_excludes_bare_dir(dir in path_segment()) {
+            let pat = format!("{dir}/");
+            prop_assert!(!pattern_matches(&pat, &dir));
+        }
+
+        /// A literal anchored path must match itself and nothing else.
+        #[test]
+        fn literal_path_matches_self_only(
+            base in repo_path(),
+            other in repo_path(),
+        ) {
+            let pat = format!("/{base}");
+            prop_assert!(pattern_matches(&pat, &base));
+            if base != other {
+                prop_assert!(!pattern_matches(&pat, &other));
+            }
+        }
+    }
 }

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -43,3 +43,6 @@ sha2 = "0.10"
 tar = "0.4"
 flate2 = "1"
 toml = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/sakimori-proxy/fuzz/.gitignore
+++ b/crates/sakimori-proxy/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/crates/sakimori-proxy/fuzz/Cargo.toml
+++ b/crates/sakimori-proxy/fuzz/Cargo.toml
@@ -1,0 +1,86 @@
+[package]
+name = "sakimori-proxy-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+# Coverage-guided libFuzzer harnesses for the proxy's attacker-
+# controlled byte parsers / rewriters. NOT part of the workspace
+# (lives behind `[workspace] exclude` in the root Cargo.toml) because
+# `libfuzzer-sys` requires nightly and pulls a sanitizer runtime
+# we don't want polluting the normal build.
+#
+# To run a target:
+#
+#   cd crates/sakimori-proxy/fuzz
+#   cargo +nightly fuzz run inspect_npm_tarball
+#
+# Property-style invariants (no-panic, idempotence, hash drift) are
+# also covered by `proptest` blocks inline in each module's
+# `#[cfg(test)] mod tests` — those run on every `cargo test`. The
+# fuzz harnesses go deeper on the byte-decoder surface and are
+# intended for ad-hoc / nightly CI runs, not the pre-commit gate.
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+sakimori-proxy = { path = ".." }
+
+[[bin]]
+name = "inspect_npm_tarball"
+path = "fuzz_targets/inspect_npm_tarball.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "strip_npm_tarball"
+path = "fuzz_targets/strip_npm_tarball.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "inspect_pypi_sdist"
+path = "fuzz_targets/inspect_pypi_sdist.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rewrite_npm_packument"
+path = "fuzz_targets/rewrite_npm_packument.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rewrite_pypi_simple_html"
+path = "fuzz_targets/rewrite_pypi_simple_html.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rewrite_pypi_json_api"
+path = "fuzz_targets/rewrite_pypi_json_api.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rewrite_nuget_registration"
+path = "fuzz_targets/rewrite_nuget_registration.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "host_matcher_parse"
+path = "fuzz_targets/host_matcher_parse.rs"
+test = false
+doc = false
+bench = false

--- a/crates/sakimori-proxy/fuzz/README.md
+++ b/crates/sakimori-proxy/fuzz/README.md
@@ -1,0 +1,49 @@
+# sakimori-proxy fuzz harnesses
+
+Coverage-guided libFuzzer harnesses for the proxy's attacker-controlled
+byte parsers / rewriters. Excluded from the main workspace so the
+nightly + sanitizer toolchain doesn't leak into ordinary
+`cargo build` / `cargo test`.
+
+## Why this exists alongside proptest
+
+Each module under `crates/sakimori-proxy/src/` already has a
+`#[cfg(test)] mod tests` block with `proptest!` invariants (no-panic,
+idempotence, hash drift, `min_age=0` no-op). Those run on every
+`cargo test` and catch the obvious shapes.
+
+The fuzz harnesses below go deeper on the byte-decoder surface — gzip
+framing, tar header parsing, JSON parser corner cases, raw HTML byte
+walking — using libFuzzer's coverage guidance to discover inputs
+proptest's random generation would miss in any reasonable case count.
+They're intended for ad-hoc / nightly CI runs, not the pre-commit
+gate.
+
+## Running
+
+Requires nightly Rust and `cargo install cargo-fuzz`.
+
+```sh
+cd crates/sakimori-proxy/fuzz
+cargo +nightly fuzz run inspect_npm_tarball
+```
+
+Targets:
+
+| target                       | what it drives                                   |
+| ---------------------------- | ------------------------------------------------ |
+| `inspect_npm_tarball`        | `lifecycle::inspect_npm_tarball`                 |
+| `strip_npm_tarball`          | `lifecycle::strip_npm_tarball` (gzip→tar→edit→) |
+| `inspect_pypi_sdist`         | `lifecycle::inspect_pypi_sdist`                  |
+| `rewrite_npm_packument`      | `rewrite_npm::rewrite_npm_packument`             |
+| `rewrite_pypi_simple_html`   | `rewrite_pypi::rewrite_pypi_simple_html`         |
+| `rewrite_pypi_json_api`      | `rewrite_pypi::rewrite_pypi_json_api`            |
+| `rewrite_nuget_registration` | `rewrite_nuget::rewrite_nuget_registration`      |
+| `host_matcher_parse`         | `host_allow::HostMatcher` parse + match          |
+
+## Seeding corpora
+
+Drop interesting inputs under `corpus/<target>/`. The proxy's existing
+test fixtures (e.g. captured npm packuments, real PyPI Simple HTML
+samples) make excellent seeds — fewer wasted cycles before the fuzzer
+finds structured paths.

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/host_matcher_parse.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/host_matcher_parse.rs
@@ -1,0 +1,19 @@
+#![no_main]
+//! Host-allow parser + matcher. Drives `from_patterns` with a
+//! `\n`-split chunk so a single fuzz input exercises both arbitrary
+//! patterns *and* arbitrary match queries.
+
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::host_allow::HostMatcher;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+    let mut lines = s.split('\n');
+    let query = lines.next().unwrap_or("");
+    let patterns: Vec<&str> = lines.collect();
+    if let Ok(m) = HostMatcher::from_patterns(patterns) {
+        let _ = m.allows(query);
+    }
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/inspect_npm_tarball.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/inspect_npm_tarball.rs
@@ -1,0 +1,11 @@
+#![no_main]
+//! Inspector reads attacker-controlled npm tarballs (gzipped tar +
+//! JSON `package.json`). A panic at the proxy layer becomes a 5xx
+//! and silently disables the lifecycle-script defence.
+
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::lifecycle::inspect_npm_tarball;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = inspect_npm_tarball(data);
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/inspect_pypi_sdist.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/inspect_pypi_sdist.rs
@@ -1,0 +1,10 @@
+#![no_main]
+//! PyPI sdist inspector — gzipped tar with `setup.py` / `pyproject.toml`.
+//! Same decode-surface risk as the npm inspector.
+
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::lifecycle::inspect_pypi_sdist;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = inspect_pypi_sdist(data);
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_npm_packument.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_npm_packument.rs
@@ -1,0 +1,14 @@
+#![no_main]
+//! npm packument JSON rewriter — drops too-young versions and
+//! retargets `dist-tags`. Attacker model: an upstream / on-path
+//! mirror serving crafted JSON that triggers a panic or
+//! mis-classification.
+
+use chrono::Utc;
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::rewrite_npm::rewrite_npm_packument;
+use std::time::Duration;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rewrite_npm_packument(data, Duration::from_secs(86_400), Utc::now());
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_nuget_registration.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_nuget_registration.rs
@@ -1,0 +1,11 @@
+#![no_main]
+//! NuGet v3 registration-index rewriter.
+
+use chrono::Utc;
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::rewrite_nuget::rewrite_nuget_registration;
+use std::time::Duration;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rewrite_nuget_registration(data, Duration::from_secs(86_400), Utc::now());
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_pypi_json_api.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_pypi_json_api.rs
@@ -1,0 +1,11 @@
+#![no_main]
+//! Warehouse JSON API rewriter (`/pypi/<pkg>/json`).
+
+use chrono::Utc;
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::rewrite_pypi::rewrite_pypi_json_api;
+use std::time::Duration;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rewrite_pypi_json_api(data, Duration::from_secs(86_400), Utc::now());
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_pypi_simple_html.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/rewrite_pypi_simple_html.rs
@@ -1,0 +1,13 @@
+#![no_main]
+//! PEP 503 Simple HTML rewriter — the trickiest of the PyPI shapes
+//! because it mutates raw bytes around anchor boundaries. Off-by-one
+//! / unicode-boundary bugs land here.
+
+use chrono::Utc;
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::rewrite_pypi::rewrite_pypi_simple_html;
+use std::time::Duration;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = rewrite_pypi_simple_html(data, Duration::from_secs(86_400), Utc::now(), |_| None);
+});

--- a/crates/sakimori-proxy/fuzz/fuzz_targets/strip_npm_tarball.rs
+++ b/crates/sakimori-proxy/fuzz/fuzz_targets/strip_npm_tarball.rs
@@ -1,0 +1,13 @@
+#![no_main]
+//! Strip-mode rewriter — the most complex byte-level path in the
+//! proxy (gzip → tar → JSON edit → tar rebuild → gzip → SHA hash).
+//! Default `StripLimits` is sized to admit every legitimate npm
+//! package; the cap-check itself is part of what's under test for
+//! pathological inputs.
+
+use libfuzzer_sys::fuzz_target;
+use sakimori_proxy::lifecycle::{StripLimits, strip_npm_tarball};
+
+fuzz_target!(|data: &[u8]| {
+    let _ = strip_npm_tarball(data, &StripLimits::default());
+});

--- a/crates/sakimori-proxy/src/host_allow.rs
+++ b/crates/sakimori-proxy/src/host_allow.rs
@@ -286,4 +286,109 @@ mod tests {
         assert_eq!(strip_port("[::1]:8080"), "::1");
         assert_eq!(strip_port("[2001:db8::1]:443"), "2001:db8::1");
     }
+
+    // --- proptest: invariants on the parser + matcher -------------------
+    //
+    // The hand-written tests above cover specific shapes; the props
+    // below assert the *behaviour* that defines the feature, so any
+    // future tweak that breaks the security contract trips a counter-
+    // example instead of slipping through.
+
+    use proptest::prelude::*;
+
+    /// A label that's safe to splice into a hostname: a non-empty
+    /// ASCII-alphanumeric/hyphen string. Stops the generator from
+    /// emitting strings that contain `*` or `:` (those are tested
+    /// elsewhere) so each property targets exactly one contract.
+    fn host_label() -> impl Strategy<Value = String> {
+        "[a-z][a-z0-9-]{0,15}"
+    }
+
+    fn host_name() -> impl Strategy<Value = String> {
+        proptest::collection::vec(host_label(), 1..5).prop_map(|segs| segs.join("."))
+    }
+
+    proptest! {
+        /// Parser never panics. Any byte string either parses or
+        /// returns a structured `ParseError`.
+        #[test]
+        fn parse_never_panics(input in ".{0,64}") {
+            let _ = HostMatcher::from_patterns([input]);
+        }
+
+        /// Match path never panics for arbitrary host inputs.
+        #[test]
+        fn allows_never_panics(
+            pats in proptest::collection::vec(host_name(), 0..4),
+            host in ".{0,64}",
+        ) {
+            let m = HostMatcher::from_patterns(pats).unwrap_or_default();
+            let _ = m.allows(&host);
+        }
+
+        /// Security contract: `*.suffix` must NEVER match the bare
+        /// apex `suffix`. A regression here turns the wildcard into a
+        /// silent egress hole.
+        #[test]
+        fn wildcard_never_matches_apex(apex in host_name()) {
+            let pat = format!("*.{apex}");
+            let m = HostMatcher::from_patterns([pat]).unwrap();
+            prop_assert!(!m.allows(&apex));
+        }
+
+        /// Security contract: `*.suffix` must NOT match strings that
+        /// only happen to end in `suffix` (e.g. `notexample.com` vs
+        /// `*.example.com`, or `example.com.attacker.com`).
+        #[test]
+        fn wildcard_only_matches_proper_subdomains(
+            suffix in host_name(),
+            prefix in host_label(),
+            attacker_tail in host_name(),
+        ) {
+            let m = HostMatcher::from_patterns([format!("*.{suffix}")]).unwrap();
+            let proper = format!("{prefix}.{suffix}");
+            prop_assert!(m.allows(&proper));
+            let collision = format!("{prefix}{suffix}");
+            prop_assert!(!m.allows(&collision));
+            let evil = format!("{suffix}.{attacker_tail}");
+            let dot_suffix = format!(".{suffix}");
+            if !evil.ends_with(&dot_suffix) {
+                prop_assert!(!m.allows(&evil));
+            }
+        }
+
+        /// Match is case-insensitive on both sides.
+        #[test]
+        fn match_is_case_insensitive(host in host_name()) {
+            let m = HostMatcher::from_patterns([host.to_uppercase()]).unwrap();
+            prop_assert!(m.allows(&host));
+            prop_assert!(m.allows(&host.to_uppercase()));
+        }
+
+        /// A port suffix on the query side must never change the
+        /// allow/deny verdict — the matcher describes hosts, not
+        /// (host, port) pairs.
+        #[test]
+        fn port_suffix_does_not_change_verdict(
+            host in host_name(),
+            port in 1u16..=65535,
+        ) {
+            let m = HostMatcher::from_patterns([host.clone()]).unwrap();
+            let with_port = format!("{host}:{port}");
+            prop_assert_eq!(m.allows(&host), m.allows(&with_port));
+        }
+
+        /// Any pattern containing an embedded `*` (not as a leading
+        /// `*.`) must be rejected. This is the rule that stops a
+        /// typoed pattern from silently matching nothing.
+        #[test]
+        fn embedded_wildcard_always_rejected(
+            left in host_label(),
+            right in host_name(),
+        ) {
+            // Construct `<label>*.<rest>` — always has an embedded `*`.
+            let bad = format!("{left}*.{right}");
+            prop_assert!(HostMatcher::from_patterns([bad]).is_err());
+        }
+    }
 }

--- a/crates/sakimori-proxy/src/lifecycle.rs
+++ b/crates/sakimori-proxy/src/lifecycle.rs
@@ -1184,4 +1184,161 @@ build-backend = "setuptools.build_meta"
         let ok = std::path::Path::new("package/lib/foo.js");
         assert!(validate_entry_path(ok).is_ok());
     }
+
+    // --- proptest: invariants on tarball inspection + strip --------------
+    //
+    // The tarball path is the single attacker-controlled byte stream
+    // with the deepest decode surface in the proxy (gzip → tar →
+    // serde_json). These props cover the security contract:
+    // - Neither inspector nor stripper may ever panic on arbitrary
+    //   input. A panic at the proxy layer becomes a 5xx and a
+    //   silently-failed defence.
+    // - Stripping a benign tarball (no lifecycle scripts) must report
+    //   `Ok(None)` so the proxy serves the original bytes unchanged
+    //   and the upstream `dist.integrity` stays valid.
+    // - Strip is idempotent: running it a second time on already-
+    //   stripped bytes must report `Ok(None)`. If it ever produced
+    //   different bytes, the cache's `(name, version, orig_integrity)`
+    //   key would mis-classify and serve mismatched bytes.
+    // - The recomputed sha512/sha1 must actually match the rewritten
+    //   tarball's bytes. npm verifies these client-side; a drift here
+    //   is an `EINTEGRITY` install failure.
+
+    use proptest::prelude::*;
+    use sha2::Digest as _;
+
+    /// Build a gzipped npm-shaped tarball where `scripts` is the
+    /// user-controlled JSON object. The wrapping `name`/`version`
+    /// keep the package.json parseable for both strip and inspect.
+    fn pack_with_scripts(scripts_json: &str) -> Vec<u8> {
+        let pkg = format!(r#"{{"name":"x","version":"1.0.0","scripts":{scripts_json}}}"#);
+        pack_tarball(pkg.as_bytes())
+    }
+
+    fn lifecycle_key() -> impl Strategy<Value = &'static str> {
+        prop_oneof![
+            Just("preinstall"),
+            Just("install"),
+            Just("postinstall"),
+            Just("prepare"),
+        ]
+    }
+
+    /// Generate a `scripts` JSON object that mixes lifecycle and
+    /// non-lifecycle keys with arbitrary string bodies. Body uses a
+    /// restricted alphabet to keep the JSON well-formed without a
+    /// full escaper.
+    fn scripts_object() -> impl Strategy<Value = String> {
+        let lifecycle =
+            proptest::collection::vec((lifecycle_key(), "[a-zA-Z0-9 ._/-]{0,32}"), 0..5);
+        let other = proptest::collection::vec(("[a-z]{1,8}", "[a-zA-Z0-9 ._/-]{0,32}"), 0..3);
+        (lifecycle, other).prop_map(|(life, other)| {
+            // Dedupe keys — later wins, matching serde_json semantics.
+            let mut map = std::collections::BTreeMap::new();
+            for (k, v) in life {
+                map.insert(k.to_string(), v);
+            }
+            for (k, v) in other {
+                if !LIFECYCLE_KEYS.contains(&k.as_str()) {
+                    map.insert(k, v);
+                }
+            }
+            let body: String = map
+                .iter()
+                .map(|(k, v)| format!("\"{k}\":\"{v}\""))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{body}}}")
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        /// `inspect_npm_tarball` must never panic on arbitrary bytes —
+        /// returns `Err(NotGzip)` / `Err(Tar)` or `Ok(Inspection)`.
+        #[test]
+        fn inspect_never_panics(body in proptest::collection::vec(any::<u8>(), 0..2048)) {
+            let _ = inspect_npm_tarball(&body);
+        }
+
+        /// `strip_npm_tarball` must never panic on arbitrary bytes.
+        /// Default limits are kept small enough that proptest cases
+        /// don't OOM, but the cap-check itself is the property under
+        /// test for oversize inputs.
+        #[test]
+        fn strip_never_panics(body in proptest::collection::vec(any::<u8>(), 0..2048)) {
+            let _ = strip_npm_tarball(&body, &StripLimits::default());
+        }
+
+        /// `inspect` only ever surfaces lifecycle-keyed scripts. Any
+        /// non-lifecycle key (test/lint/build/...) must be ignored
+        /// even if its body is non-empty.
+        #[test]
+        fn inspect_only_surfaces_lifecycle_keys(scripts in scripts_object()) {
+            let tgz = pack_with_scripts(&scripts);
+            let out = inspect_npm_tarball(&tgz).unwrap();
+            for s in &out.scripts {
+                prop_assert!(LIFECYCLE_KEYS.contains(&s.stage));
+                prop_assert!(!s.body.trim().is_empty());
+            }
+        }
+
+        /// Strip is a no-op on a tarball with no lifecycle scripts
+        /// at all. `Ok(None)` means the proxy serves the original
+        /// bytes and the upstream integrity stays valid.
+        #[test]
+        fn strip_is_noop_when_no_lifecycle_scripts(other_keys in proptest::collection::vec(("[a-z]{1,8}", "[a-zA-Z0-9 ._/-]{0,32}"), 0..4)) {
+            // Build a scripts object with only non-lifecycle keys.
+            let mut filtered: Vec<(String, String)> = other_keys.into_iter()
+                .filter(|(k, _)| !LIFECYCLE_KEYS.contains(&k.as_str()))
+                .collect();
+            filtered.sort();
+            filtered.dedup_by(|a, b| a.0 == b.0);
+            let body: String = filtered.iter()
+                .map(|(k, v)| format!("\"{k}\":\"{v}\""))
+                .collect::<Vec<_>>()
+                .join(",");
+            let scripts = format!("{{{body}}}");
+            let tgz = pack_with_scripts(&scripts);
+            let out = strip_npm_tarball(&tgz, &StripLimits::default()).unwrap();
+            prop_assert!(out.is_none(), "expected no-op strip, got {:?}", out.as_ref().map(|o| &o.stripped_stages));
+        }
+
+        /// Strip is idempotent: after stripping a tarball with
+        /// lifecycle scripts, re-stripping the output must be a
+        /// no-op (`Ok(None)`). And the recomputed integrity hashes
+        /// must match the rewritten bytes — drift here breaks the
+        /// downstream `npm install` integrity check.
+        #[test]
+        fn strip_is_idempotent_and_hashes_match(scripts in scripts_object()) {
+            let tgz = pack_with_scripts(&scripts);
+            let Some(first) = strip_npm_tarball(&tgz, &StripLimits::default()).unwrap() else {
+                // Generated scripts happened to have no lifecycle
+                // keys with non-empty bodies — nothing to strip.
+                return Ok(());
+            };
+
+            // sha512 base64 of `first.bytes` must equal first.sha512_b64.
+            use base64::Engine;
+            let mut h = sha2::Sha512::new();
+            h.update(&first.bytes);
+            let computed = base64::engine::general_purpose::STANDARD.encode(h.finalize());
+            prop_assert_eq!(&computed, &first.sha512_b64);
+
+            // Re-stripping the rewritten bytes must be a no-op.
+            let second = strip_npm_tarball(&first.bytes, &StripLimits::default()).unwrap();
+            prop_assert!(
+                second.is_none(),
+                "strip not idempotent: second pass stripped {:?}",
+                second.as_ref().map(|o| &o.stripped_stages),
+            );
+
+            // Inspecting the stripped tarball must surface no
+            // lifecycle scripts (defence-in-depth: the inspector
+            // and stripper agree on what "no scripts" means).
+            let insp = inspect_npm_tarball(&first.bytes).unwrap();
+            prop_assert!(!insp.has_scripts(), "stripped tarball still reports scripts: {:?}", insp.scripts);
+        }
+    }
 }

--- a/crates/sakimori-proxy/src/rewrite_npm.rs
+++ b/crates/sakimori-proxy/src/rewrite_npm.rs
@@ -860,4 +860,62 @@ mod tests {
         let doc = parse(&out);
         assert_eq!(doc["versions"]["1.0.0"]["dist"]["integrity"], "sha512-ORIG");
     }
+
+    // --- proptest: invariants on the packument rewriter -----------------
+    //
+    // The npm packument rewriter takes attacker-controlled JSON bytes
+    // (we don't trust the upstream registry mirror to be benign).
+    // These props lock in:
+    // - No panic on arbitrary bytes / arbitrary JSON shapes.
+    // - `min_age = 0` is always a semantic no-op (kept count = total
+    //   versions; dropped = 0; dist-tags untouched). A regression
+    //   here would silently filter without the user asking.
+    // - Output is always valid UTF-8 / parseable JSON when the input
+    //   was. The rewriter promises pass-through on parse failure;
+    //   the round-trip property catches accidental binary corruption.
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        #[test]
+        fn rewrite_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let now = Utc::now();
+            let _ = rewrite_npm_packument(&body, Duration::from_secs(86_400), now);
+        }
+
+        /// min_age = 0 must never drop a version.
+        #[test]
+        fn zero_min_age_is_a_noop(version_count in 0usize..=8) {
+            let now = Utc::now();
+            let mut versions = serde_json::Map::new();
+            let mut time = serde_json::Map::new();
+            for i in 0..version_count {
+                let v = format!("{i}.0.0");
+                versions.insert(v.clone(), serde_json::json!({"name": "x", "version": v}));
+                time.insert(v, serde_json::Value::String(now.to_rfc3339()));
+            }
+            let body = serde_json::to_vec(&serde_json::json!({
+                "name": "x",
+                "dist-tags": {"latest": format!("{}.0.0", version_count.saturating_sub(1))},
+                "versions": versions,
+                "time": time,
+            })).unwrap();
+            let (_out, stats) = rewrite_npm_packument(&body, Duration::ZERO, now);
+            prop_assert_eq!(stats.dropped, 0);
+            prop_assert_eq!(stats.retargeted_tags, 0);
+        }
+
+        /// A packument with no recognisable shape (random JSON value
+        /// at the top, or unparseable bytes) passes through
+        /// byte-for-byte. Drops/retargets must stay at zero.
+        #[test]
+        fn unparseable_or_non_object_passes_through(garbage in "[^{]{0,128}") {
+            let now = Utc::now();
+            let (out, stats) = rewrite_npm_packument(garbage.as_bytes(), Duration::from_secs(86_400), now);
+            prop_assert_eq!(stats.dropped, 0);
+            prop_assert_eq!(out, garbage.as_bytes());
+        }
+    }
 }

--- a/crates/sakimori-proxy/src/rewrite_nuget.rs
+++ b/crates/sakimori-proxy/src/rewrite_nuget.rs
@@ -560,4 +560,67 @@ mod tests {
         assert_eq!(stats.dropped, 0);
         assert_eq!(stats.kept, 2);
     }
+
+    // --- proptest: no-panic + min_age=0 noop ----------------------------
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        #[test]
+        fn registration_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let _ = rewrite_nuget_registration(&body, Duration::from_secs(86_400), Utc::now());
+        }
+
+        #[test]
+        fn flatcontainer_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let _ = rewrite_nuget_flatcontainer(
+                &body,
+                Duration::from_secs(86_400),
+                Utc::now(),
+                |_| None,
+            );
+        }
+
+        /// Registration rewriter with min_age=0 must not drop anything.
+        #[test]
+        fn registration_zero_min_age_is_noop(leaf_count in 0usize..=8) {
+            let now = Utc::now();
+            let items: Vec<serde_json::Value> = (0..leaf_count)
+                .map(|i| {
+                    serde_json::json!({
+                        "catalogEntry": {
+                            "version": format!("{i}.0.0"),
+                            "published": now.to_rfc3339(),
+                        }
+                    })
+                })
+                .collect();
+            let body = serde_json::to_vec(&serde_json::json!({
+                "count": leaf_count,
+                "items": items,
+            })).unwrap();
+            let (_out, stats) = rewrite_nuget_registration(&body, Duration::ZERO, now);
+            prop_assert_eq!(stats.dropped, 0);
+            prop_assert_eq!(stats.kept, leaf_count);
+        }
+
+        /// Flat-container with an empty oracle is fail-open: every
+        /// version is kept (the registration-index lookup may have
+        /// failed; pinned .nupkg fetches still hard-deny). A change
+        /// that flipped this to fail-closed would brick installs.
+        #[test]
+        fn flatcontainer_empty_oracle_is_fail_open(versions in proptest::collection::vec("[0-9]+\\.[0-9]+\\.[0-9]+", 0..6)) {
+            let now = Utc::now();
+            let body = serde_json::to_vec(&serde_json::json!({"versions": versions})).unwrap();
+            let (_out, stats) = rewrite_nuget_flatcontainer(
+                &body,
+                Duration::from_secs(86_400),
+                now,
+                |_| None,
+            );
+            prop_assert_eq!(stats.dropped, 0);
+        }
+    }
 }

--- a/crates/sakimori-proxy/src/rewrite_pypi.rs
+++ b/crates/sakimori-proxy/src/rewrite_pypi.rs
@@ -800,4 +800,67 @@ mod tests {
         // No href at all.
         assert_eq!(extract_href_value(r#"<a class="foo">y</a>"#), None);
     }
+
+    // --- proptest: no-panic + identity invariants -----------------------
+    //
+    // The Simple HTML rewriter is the most fragile of the three PyPI
+    // shapes — it walks raw bytes, finds anchor boundaries, and
+    // mutates around them. Property tests here are the cheapest way
+    // to catch off-by-one / unicode-boundary panics that hand-written
+    // tests miss.
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        #[test]
+        fn json_api_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let _ = rewrite_pypi_json_api(&body, Duration::from_secs(86_400), Utc::now());
+        }
+
+        #[test]
+        fn simple_json_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let _ = rewrite_pypi_simple_json(&body, Duration::from_secs(86_400), Utc::now());
+        }
+
+        #[test]
+        fn simple_html_never_panics(body in proptest::collection::vec(any::<u8>(), 0..1024)) {
+            let _ = rewrite_pypi_simple_html(&body, Duration::from_secs(86_400), Utc::now(), |_| None);
+        }
+
+        /// An oracle that returns `None` for every version means
+        /// "we don't know any publish times" — the HTML rewriter
+        /// must then leave the body byte-for-byte identical. A
+        /// regression here would drop entries the oracle never
+        /// claimed are too young.
+        #[test]
+        fn empty_oracle_is_identity(body in ".{0,512}") {
+            let (out, stats) = rewrite_pypi_simple_html(
+                body.as_bytes(),
+                Duration::from_secs(86_400),
+                Utc::now(),
+                |_| None,
+            );
+            prop_assert_eq!(stats.dropped, 0);
+            prop_assert_eq!(out, body.as_bytes());
+        }
+
+        /// min_age = 0 → JSON API rewriter is a no-op.
+        #[test]
+        fn json_zero_min_age_drops_nothing(version_count in 0usize..=8) {
+            let now = Utc::now();
+            let mut releases = serde_json::Map::new();
+            for i in 0..version_count {
+                let v = format!("{i}.0.0");
+                releases.insert(
+                    v,
+                    serde_json::json!([{"upload_time_iso_8601": now.to_rfc3339()}]),
+                );
+            }
+            let body = serde_json::to_vec(&serde_json::json!({"releases": releases})).unwrap();
+            let (_out, stats) = rewrite_pypi_json_api(&body, Duration::ZERO, now);
+            prop_assert_eq!(stats.dropped, 0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Hardens the proxy's attacker-controlled byte-decode surface against panics, hash drift, and silent semantic regressions. Two layers:

1. **Inline `proptest!` blocks** — run on every `cargo test`, no infra change. Cover:
   - `host_allow::HostMatcher` — parse/match never-panic, wildcard never matches apex, suffix-collision safety, port-suffix invariance, embedded `*` always rejected.
   - `codeowners::pattern_matches` — parse/match never-panic, `*` catch-all, `.github/**` subtree, trailing-slash semantics, literal-anchored self-match.
   - `lifecycle::inspect_npm_tarball` / `strip_npm_tarball` — never-panic on arbitrary bytes, only lifecycle keys surfaced, benign tarball is a no-op, **strip is idempotent** and recomputed SHA-512 matches rewritten bytes.
   - `rewrite_npm_packument` / `rewrite_pypi_{json_api,simple_json,simple_html}` / `rewrite_nuget_{registration,flatcontainer}` — never-panic, `min_age=0` is a semantic no-op, empty oracle on the HTML rewriter is byte-identity, flat-container empty oracle is fail-open.

2. **cargo-fuzz harnesses** under [`crates/sakimori-proxy/fuzz/`](crates/sakimori-proxy/fuzz/) (excluded from the workspace; libfuzzer-sys needs nightly + sanitizer runtime). Eight targets cover the inspectors + every rewriter + the host matcher. README documents how to run.

## Why both

proptest catches the obvious shapes on every `cargo test` (64 cases per property by default). cargo-fuzz uses coverage guidance to go deeper on gzip/tar/JSON/HTML byte parsers — discoveries that random proptest generation would miss in any reasonable case count. Fuzzing is opt-in / nightly-CI, not pre-commit.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 605 passing (was ~575)
- [x] Workspace still builds with fuzz dir excluded (`cargo check --workspace --all-targets`)
- [ ] (manual / nightly) `cd crates/sakimori-proxy/fuzz && cargo +nightly fuzz run strip_npm_tarball -- -max_total_time=60`

🤖 Generated with [Claude Code](https://claude.com/claude-code)