### PR TITLE
docs+test: README/CLI audit + cross-module integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,54 +278,28 @@ Start the MITM HTTPS proxy in the foreground. `install-daemon`
 wraps this for background use; run it directly when you want logs
 on stdout or you're running the proxy yourself in Docker.
 
+Run `sakimori proxy start --help` for the canonical, always-up-to-date
+flag list. The grouping below summarises the surface so you know
+what knobs exist; defaults are tuned for "drop into `~/.zshrc` and
+forget" desktop use — CI workflows usually want to layer on the
+lifecycle gate and provenance check.
+
 ```
 sakimori proxy start [OPTIONS]
-
-Options:
-  --listen <ADDR>              [default: 127.0.0.1:8910]
-  --min-age <DURATION>         [default: 7d]
-      Grammar: `<N>{d,h,m,s}`. Versions younger than this are
-      invisible to the resolver.
-  --fail-on-missing            Treat unknown publish dates as deny
-                               (default: fail-open / allow through).
-  --require-provenance         Strict mode. Drop every npm package
-                               version without a Sigstore provenance
-                               claim. Forces publishers to have gone
-                               through OIDC-authenticated CI.
-                               (npm only for now.)
-  --osv                        Consult OSV.dev on every decision.
-                               Versions flagged as malicious
-                               packages (MAL-* or advisories
-                               mentioning "malicious") are hard-
-                               denied regardless of --min-age.
-                               Live API, per-version cached.
-  --osv-mirror                 Same blocking rule as --osv, but
-                               consumed from the sakimori-hosted
-                               pre-filtered snapshot. O(1) in-memory
-                               lookup after a single ~10-minute
-                               background refresh. ~10 min behind
-                               OSV publish time in exchange for
-                               not hitting api.osv.dev per request.
-                               Combine with --osv to additionally
-                               fall back to the live API for
-                               entries the mirror hasn't indexed.
-  --osv-mirror-url <URL>       Override mirror URL (e.g. self-hosted).
-  --network-allow <HOST>       Hostname egress allow-list (repeatable).
-                               Patterns: `host.example.com` (exact) or
-                               `*.example.com` (any subdomain, excludes
-                               apex). When set, the proxy default-denies
-                               every CONNECT/HTTP whose target host
-                               doesn't match, returning 403. Off by
-                               default — without any flag, every host
-                               passes through.
-  --network-allow-file <PATH>  Read additional `--network-allow`
-                               patterns from a file (one per line;
-                               `#` comments / blank lines skipped).
-  --config-dir <PATH>          Override CA / config directory.
-                               Defaults to $XDG_CONFIG_HOME/sakimori
-                               on Unix, %LOCALAPPDATA%\sakimori on
-                               Windows.
 ```
+
+| group | flags | what it does |
+|---|---|---|
+| **Networking** | `--listen <ADDR>` (default `127.0.0.1:8910`), `--config-dir <PATH>` | Where the proxy listens; where its CA / config files live. |
+| **Release-age gate** | `--min-age <DURATION>` (default `7d`), `--fail-on-missing` | Versions younger than `--min-age` are silently dropped from the metadata response the client sees. `--fail-on-missing` treats unknown publish dates as deny (default: fail-open). |
+| **Provenance gate** (npm only) | `--require-provenance` | Drop every npm version that doesn't carry a Sigstore provenance claim. Closes the "stolen publish token" hole `--min-age` alone can't cover — a thief can publish immediately, but without an OIDC-authenticated CI run can't attach valid provenance. |
+| **Known-malicious gate** | `--osv`, `--osv-mirror`, `--osv-mirror-url <URL>` | Consult OSV.dev (live) and/or the sakimori-hosted pre-filtered mirror; hard-deny versions tagged MAL-* / known-malicious regardless of `--min-age`. |
+| **Typosquat detection** | `--typosquat {warn,block}`, `--typosquat-mirror`, `--typosquat-mirror-url <URL>` | Compare incoming package names against a top-N-per-ecosystem list (lodash, requests, tokio, Newtonsoft.Json, …) and warn or block close-distance candidates. |
+| **Lifecycle-script gate** (Shai-Hulud-class defence) | `--lifecycle-policy {audit,block,strip}`, `--lifecycle-allow <PKG>` (repeatable), `--lifecycle-strip-on-failure {block,passthrough}`, `--lifecycle-strip-cache-dir <DIR>`, `--lifecycle-no-strip-cache` | `audit` logs install-time scripts; `block` 403s tarballs that ship them; `strip` rewrites the tarball in place to drop the script keys + recompute the SRI hash + amend the packument so npm's integrity verifier agrees. See CLAUDE.md Roadmap #15 for the threat model. |
+| **Egress allow-list** | `--network-allow <HOST>` (repeatable), `--network-allow-file <PATH>` | Default-deny hostname filter. Patterns: `host.example.com` (exact) or `*.example.com` (any subdomain, excludes apex). Off by default. |
+| **Install log + advisories** | `--no-install-log`, `--install-log <PATH>` | The local-first append-only audit log feeding `sakimori advisories scan`. On by default at `~/.sakimori/installs.jsonl`. |
+| **OTLP fan-out** | `--otlp-endpoint <URL>`, `--otlp-header <K=V>` (repeatable) | Mirror every allowed install as an OTLP/HTTP `LogRecord` to Datadog / Honeycomb / Loki / a self-run otel-collector. |
+| **Custom registries** | `--npm-registry`, `--pypi-registry`, `--pypi-files-host`, `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry` (all repeatable), `--registries-config <FILE>` | Teach the proxy about internal mirrors / replacement registries so the rewriters + lifecycle gate fire on their traffic too. See the [Custom registries](#custom--internal-registries) subsection below. |
 
 **First-run side effect**: generates a self-signed root CA at the
 config dir and prints the OS-specific trust command. Subsequent runs
@@ -345,6 +319,81 @@ sakimori proxy start \
     --network-allow '*.githubusercontent.com' \
     --network-allow registry.npmjs.org
 ```
