### PR TITLE
ci: dogfood bokuweb/sakimori/job@v0 on the userspace job

### DIFF
--- a/.github/sakimori.yml
+++ b/.github/sakimori.yml
@@ -1,0 +1,47 @@
+# sakimori policy for this repo's own CI — dogfood reference.
+#
+# The `userspace` job in .github/workflows/ci.yml runs every step
+# under `bokuweb/sakimori/job@v0`, which reads this file. We keep it
+# in `mode: audit` so the supervisor only *reports* what cargo /
+# rustup / git / etc. touch — nothing is blocked. A future iteration
+# can tighten to `mode: block` once the audit log has shown what a
+# clean run actually looks like.
+#
+# The deny-lists below are intentionally short and high-signal:
+# they describe destinations / paths that a healthy Rust build
+# never legitimately touches but a supply-chain compromise of a
+# build-script / proc-macro would reach for. In audit mode each
+# match shows up as a ❌ row in the step summary and JSON log — a
+# loud, free smoke alarm with zero risk of false-blocking the build.
+
+mode: audit
+
+network:
+  default: allow
+  deny:
+    # IMDS — AWS / GCP / Azure cloud-credential exfiltration. A
+    # Rust build script has no business reading instance metadata.
+    - target: 169.254.169.254
+    # GHA OIDC token mint. A compromised proc-macro stealing the
+    # `id-token: write` workflow token would call this endpoint;
+    # legitimate Rust builds never do.
+    - target: vstoken.actions.githubusercontent.com
+
+file:
+  default: allow
+  deny:
+    # SSH keys — the highest-value exfil target on a CI runner.
+    - /root/.ssh
+    - /home/runner/.ssh
+    # Persistent shell rc — used by Shai-Hulud-class droppers to
+    # establish persistence across runner reuse.
+    - /home/runner/.bashrc
+    - /home/runner/.zshrc
+
+process:
+  # Audit-only list of binaries that should be visible if invoked
+  # — none of these get blocked, but their appearance in the JSON
+  # log is the first thing to look at if anything looks off.
+  deny_exec:
+    - /usr/bin/whoami
+    - /usr/bin/curl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Dogfood: audit every subsequent step of this job with our
+      # own job-scoped supervisor. Reads `.github/sakimori.yml`
+      # (mode: audit) and posts the per-host/per-path/per-binary
+      # tables into this job's step summary at post-time. The
+      # rendered report is also uploaded as a build artifact at
+      # the end of the job. If a future change here pulls in a
+      # crate whose build script reaches for IMDS or rewrites
+      # `.bashrc`, the deny rules in the policy file will surface
+      # it as a ❌ row even in audit mode.
+      # SHA-pinned per our own `sakimori actions audit` rule —
+      # mutable third-party tags (`@v0`) trip an Error finding, so
+      # we eat our own dogfood and pin the action by commit. Bump
+      # the comment + SHA when cutting a new floating-v0 release.
+      - uses: bokuweb/sakimori/job@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
+        with:
+          mode: audit
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
@@ -110,6 +128,21 @@ jobs:
             grep -q "${label}/" /tmp/mixed.txt || { echo "::error::no ${label} violations surfaced"; exit 1; }
           done
           echo "✓ all 4 ecosystems produced violations at --min-age 3650d"
+
+      # Upload the audit log + HTML report produced by the
+      # `bokuweb/sakimori/job` supervisor above. `if: always()` so
+      # we get the artefact even on a failed cargo step — that's
+      # exactly when you want it. The daemon writes both files
+      # during its post-hook.
+      - name: Upload sakimori audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sakimori-userspace-audit
+          path: |
+            sakimori.log.json
+            sakimori-report.html
+          if-no-files-found: ignore
 
   proxy-smoke:
     # End-to-end check that the MITM proxy correctly rewrites metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,17 @@ jobs:
       # mutable third-party tags (`@v0`) trip an Error finding, so
       # we eat our own dogfood and pin the action by commit. Bump
       # the comment + SHA when cutting a new floating-v0 release.
+      #
+      # `version: v0` is required because `job/pre.js` derives the
+      # release tag from `GITHUB_ACTION_REF`, which here is the
+      # 40-char SHA. The installer treats unknown refs as literal
+      # release tags and 404s. Passing `version` explicitly skips
+      # that path — supply-chain integrity stays on the SHA pin,
+      # the installer just learns which release tarball to fetch.
       - uses: bokuweb/sakimori/job@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
         with:
           mode: audit
+          version: v0
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:


### PR DESCRIPTION
## Summary

- Adds `bokuweb/sakimori/job@<sha>` right after `actions/checkout` in the `userspace` job, so every subsequent step (cargo fmt, clippy, build, test, deps check) runs under our own job-scoped supervisor.
- Checks in a minimal [`.github/sakimori.yml`](.github/sakimori.yml) audit-mode policy with high-signal denies: IMDS (`169.254.169.254`), the GHA OIDC token endpoint, SSH keys, and shell rc files.
- Uploads the JSON audit log + HTML report as a job artefact (`if: always()`).

The third-party action ref is SHA-pinned because our own `sakimori actions audit` rule errors on mutable `@v0` for third-party actions — caught while preparing this PR, fixed by pinning, audit then drops to 0 errors. First-party actions (`actions/checkout`, `actions/upload-artifact`) keep their floating tags to match the rest of this file (`@v4`, Warn-level under the same rule).

## Why

This repo *is* the canonical example of sakimori usage. Until now we exercised the action via [`consumer-smoke.yml`](.github/workflows/consumer-smoke.yml) (a synthetic run with a hand-crafted policy that intentionally trips every deny), but the main CI itself wasn't audited. After this change, every `cargo build` / `cargo test` on this repo produces a real audit log of the network + filesystem behaviour of our actual transitive dep tree — the best possible reference for anyone wondering "what does sakimori output look like on a real Rust build?"

## Test plan

- [x] `sakimori check-policy --policy .github/sakimori.yml` — parses clean, all defaults expand as expected.
- [x] `sakimori actions audit .github/workflows/ci.yml` — 14 ok, 16 warn, **0 error** (down from 1 error before the SHA pin).
- [ ] CI on this PR will run `userspace` with sakimori attached; download the `sakimori-userspace-audit` artefact and confirm the JSON log + HTML report are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)