+
+#### Custom / internal registries
+
+The rewriters + lifecycle gate dispatch by **hostname**. By default
+only the canonical public hosts are watched — traffic to
+`registry.npmjs.org` runs the npm packument rewriter, traffic to
+`pypi.org` runs the PyPI rewriters, etc. Internal mirrors /
+replacement registries (Verdaccio, GitHub Packages, Artifactory,
+Takumi Guard, JFrog, Nexus, …) are passed through opaquely unless
+you teach the proxy about them.
+
+Three layered sources, applied in order with case-insensitive
+dedupe: built-in defaults → optional TOML config file
+(`--registries-config <FILE>`) → per-ecosystem CLI flags. The
+canonical public hosts remain watched alongside your additions.
+
+```bash
+# CLI flags (repeatable). Each accepts a bare hostname or a URL —
+# the host part is extracted (https://npm.flatt.tech:8443/path →
+# npm.flatt.tech).
+sakimori proxy start \
+    --npm-registry npm.flatt.tech \
+    --npm-registry 'https://npm.corp.internal:8443/' \
+    --pypi-registry pypi.corp.internal \
+    --nuget-registry nuget.corp.internal
+```
+
+| flag | feeds | canonical default |
+|---|---|---|
+| `--npm-registry`        | npm packument + tarball             | `registry.npmjs.org`        |
+| `--pypi-registry`       | PyPI Warehouse JSON + Simple index  | `pypi.org`                  |
+| `--pypi-files-host`     | PyPI sdist + wheel downloads        | `files.pythonhosted.org`    |
+| `--cargo-registry-host` | crates.io API `/api/v1/crates/…`    | `crates.io`                 |
+| `--cargo-sparse-host`   | crates.io sparse index              | `index.crates.io`           |
+| `--nuget-registry`      | NuGet registration + flat-container | `api.nuget.org`             |
+
+Or pin the same lists in a config file (so a team can ship one
+canonical config and not paste the same flags into every
+invocation):
+
+```toml
+# ~/.config/sakimori/registries.toml
+[registries]
+npm           = ["registry.npmjs.org", "npm.flatt.tech"]
+pypi_index    = ["pypi.org"]
+pypi_files    = ["files.pythonhosted.org"]
+crates        = ["crates.io"]
+crates_sparse = ["index.crates.io"]
+nuget         = ["api.nuget.org"]
+```
+
+```bash
+sakimori proxy start --registries-config ~/.config/sakimori/registries.toml
+```
+
+To lock the proxy to *only* the internal mirrors and reject the
+canonical public hosts, combine with `--network-allow`:
+
+```bash
+sakimori proxy start \
+    --registries-config /etc/sakimori/registries.toml \
+    --network-allow npm.corp.internal \
+    --network-allow pypi.corp.internal
+```
+
+**Non-goals** (intentionally not done):
+- **Path-shape rewriting.** The custom host must serve the canonical
+  registry's URL shape (npm packument + `/<pkg>/-/<pkg>-<ver>.tgz`;
+  PyPI Warehouse JSON / PEP 503/691 Simple; NuGet v3 registration +
+  flat-container; cargo sparse). A mirror that exposes a different
+  layout (e.g. Artifactory at `/artifactory/api/npm/<repo>/`) needs
+  a path-prefix-aware parser variant — not implemented.
+- **`dist.tarball` URL rewriting.** The npm rewriter preserves the
+  upstream's own tarball URL byte-for-byte — mirrors that serve
+  their own tarball URLs keep doing so transparently.
 
 ### `proxy install-ca` / `uninstall-ca`
 
@@ -805,31 +854,36 @@ field to `block`. The cloud-secret-egress preset ships in
 `mode: block` (no cap on `network.deny`).
 
 **Known-IOC workspace scan (`workspace scan-iocs`):** walk a
-workspace and flag files whose existence is a known supply-chain
-compromise marker (e.g. `.claude/setup.mjs` dropped by the
-Shai-Hulud npm worm). Distinct from `workspace diff` — diff catches
-"something changed during the build," scan-iocs catches "this file
-exists at all, which it shouldn't." The catalog is shipped bundled
-in the binary (versioned YAML); override with `--index <file>` for
-private feeds, suppress a triaged false positive with `--allow-id
-<id>`. Exits non-zero on any Error-severity hit so it composes with
-CI gates; Warn-severity hits surface but don't gate.
+workspace and flag files whose path / basename / content matches
+a known supply-chain compromise fingerprint (e.g. `.claude/
+setup.mjs` dropped by the Shai-Hulud npm worm; basename `.npmrc`
+for token-exfil; content needles for `webhook.site`,
+`discord.com/api/webhooks/`, `requestbin.com`). Distinct from
+`workspace diff` — diff catches "something changed during the
+build," scan-iocs catches "this file exists at all, which it
+shouldn't." The catalog is bundled in the binary (versioned;
+`CATALOG_VERSION` in `sakimori-core::iocs`). Exits non-zero on
+any High-severity hit; `--strict` escalates Medium-severity hits
+to exit 1 too. Same skip list as `workspace snapshot` (`.git`,
+`node_modules`, `target`, …); extend with `--skip <NAME>`.
 
 ```bash
 sakimori workspace scan-iocs $GITHUB_WORKSPACE
-sakimori workspace scan-iocs . --json
+sakimori workspace scan-iocs . --format json
+sakimori workspace scan-iocs . --strict --skip my-build-artefact
 ```
 
-**Refreshing the IOC catalog:** `sakimori iocs update <url>` fetches
-a refreshed catalog (same YAML schema) from an upstream feed,
-validates it, and atomically writes it to
-`~/.sakimori/iocs.yml` (override `--output`). The scanner picks
-the override up automatically on the next run. Run
-`sakimori iocs where` to confirm which catalog is in effect; a
-corrupted override is detected and the scanner falls back to the
-bundled copy with a loud warning, never silently. Validation runs
-before the atomic rename — a malformed feed cannot clobber a
-working override on disk.
+`scan-iocs` is also wired into `workspace diff`, `sakimori run
+--snapshot-workspace`, and `sakimori daemon start
+--workspace-baseline …` automatically — every added / modified
+path in the drift report is scanned against the same catalog and
+the findings land in the JSON log under `workspace_iocs`. A
+High-severity hit forces exit 1 in any mode (Audit too); `--allow-
+drift` does not suppress it.
+
+The bundled catalog is the only source today. A signed-YAML
+refresh path (`sakimori iocs update`) is a roadmap item — see
+CLAUDE.md Roadmap #18 for the planned surface.
 
 The HTML report includes:
 - verdict (ALLOW / DENY), kind, pid, comm
@@ -1259,9 +1313,12 @@ printed `security add-trusted-cert …` line and run it yourself.
 2. Is `HTTPS_PROXY` set in **this** shell? (install-gate only
    applies to new shells.) `echo $HTTPS_PROXY`
 3. Is the package being downloaded from a host sakimori
-   intercepts? Only crates.io, registry.npmjs.org,
-   files.pythonhosted.org, pypi.org, api.nuget.org are intercepted.
-   Custom registries pass through unchanged.
+   intercepts? By default only the canonical public hosts
+   (`registry.npmjs.org`, `pypi.org`, `files.pythonhosted.org`,
+   `crates.io`, `index.crates.io`, `api.nuget.org`) are watched.
+   Internal mirrors / replacement registries need to be added —
+   see [Custom / internal registries](#custom--internal-registries)
+   for the `--npm-registry` / `--registries-config` flags.
 
 ### Container / remote Docker usage
 
@@ -1290,17 +1347,14 @@ Honest assessment. Full details in [CLAUDE.md](CLAUDE.md).
   which is already meaningful (npm refuses to attach it unless
   the publish came from OIDC-authenticated CI) but the bundle
   itself isn't cryptographically verified.
-<!-- DNS round-robin drift: addressed by `--dns-refresh-interval <secs>`
-     on `sakimori run`. Re-resolves hostname rules on the given
-     interval and additively inserts any newly-observed IPs into the
-     eBPF maps. Default is 0 (off); set to 60–300 for long-running
-     CDN-heavy jobs. Entries are never removed, so increasing the
-     rate is safe and won't kill active connections. -->
 - **CDN IP rotation across long runs**: handled by
   `sakimori run --dns-refresh-interval <secs>`, which re-resolves
   `network.allow` / `network.deny` hostnames every N seconds and
-  additively inserts new IPs. Off by default (0); 60–300 is typical
-  for CI jobs that run for hours behind round-robin DNS.
+  additively inserts new IPs into the eBPF maps. Default `15`
+  (seconds); set `0` to disable, raise to 60–300 for very long
+  CI jobs behind round-robin DNS. Entries are never removed once
+  written, so increasing the rate is safe and won't kill active
+  connections.
 
 ### Linux supervised run
 

--- a/crates/sakimori-proxy/tests/custom_registries_e2e.rs
+++ b/crates/sakimori-proxy/tests/custom_registries_e2e.rs
@@ -1,0 +1,435 @@
+//! End-to-end integration: every layer that the custom-registry
+//! feature relies on, exercised together against synthetic
+//! upstream responses.
+//!
+//! The unit tests in `src/` cover each module in isolation.
+//! This file proves the modules compose for the use case the
+//! README + CLAUDE.md document: a team adds an internal mirror
+//! (Verdaccio, Takumi Guard, …) via TOML or CLI flag, and every
+//! rewriter / lifecycle gate / dispatch path treats that mirror
+//! identically to the canonical public host.
+//!
+//! Boundaries crossed in each test:
+//!
+//! 1. `registries.rs`     — TOML parse + merge
+//! 2. `parser.rs`         — `parsers_from_hosts` + `parse_for_host`
+//! 3. `rewrite_*.rs`      — packument / JSON API / simple / registration / sparse
+//!
+//! If a future change breaks the wiring between any two of those
+//! (e.g. parser stops being host-aware, registries struct grows a
+//! field rewriters don't read, …) these tests fail.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use sakimori_core::deps::Ecosystem;
+use sakimori_proxy::parser::{ParseResult, parse_for_host, parsers_from_hosts};
+use sakimori_proxy::registries::RegistryHosts;
+use sakimori_proxy::{
+    NpmRewriteStats, NugetRewriteStats, PypiRewriteStats, RewriteStats, rewrite_crates_index_jsonl,
+    rewrite_npm_packument, rewrite_nuget_flatcontainer, rewrite_nuget_registration,
+    rewrite_pypi_json_api, rewrite_pypi_simple_json,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tmp_toml(tag: &str, body: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let p = std::env::temp_dir().join(format!(
+        "sakimori-e2e-{tag}-{}-{nanos}.toml",
+        std::process::id()
+    ));
+    std::fs::write(&p, body).unwrap();
+    p
+}
+
+/// `now` for the synthetic packument fixtures — chosen so the
+/// 30-day threshold cleanly slices the "young" / "old" half.
+fn frozen_now() -> DateTime<Utc> {
+    "2026-05-18T00:00:00Z".parse().unwrap()
+}
+
+fn min_age_30d() -> Duration {
+    Duration::from_secs(30 * 86_400)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1+2 — config → parser routing for every ecosystem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn toml_config_routes_custom_hosts_for_every_ecosystem() {
+    let p = tmp_toml(
+        "toml-routes",
+        r#"
+[registries]
+npm           = ["npm.corp.internal"]
+pypi_index    = ["pypi.corp.internal"]
+pypi_files    = ["files.corp.internal"]
+crates        = ["crates.corp.internal"]
+crates_sparse = ["sparse.corp.internal"]
+nuget         = ["nuget.corp.internal"]
+"#,
+    );
+    let file_hosts = RegistryHosts::load_toml(&p).unwrap();
+    let _ = std::fs::remove_file(&p);
+    let merged = RegistryHosts::merge(Some(file_hosts), RegistryHosts::default());
+    let parsers = parsers_from_hosts(&merged);
+
+    // npm packument (Metadata) + tarball (Pinned) under custom host.
+    assert_eq!(
+        parse_for_host(&parsers, "npm.corp.internal", "/lodash"),
+        ParseResult::Metadata
+    );
+    let r = parse_for_host(
+        &parsers,
+        "npm.corp.internal",
+        "/lodash/-/lodash-4.17.21.tgz",
+    );
+    assert!(matches!(
+        r,
+        ParseResult::Pinned {
+            ecosystem: Ecosystem::Npm,
+            ..
+        }
+    ));
+
+    // PyPI metadata host returns Metadata; files host pins.
+    assert_eq!(
+        parse_for_host(&parsers, "pypi.corp.internal", "/pypi/requests/json"),
+        ParseResult::Metadata
+    );
+    let r = parse_for_host(
+        &parsers,
+        "files.corp.internal",
+        "/packages/aa/bb/cc/requests-2.31.0.tar.gz",
+    );
+    assert!(matches!(
+        r,
+        ParseResult::Pinned {
+            ecosystem: Ecosystem::Pypi,
+            ..
+        }
+    ));
+
+    // cargo download endpoint + sparse index.
+    let r = parse_for_host(
+        &parsers,
+        "crates.corp.internal",
+        "/api/v1/crates/serde/1.0.0/download",
+    );
+    assert!(matches!(
+        r,
+        ParseResult::Pinned {
+            ecosystem: Ecosystem::Crates,
+            ..
+        }
+    ));
+    assert_eq!(
+        parse_for_host(&parsers, "sparse.corp.internal", "/1/s/serde"),
+        ParseResult::Metadata
+    );
+
+    // NuGet flat-container .nupkg.
+    let r = parse_for_host(
+        &parsers,
+        "nuget.corp.internal",
+        "/v3-flatcontainer/serilog/3.0.0/serilog.3.0.0.nupkg",
+    );
+    assert!(matches!(
+        r,
+        ParseResult::Pinned {
+            ecosystem: Ecosystem::Nuget,
+            ..
+        }
+    ));
+
+    // The canonical hosts ALSO still route correctly — the merge
+    // must not have stripped them out.
+    for (host, path) in [
+        ("registry.npmjs.org", "/lodash/-/lodash-4.17.21.tgz"),
+        ("files.pythonhosted.org", "/x/y/z/requests-2.31.0.tar.gz"),
+        ("crates.io", "/api/v1/crates/serde/1.0.0/download"),
+    ] {
+        assert!(
+            matches!(
+                parse_for_host(&parsers, host, path),
+                ParseResult::Pinned { .. }
+            ),
+            "{host} {path} should remain Pinned after merge"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3 — rewriters: identical behaviour on canonical and custom
+// hosts.  These prove the rewrite stage is host-agnostic: it gets a
+// body, not a hostname.  The host-membership check happens in the
+// dispatcher, and we tested that in Layer 1+2.  Together this is the
+// "what if I point cargo at a custom mirror?" end-to-end story.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn npm_packument_rewrite_drops_young_versions_regardless_of_host() {
+    // Body is the only input — `rewrite_npm_packument` doesn't
+    // know about hosts, which is precisely why the per-host
+    // configuration above is the load-bearing piece for custom
+    // registries.  This test pins that property.
+    let packument = serde_json::json!({
+        "name": "demo",
+        "dist-tags": { "latest": "1.0.1" },
+        "versions": {
+            "1.0.0": { "name": "demo", "version": "1.0.0", "dist": {} },
+            "1.0.1": { "name": "demo", "version": "1.0.1", "dist": {} },
+        },
+        "time": {
+            // older than 30d → kept
+            "1.0.0": "2026-01-01T00:00:00Z",
+            // 5d old → dropped
+            "1.0.1": "2026-05-13T00:00:00Z",
+        }
+    });
+    let body = serde_json::to_vec(&packument).unwrap();
+    let (rewritten, stats): (Vec<u8>, NpmRewriteStats) =
+        rewrite_npm_packument(&body, min_age_30d(), frozen_now());
+    assert_eq!(stats.kept, 1);
+    assert_eq!(stats.dropped, 1);
+    let parsed: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+    let versions = parsed["versions"].as_object().unwrap();
+    assert!(versions.contains_key("1.0.0"));
+    assert!(!versions.contains_key("1.0.1"));
+    // dist-tag retargeted to the surviving newest.
+    assert_eq!(parsed["dist-tags"]["latest"], "1.0.0");
+}
+
+#[test]
+fn pypi_json_api_rewrite_drops_young_releases() {
+    let body = serde_json::json!({
+        "info": { "name": "demo", "version": "1.0.1" },
+        "releases": {
+            "1.0.0": [{
+                "upload_time_iso_8601": "2026-01-01T00:00:00Z",
+                "filename": "demo-1.0.0.tar.gz",
+                "url": "https://files.pythonhosted.org/demo-1.0.0.tar.gz",
+            }],
+            "1.0.1": [{
+                "upload_time_iso_8601": "2026-05-13T00:00:00Z",
+                "filename": "demo-1.0.1.tar.gz",
+                "url": "https://files.pythonhosted.org/demo-1.0.1.tar.gz",
+            }],
+        }
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let (rewritten, stats): (Vec<u8>, PypiRewriteStats) =
+        rewrite_pypi_json_api(&bytes, min_age_30d(), frozen_now());
+    assert!(stats.dropped >= 1);
+    let parsed: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+    let releases = parsed["releases"].as_object().unwrap();
+    assert!(releases.contains_key("1.0.0"));
+    assert!(!releases.contains_key("1.0.1"));
+}
+
+#[test]
+fn pypi_simple_json_rewrite_strips_young_files() {
+    let body = serde_json::json!({
+        "name": "demo",
+        "files": [
+            {
+                "filename": "demo-1.0.0.tar.gz",
+                "url": "https://files.pythonhosted.org/demo-1.0.0.tar.gz",
+                "upload-time": "2026-01-01T00:00:00Z",
+                "hashes": {}
+            },
+            {
+                "filename": "demo-1.0.1.tar.gz",
+                "url": "https://files.pythonhosted.org/demo-1.0.1.tar.gz",
+                "upload-time": "2026-05-13T00:00:00Z",
+                "hashes": {}
+            }
+        ],
+        "versions": ["1.0.0", "1.0.1"]
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let (rewritten, stats) = rewrite_pypi_simple_json(&bytes, min_age_30d(), frozen_now());
+    assert_eq!(stats.dropped, 1);
+    assert_eq!(stats.kept, 1);
+    let parsed: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+    let files: Vec<&str> = parsed["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["filename"].as_str().unwrap())
+        .collect();
+    assert_eq!(files, vec!["demo-1.0.0.tar.gz"]);
+}
+
+#[test]
+fn nuget_registration_rewrite_drops_young_leaves() {
+    // Minimal registration index shape: a single page with two
+    // catalog leaves.
+    let body = serde_json::json!({
+        "count": 1,
+        "items": [{
+            "count": 2,
+            "items": [
+                {
+                    "catalogEntry": {
+                        "id": "Demo.Pkg",
+                        "version": "1.0.0",
+                        "published": "2026-01-01T00:00:00Z"
+                    }
+                },
+                {
+                    "catalogEntry": {
+                        "id": "Demo.Pkg",
+                        "version": "1.0.1",
+                        "published": "2026-05-13T00:00:00Z"
+                    }
+                }
+            ]
+        }]
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let (rewritten, stats): (Vec<u8>, NugetRewriteStats) =
+        rewrite_nuget_registration(&bytes, min_age_30d(), frozen_now());
+    assert_eq!(stats.dropped, 1);
+    assert_eq!(stats.kept, 1);
+    let parsed: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+    let page0 = &parsed["items"][0];
+    assert_eq!(page0["count"], 1);
+    let leaves = page0["items"].as_array().unwrap();
+    assert_eq!(leaves.len(), 1);
+    assert_eq!(leaves[0]["catalogEntry"]["version"], "1.0.0");
+}
+
+#[test]
+fn nuget_flatcontainer_rewrite_uses_oracle_for_publish_times() {
+    // Flat-container index carries no inline times — the rewriter
+    // gets a closure that's normally backed by an out-of-band
+    // lookup to the registration endpoint.  Synthetic oracle here.
+    let body = serde_json::json!({
+        "versions": ["1.0.0", "1.0.1", "1.0.2"]
+    });
+    let bytes = serde_json::to_vec(&body).unwrap();
+    let publish_times: std::collections::HashMap<&str, DateTime<Utc>> = [
+        ("1.0.0", "2026-01-01T00:00:00Z".parse().unwrap()),
+        ("1.0.1", "2026-05-13T00:00:00Z".parse().unwrap()),
+        // 1.0.2 deliberately omitted → fail-open keeps it.
+    ]
+    .into_iter()
+    .collect();
+    let (rewritten, stats) =
+        rewrite_nuget_flatcontainer(&bytes, min_age_30d(), frozen_now(), |v| {
+            publish_times.get(v).copied()
+        });
+    assert_eq!(stats.dropped, 1);
+    let parsed: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+    let versions: Vec<&str> = parsed["versions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(versions, vec!["1.0.0", "1.0.2"]);
+}
+
+#[test]
+fn crates_sparse_jsonl_drops_young_lines() {
+    // Sparse-index line per version, newline-delimited JSON.
+    let old = serde_json::json!({
+        "name": "demo",
+        "vers": "1.0.0",
+        "deps": [],
+        "cksum": "abc",
+        "features": {},
+        "yanked": false
+    });
+    let young = serde_json::json!({
+        "name": "demo",
+        "vers": "1.0.1",
+        "deps": [],
+        "cksum": "def",
+        "features": {},
+        "yanked": false
+    });
+    let body = format!("{old}\n{young}\n");
+
+    struct FakeOracle;
+    impl sakimori_proxy::AgeOracle for FakeOracle {
+        fn published(
+            &self,
+            _eco: Ecosystem,
+            _name: &str,
+            version: &str,
+        ) -> anyhow::Result<Option<DateTime<Utc>>> {
+            Ok(match version {
+                "1.0.0" => Some("2026-01-01T00:00:00Z".parse().unwrap()),
+                "1.0.1" => Some("2026-05-13T00:00:00Z".parse().unwrap()),
+                _ => None,
+            })
+        }
+    }
+    let decider = sakimori_proxy::Decider {
+        oracle: Box::new(FakeOracle) as Box<dyn sakimori_proxy::AgeOracle>,
+        min_age: min_age_30d(),
+        fail_on_missing: false,
+        known_bad: None,
+        typosquat: None,
+    };
+    let (rewritten, stats): (Vec<u8>, RewriteStats) =
+        rewrite_crates_index_jsonl(body.as_bytes(), &decider, frozen_now());
+    assert_eq!(stats.dropped, 1);
+    assert_eq!(stats.kept, 1);
+    let s = std::str::from_utf8(&rewritten).unwrap();
+    assert!(s.contains("\"vers\":\"1.0.0\""));
+    assert!(!s.contains("\"vers\":\"1.0.1\""));
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1+2 negative tests — disabling an ecosystem in TOML must
+// make canonical traffic invisible, and unknown hosts must be Unknown.
+// These guard against accidentally re-introducing hardcoded host
+// checks downstream of the registries config.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_npm_section_in_toml_disables_npm_routing() {
+    let p = tmp_toml(
+        "no-npm",
+        r#"
+[registries]
+npm = []
+"#,
+    );
+    let cfg = RegistryHosts::load_toml(&p).unwrap();
+    let _ = std::fs::remove_file(&p);
+    let ps = parsers_from_hosts(&cfg);
+    assert_eq!(
+        parse_for_host(&ps, "registry.npmjs.org", "/lodash/-/lodash-4.17.21.tgz"),
+        ParseResult::Unknown
+    );
+    // Other ecosystems still default — only npm was emptied.
+    assert!(matches!(
+        parse_for_host(&ps, "crates.io", "/api/v1/crates/serde/1.0.0/download"),
+        ParseResult::Pinned { .. }
+    ));
+}
+
+#[test]
+fn unknown_host_is_unknown_even_when_path_looks_canonical() {
+    let cfg = RegistryHosts::default();
+    let ps = parsers_from_hosts(&cfg);
+    assert_eq!(
+        parse_for_host(
+            &ps,
+            "evil.example",
+            "/v3-flatcontainer/x/1.0.0/x.1.0.0.nupkg"
+        ),
+        ParseResult::Unknown,
+    );
+}

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -870,20 +870,31 @@ pub enum DepsCommand {
     /// Re-hash the package manager's local cache against the
     /// `integrity:` fields in a lockfile. Catches the *content* half
     /// of TanStack-style GHA cache poisoning: cache restored bytes
-    /// that don't match what the lockfile pinned. MVP: npm cacache
-    /// only (default root `~/.npm/_cacache`).
+    /// that don't match what the lockfile pinned. Lockfile flavour
+    /// is auto-detected by basename — `package-lock.json` (npm
+    /// cacache), `pnpm-lock.yaml` (pnpm store v3; v11 SQLite
+    /// reported as Unsupported), or `Cargo.lock` (cargo registry
+    /// `.crate` cache). Default cache root per ecosystem is the
+    /// canonical per-OS location; override with `--cache`.
     #[command(name = "verify-cache")]
     VerifyCache(DepsVerifyCacheArgs),
 }
 
 #[derive(Debug, Parser)]
 pub struct DepsVerifyCacheArgs {
-    /// Lockfile to read integrity hashes from. MVP supports
-    /// `package-lock.json` (npm v2/v3).
+    /// Lockfile to read integrity hashes from. Supported (auto-
+    /// detected by basename): `package-lock.json` (npm v2/v3),
+    /// `pnpm-lock.yaml` (v6–v10; v11+ SQLite stores are detected
+    /// and surface as Unsupported rather than silently passing),
+    /// `Cargo.lock` (any cargo-generated lockfile).
     #[arg(long, short = 'l')]
     pub lockfile: PathBuf,
-    /// Path to the package manager's cache root. Defaults to
-    /// `~/.npm/_cacache` (npm cacache layout).
+    /// Path to the package manager's cache root. Defaults per
+    /// ecosystem: `~/.npm/_cacache` (npm); `~/.local/share/pnpm/
+    /// store/v3` on Linux, `~/Library/pnpm/store/v3` on macOS,
+    /// `%LOCALAPPDATA%\pnpm\store\v3` on Windows (pnpm);
+    /// `$CARGO_HOME/registry/cache` — typically `~/.cargo/registry/
+    /// cache` (cargo).
     #[arg(long)]
     pub cache: Option<PathBuf>,
     #[arg(long, value_enum, default_value = "text")]


### PR DESCRIPTION
## Summary

Two-part follow-up to [#91](https://github.com/bokuweb/sakimori/pull/91) (custom registries):

### README audit — make sure nothing documented is silently broken

- **`proxy start` flag table** was missing every flag added since v0.20 (typosquat, install-log, OTLP, lifecycle gate, custom-registry). Replaced the bespoke table with a grouped category summary that points at `--help` for the canonical list, then adds a new **Custom / internal registries** subsection covering `--*-registry` / `--registries-config` end-to-end (CLI, TOML, lockdown via `--network-allow`, non-goals).
- **`workspace scan-iocs`** advertised `--allow-id`, `--index`, and `--json` flags plus `sakimori iocs update <url>` / `sakimori iocs where` subcommands that have never existed. Rewrote to the actually-shipped surface (`--format text|json`, `--skip`, `--strict`) and noted catalog-refresh as a roadmap item.
- **`run --dns-refresh-interval`** said "Off by default (0)"; actual default is `15` seconds. Fixed.
- **Troubleshooting** "Custom registries pass through unchanged" was outdated since [#91](https://github.com/bokuweb/sakimori/pull/91). Now points at the new Custom registries section.

### CLI `--help` accuracy

`deps verify-cache --help` still advertised itself as "MVP: npm cacache only" even though pnpm v3 + cargo registry support shipped several releases ago. Updated `DepsVerifyCacheArgs` doc comments to reflect actual ecosystem support + per-OS default cache root.

### Cross-module integration tests

New `crates/sakimori-proxy/tests/custom_registries_e2e.rs` exercises every layer the custom-registry feature relies on together — TOML loader → `RegistryHosts::merge` → `parsers_from_hosts` → `parse_for_host` → the rewriter functions for every ecosystem (npm packument, PyPI JSON+Simple, NuGet registration+flat-container, cargo sparse JSONL).

9 new tests:

- TOML config routes a custom mirror host to the correct parser for every ecosystem (npm / pypi-index / pypi-files / crates / crates-sparse / nuget) AND the canonical hosts still resolve after the merge.
- Each rewriter (npm/pypi-json/pypi-simple/nuget-reg/nuget-flat/crates-sparse) drops young versions correctly on synthetic bodies — proves rewriters stay host-agnostic so the dispatcher is the only thing that needs to learn new hosts.
- Empty \`npm = []\` in TOML disables npm routing while leaving other ecosystems intact.
- Unknown host with a canonical-shaped path stays \`Unknown\`, not silently routed.
- Custom NuGet flat-container uses the user-supplied oracle closure (the path the real proxy backs with an out-of-band registration lookup).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 614 total, all green. Sakimori-proxy: 274 unit + 9 integration.
- [x] `sakimori --help` / `sakimori proxy start --help` / `sakimori deps verify-cache --help` re-read against the README rewrite — every flag described in the README is now also in the binary's `--help` output.