### PR TITLE
test(proxy): lifecycle strip roundtrip + HTTPS MITM e2e + extra upstream roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,15 +1968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,7 +2096,6 @@ dependencies = [
  "proptest",
  "rcgen",
  "rustls 0.23.40",
- "rustls-pemfile",
  "sakimori-core",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,10 +2099,13 @@ dependencies = [
  "http",
  "http-body-util",
  "hudsucker",
+ "hyper-rustls",
+ "hyper-util",
  "log",
  "proptest",
  "rcgen",
  "rustls 0.23.40",
+ "rustls-pemfile",
  "sakimori-core",
  "semver",
  "serde",
@@ -2103,8 +2115,10 @@ dependencies = [
  "tar",
  "time",
  "tokio",
+ "tokio-rustls",
  "toml",
  "ureq",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ sakimori proxy start [OPTIONS]
 | **Egress allow-list** | `--network-allow <HOST>` (repeatable), `--network-allow-file <PATH>` | Default-deny hostname filter. Patterns: `host.example.com` (exact) or `*.example.com` (any subdomain, excludes apex). Off by default. |
 | **Install log + advisories** | `--no-install-log`, `--install-log <PATH>` | The local-first append-only audit log feeding `sakimori advisories scan`. On by default at `~/.sakimori/installs.jsonl`. |
 | **OTLP fan-out** | `--otlp-endpoint <URL>`, `--otlp-header <K=V>` (repeatable) | Mirror every allowed install as an OTLP/HTTP `LogRecord` to Datadog / Honeycomb / Loki / a self-run otel-collector. |
-| **Custom registries** | `--npm-registry`, `--pypi-registry`, `--pypi-files-host`, `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry` (all repeatable), `--registries-config <FILE>` | Teach the proxy about internal mirrors / replacement registries so the rewriters + lifecycle gate fire on their traffic too. See the [Custom registries](#custom--internal-registries) subsection below. |
+| **Custom registries** | `--npm-registry`, `--pypi-registry`, `--pypi-files-host`, `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry` (all repeatable), `--registries-config <FILE>`, `--upstream-ca-file <PATH>` (repeatable) | Teach the proxy about internal mirrors / replacement registries so the rewriters + lifecycle gate fire on their traffic too. `--upstream-ca-file` adds a PEM CA to the upstream rustls trust store for mirrors behind a private CA. See the [Custom registries](#custom--internal-registries) subsection below. |
 
 **First-run side effect**: generates a self-signed root CA at the
 config dir and prints the OS-specific trust command. Subsequent runs
@@ -382,6 +382,19 @@ sakimori proxy start \
     --registries-config /etc/sakimori/registries.toml \
     --network-allow npm.corp.internal \
     --network-allow pypi.corp.internal
+```
+
+If the internal mirror's TLS chain is signed by a **private CA**
+not in the `webpki-roots`-shipped trust store, pass each CA PEM
+file with `--upstream-ca-file` (repeatable). Without this the
+upstream handshake fails with `UnknownIssuer` even when the
+hostname is on `--registries-config`:
+
+```bash
+sakimori proxy start \
+    --registries-config /etc/sakimori/registries.toml \
+    --upstream-ca-file /etc/ssl/corp-root-ca.pem \
+    --upstream-ca-file /etc/ssl/intermediate.pem
 ```
 
 **Non-goals** (intentionally not done):

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -44,5 +44,20 @@ tar = "0.4"
 flate2 = "1"
 toml = { workspace = true }
 
+# Custom upstream TLS client for `extra_upstream_roots`. Versions
+# pinned to match what hudsucker 0.22 itself uses internally — the
+# `ClientConfig` types these construct must be the same rustls
+# version hudsucker's connector expects (rustls 0.22 via
+# tokio-rustls). We reuse `hudsucker::rustls` for the rustls types
+# so we don't add a second `rustls` direct dep.
+hyper-rustls = { version = "0.26", default-features = false, features = ["http1", "logging", "ring", "tls12", "webpki-tokio"] }
+hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http1", "tokio"] }
+webpki-roots = "0.26"
+rustls-pemfile = "2"
+
 [dev-dependencies]
 proptest = { workspace = true }
+# Mock HTTPS upstream for proxy_https_e2e.rs. tokio-rustls 0.25
+# matches hudsucker's internal rustls 0.22 pin (same TLS types
+# both ends of the proxy must speak).
+tokio-rustls = { version = "0.25", default-features = false, features = ["logging", "tls12", "ring"] }

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -53,7 +53,11 @@ toml = { workspace = true }
 hyper-rustls = { version = "0.26", default-features = false, features = ["http1", "logging", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http1", "tokio"] }
 webpki-roots = "0.26"
-rustls-pemfile = "2"
+# NB: PEM parsing uses `rustls_pki_types::pem::PemObject` (reached
+# via `hudsucker::rustls::pki_types`). The `rustls-pemfile` crate
+# would be the obvious dep but it was archived in August 2025
+# (RUSTSEC-2025-0134) and its maintainers point users at
+# rustls-pki-types' built-in `PemObject` trait.
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -142,6 +142,16 @@ pub struct ProxyConfig {
     /// rewriters / lifecycle gate fire on internal-mirror traffic.
     /// See [`RegistryHosts`].
     pub registries: RegistryHosts,
+    /// PEM-encoded CA certificate files to add to the rustls
+    /// **upstream** trust store. Needed when the proxy forwards to
+    /// an internal mirror (Verdaccio, Artifactory, GitHub Packages
+    /// internal, Takumi Guard, …) whose TLS chain is signed by a
+    /// private CA that webpki-roots doesn't carry. Empty (default)
+    /// preserves the original `with_rustls_client()` behaviour
+    /// byte-for-byte. Each file is parsed at startup; a missing
+    /// file or a PEM that contains zero certs is a hard error so
+    /// the user knows the trust hole was never closed.
+    pub extra_upstream_roots: Vec<std::path::PathBuf>,
 }
 
 impl ProxyConfig {
@@ -171,6 +181,7 @@ impl ProxyConfig {
             lifecycle_strip_limits: crate::lifecycle::StripLimits::default(),
             lifecycle_strip_cache_dir: None,
             registries: RegistryHosts::default(),
+            extra_upstream_roots: Vec::new(),
         })
     }
 }
@@ -361,15 +372,115 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
     };
 
     // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
-    let proxy = Proxy::builder()
-        .with_addr(cfg.listen)
-        .with_rustls_client()
-        .with_ca(authority)
-        .with_http_handler(handler)
+    //
+    // Branch on whether the user supplied any extra upstream roots.
+    // The empty path stays on hudsucker's built-in
+    // `with_rustls_client()` so we don't perturb the default code
+    // path. With extras, we build the same connector shape
+    // (`https_or_http()` + `enable_http1()` +
+    // `http1_title_case_headers(true)` +
+    // `http1_preserve_header_case(true)`) but with an enlarged
+    // root store. HTTP/2 is deliberately NOT enabled — hudsucker
+    // only enables it under its own `http2` feature, which this
+    // crate doesn't opt into. Keeping HTTP/1-only matches today's
+    // behaviour byte-for-byte.
+    if cfg.extra_upstream_roots.is_empty() {
+        let proxy = Proxy::builder()
+            .with_addr(cfg.listen)
+            .with_rustls_client()
+            .with_ca(authority)
+            .with_http_handler(handler)
+            .build();
+        log::info!("sakimori-proxy listening on {}", cfg.listen);
+        proxy.start().await.context("proxy.start()")
+    } else {
+        let client = build_upstream_client_with_extra_roots(&cfg.extra_upstream_roots)?;
+        let proxy = Proxy::builder()
+            .with_addr(cfg.listen)
+            .with_client(client)
+            .with_ca(authority)
+            .with_http_handler(handler)
+            .build();
+        log::info!(
+            "sakimori-proxy listening on {} (with {} extra upstream root(s))",
+            cfg.listen,
+            cfg.extra_upstream_roots.len(),
+        );
+        proxy.start().await.context("proxy.start()")
+    }
+}
+
+/// Build a hyper client whose rustls config trusts the standard
+/// webpki-roots PLUS each PEM file in `extras`. Used by `run()`
+/// when `ProxyConfig.extra_upstream_roots` is non-empty.
+///
+/// Mirrors hudsucker 0.22's `with_rustls_client()` connector
+/// shape (HTTP/1 only, title-case + preserve-case headers) so the
+/// only behavioural delta vs the default path is the root store.
+fn build_upstream_client_with_extra_roots(
+    extras: &[std::path::PathBuf],
+) -> Result<
+    hyper_util::client::legacy::Client<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+        hudsucker::Body,
+    >,
+> {
+    // hudsucker re-exports rustls 0.22 via tokio-rustls. Using
+    // that re-export keeps us off the workspace's direct
+    // `rustls 0.23` dep — `hyper-rustls 0.26` won't accept types
+    // from a different rustls crate compilation unit.
+    use hudsucker::rustls::{ClientConfig, RootCertStore};
+
+    // `webpki_roots::TLS_SERVER_ROOTS` is `&[TrustAnchor<'static>]`
+    // and `RootCertStore: Extend<TrustAnchor<'static>>`, so this
+    // populates the store with every webpki root in one shot.
+    let mut roots = RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let mut added = 0usize;
+    for path in extras {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("reading --upstream-ca-file {}", path.display()))?;
+        let mut cursor = std::io::Cursor::new(&bytes);
+        let mut file_added = 0usize;
+        for cert in rustls_pemfile::certs(&mut cursor) {
+            let cert = cert.with_context(|| format!("parsing PEM cert in {}", path.display()))?;
+            roots
+                .add(cert)
+                .with_context(|| format!("adding cert from {}", path.display()))?;
+            file_added += 1;
+            added += 1;
+        }
+        if file_added == 0 {
+            anyhow::bail!(
+                "--upstream-ca-file {} contained zero PEM certificates",
+                path.display()
+            );
+        }
+    }
+    log::info!(
+        "upstream trust store: {} webpki root(s) + {} extra cert(s) from {} file(s)",
+        webpki_roots::TLS_SERVER_ROOTS.len(),
+        added,
+        extras.len(),
+    );
+
+    let tls = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let https = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(tls)
+        .https_or_http()
+        .enable_http1()
         .build();
 
-    log::info!("sakimori-proxy listening on {}", cfg.listen);
-    proxy.start().await.context("proxy.start()")
+    Ok(
+        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+            .http1_title_case_headers(true)
+            .http1_preserve_header_case(true)
+            .build(https),
+    )
 }
 
 fn rcgen_cert_from_pem(pem: &[u8]) -> Result<rcgen::Certificate> {

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -429,6 +429,8 @@ fn build_upstream_client_with_extra_roots(
     // that re-export keeps us off the workspace's direct
     // `rustls 0.23` dep — `hyper-rustls 0.26` won't accept types
     // from a different rustls crate compilation unit.
+    use hudsucker::rustls::pki_types::CertificateDer;
+    use hudsucker::rustls::pki_types::pem::PemObject;
     use hudsucker::rustls::{ClientConfig, RootCertStore};
 
     // `webpki_roots::TLS_SERVER_ROOTS` is `&[TrustAnchor<'static>]`
@@ -441,10 +443,15 @@ fn build_upstream_client_with_extra_roots(
     for path in extras {
         let bytes = std::fs::read(path)
             .with_context(|| format!("reading --upstream-ca-file {}", path.display()))?;
-        let mut cursor = std::io::Cursor::new(&bytes);
         let mut file_added = 0usize;
-        for cert in rustls_pemfile::certs(&mut cursor) {
-            let cert = cert.with_context(|| format!("parsing PEM cert in {}", path.display()))?;
+        // PEM parsing via `rustls_pki_types::pem::PemObject` —
+        // the `rustls-pemfile` crate was archived in August 2025
+        // (RUSTSEC-2025-0134) and its maintainers redirect users
+        // here. `CertificateDer::pem_slice_iter` yields one
+        // owned cert per BEGIN/END CERTIFICATE block.
+        for cert in CertificateDer::pem_slice_iter(&bytes) {
+            let cert =
+                cert.map_err(|e| anyhow::anyhow!("parsing PEM cert in {}: {e}", path.display()))?;
             roots
                 .add(cert)
                 .with_context(|| format!("adding cert from {}", path.display()))?;

--- a/crates/sakimori-proxy/tests/lifecycle_strip_roundtrip.rs
+++ b/crates/sakimori-proxy/tests/lifecycle_strip_roundtrip.rs
@@ -1,0 +1,594 @@
+//! Tarball roundtrip e2e for `--lifecycle-policy strip`.
+//!
+//! Unit tests in `src/lifecycle.rs::tests` cover single-entry happy
+//! path, no-op, hash consistency, non-gzip rejection, the compressed
+//! and decompressed caps, the `validate_entry_path` helper in
+//! isolation, and a proptest harness ensuring strip never panics.
+//!
+//! This file fills the gaps those tests can't reach:
+//!
+//! 1. Multi-entry roundtrip with mode + symlink + hardlink +
+//!    directory preservation through the full strip path.
+//! 2. `max_entries` enforced end-to-end.
+//! 3. `max_single_entry_bytes` enforced end-to-end.
+//! 4. `BadPath` end-to-end (the existing test only calls the
+//!    validator helper directly).
+//! 5. Nested `package/node_modules/sub/package.json` invariant
+//!    (only the *root* `package/package.json` is modified;
+//!    enforced at `lifecycle.rs:472` by `components().count() == 2`).
+//! 6. `package.json` top-level key ordering preserved (proves the
+//!    workspace `serde_json` `preserve_order` feature is wired).
+//! 7. `StripOutcome` → `StripCacheEntry::Stripped` coupling contract
+//!    that the proxy uses inline at `proxy.rs:626-635`.
+//!
+//! Plan reviewed + approved by Codex (3 rounds).
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use sakimori_proxy::lifecycle::{StripError, StripLimits, StripOutcome, strip_npm_tarball};
+use sakimori_proxy::strip_cache::StripCacheEntry;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// One entry to pack into a synthetic .tgz. Mirrors the kinds the
+/// strip path actually handles in `rebuild_tar`
+/// (`lifecycle.rs:563-598`): regular files, symlinks, hardlinks,
+/// directories.
+enum Entry<'a> {
+    File {
+        path: &'a str,
+        body: &'a [u8],
+        mode: u32,
+    },
+    Symlink {
+        path: &'a str,
+        target: &'a str,
+    },
+    HardLink {
+        path: &'a str,
+        target: &'a str,
+    },
+    Directory {
+        path: &'a str,
+    },
+    /// Escape hatch for the security tests: write the path bytes
+    /// directly into the tar header's 100-byte `name` field,
+    /// bypassing every validation in `tar::Header::set_path` and
+    /// `tar::Builder::append_data`. Both reject `..` and leading
+    /// `/`. The strip path, however, *does* read this field —
+    /// these tests prove `validate_entry_path` catches what
+    /// arrives in the unprotected wire format.
+    RawPathRegular {
+        raw_path: &'a str,
+        body: &'a [u8],
+    },
+}
+
+fn build_tgz(entries: &[Entry<'_>]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for e in entries {
+            match e {
+                Entry::File { path, body, mode } => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(body.len() as u64);
+                    header.set_mode(*mode);
+                    header.set_entry_type(tar::EntryType::Regular);
+                    header.set_cksum();
+                    builder.append_data(&mut header, path, *body).unwrap();
+                }
+                Entry::Symlink { path, target } => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_entry_type(tar::EntryType::Symlink);
+                    header.set_mode(0o777);
+                    header.set_cksum();
+                    builder.append_link(&mut header, path, target).unwrap();
+                }
+                Entry::HardLink { path, target } => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_entry_type(tar::EntryType::Link);
+                    header.set_mode(0o644);
+                    header.set_cksum();
+                    builder.append_link(&mut header, path, target).unwrap();
+                }
+                Entry::Directory { path } => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_entry_type(tar::EntryType::Directory);
+                    header.set_mode(0o755);
+                    header.set_cksum();
+                    builder
+                        .append_data(&mut header, path, std::io::empty())
+                        .unwrap();
+                }
+                Entry::RawPathRegular { raw_path, body } => {
+                    // Bypass `set_path` (which rejects `..` /
+                    // absolute paths) by writing directly into
+                    // the 100-byte `name` field of the GNU header.
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(body.len() as u64);
+                    header.set_mode(0o644);
+                    header.set_entry_type(tar::EntryType::Regular);
+                    let raw_bytes = raw_path.as_bytes();
+                    assert!(
+                        raw_bytes.len() <= 100,
+                        "raw_path {raw_path} too long for legacy name field"
+                    );
+                    {
+                        let buf = header.as_mut_bytes();
+                        // Clear the first 100 bytes (name field) and
+                        // write the raw path. Leaves the rest of
+                        // the header (mode/size/etc. set above)
+                        // intact.
+                        for b in buf.iter_mut().take(100) {
+                            *b = 0;
+                        }
+                        buf[..raw_bytes.len()].copy_from_slice(raw_bytes);
+                    }
+                    header.set_cksum();
+                    builder.get_mut().write_all(header.as_bytes()).unwrap();
+                    builder.get_mut().write_all(body).unwrap();
+                    // Pad to 512-byte block boundary.
+                    let pad = (512 - (body.len() % 512)) % 512;
+                    if pad > 0 {
+                        builder.get_mut().write_all(&vec![0u8; pad]).unwrap();
+                    }
+                }
+            }
+        }
+        builder.finish().unwrap();
+    }
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    gz.write_all(&tar_bytes).unwrap();
+    gz.finish().unwrap()
+}
+
+struct ExtractedEntry {
+    path: PathBuf,
+    entry_type: tar::EntryType,
+    mode: u32,
+    body: Vec<u8>,
+    link_name: Option<PathBuf>,
+}
+
+fn extract_tgz(bytes: &[u8]) -> Vec<ExtractedEntry> {
+    let dec = GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(dec);
+    let mut out = Vec::new();
+    for entry in archive.entries().unwrap() {
+        let mut e = entry.unwrap();
+        let path = e.path().unwrap().into_owned();
+        let entry_type = e.header().entry_type();
+        let mode = e.header().mode().unwrap_or(0);
+        let link_name = e.header().link_name().unwrap().map(|c| c.into_owned());
+        let mut body = Vec::new();
+        if entry_type.is_file() {
+            e.read_to_end(&mut body).unwrap();
+        }
+        out.push(ExtractedEntry {
+            path,
+            entry_type,
+            mode,
+            body,
+            link_name,
+        });
+    }
+    out
+}
+
+fn find<'a>(entries: &'a [ExtractedEntry], path: &str) -> &'a ExtractedEntry {
+    let target = std::path::Path::new(path);
+    entries
+        .iter()
+        .find(|e| e.path == target)
+        .unwrap_or_else(|| {
+            panic!(
+                "entry {path} not found in: {:?}",
+                entries.iter().map(|e| &e.path).collect::<Vec<_>>()
+            )
+        })
+}
+
+/// Build a `package.json` body whose top-level key order matches
+/// the slice. Relies on `serde_json`'s `preserve_order` feature.
+fn ordered_package_json(pairs: &[(&str, serde_json::Value)]) -> Vec<u8> {
+    let mut map = serde_json::Map::new();
+    for (k, v) in pairs {
+        map.insert((*k).to_string(), v.clone());
+    }
+    serde_json::to_vec(&serde_json::Value::Object(map)).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: multi-entry roundtrip preserving mode + symlink + hardlink
+// + directory
+// ---------------------------------------------------------------------------
+
+#[test]
+fn roundtrip_preserves_structure_modes_and_links() {
+    let index_js = b"console.log('hello');\n";
+    let nested_js = b"export const X = 1;\n";
+    let bin_cli = b"#!/usr/bin/env node\nrequire('../index.js');\n";
+
+    let pkg_json = br#"{"name":"demo","version":"1.0.0","scripts":{"preinstall":"a","install":"b","postinstall":"c","prepare":"d","test":"jest"}}"#;
+
+    let tgz = build_tgz(&[
+        Entry::File {
+            path: "package/package.json",
+            body: pkg_json,
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/index.js",
+            body: index_js,
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/bin/cli",
+            body: bin_cli,
+            mode: 0o755,
+        },
+        Entry::File {
+            path: "package/lib/nested.js",
+            body: nested_js,
+            mode: 0o644,
+        },
+        Entry::Symlink {
+            path: "package/symlink",
+            target: "index.js",
+        },
+        Entry::HardLink {
+            path: "package/hardlink",
+            target: "package/index.js",
+        },
+        Entry::Directory {
+            path: "package/data/",
+        },
+    ]);
+
+    let outcome = strip_npm_tarball(&tgz, &StripLimits::default())
+        .expect("strip should succeed")
+        .expect("strip should report Some — lifecycle scripts present");
+
+    // All 4 lifecycle keys should be reported as stripped.
+    let mut stages = outcome.stripped_stages.clone();
+    stages.sort();
+    assert_eq!(
+        stages,
+        vec!["install", "postinstall", "preinstall", "prepare"]
+    );
+
+    let extracted = extract_tgz(&outcome.bytes);
+
+    // Per-entry preservation: mode, body, link target survive verbatim.
+    let index = find(&extracted, "package/index.js");
+    assert_eq!(index.entry_type, tar::EntryType::Regular);
+    assert_eq!(index.body, index_js);
+    assert_eq!(index.mode & 0o777, 0o644);
+
+    let cli = find(&extracted, "package/bin/cli");
+    assert_eq!(cli.body, bin_cli);
+    assert_eq!(
+        cli.mode & 0o777,
+        0o755,
+        "executable bit must survive the rewrite"
+    );
+
+    let nested = find(&extracted, "package/lib/nested.js");
+    assert_eq!(nested.body, nested_js);
+
+    let sym = find(&extracted, "package/symlink");
+    assert!(sym.entry_type.is_symlink(), "symlink entry-type lost");
+    assert_eq!(
+        sym.link_name.as_deref().and_then(|p| p.to_str()),
+        Some("index.js"),
+        "symlink target must be preserved byte-for-byte"
+    );
+
+    let hard = find(&extracted, "package/hardlink");
+    assert!(hard.entry_type.is_hard_link(), "hardlink entry-type lost");
+    assert_eq!(
+        hard.link_name.as_deref().and_then(|p| p.to_str()),
+        Some("package/index.js"),
+        "hardlink target must be preserved byte-for-byte"
+    );
+
+    let dir = find(&extracted, "package/data/");
+    assert!(dir.entry_type.is_dir(), "directory entry-type lost");
+
+    // Root package.json: lifecycle keys gone, non-lifecycle survives.
+    let root = find(&extracted, "package/package.json");
+    let v: serde_json::Value = serde_json::from_slice(&root.body).unwrap();
+    let scripts = v["scripts"].as_object().expect("scripts object present");
+    for key in ["preinstall", "install", "postinstall", "prepare"] {
+        assert!(
+            !scripts.contains_key(key),
+            "lifecycle key {key} should be stripped from package.json"
+        );
+    }
+    assert_eq!(scripts["test"], "jest", "non-lifecycle script must survive");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: package.json top-level key ordering preserved
+// ---------------------------------------------------------------------------
+
+#[test]
+fn package_json_top_level_key_order_preserved() {
+    let scripts = serde_json::json!({
+        "test": "jest",
+        "postinstall": "foo",
+        "install": "bar",
+    });
+
+    // The full top-level sequence we expect to see preserved
+    // through the strip: scripts is one of seven keys, with
+    // unrelated ones on both sides.
+    let original = ordered_package_json(&[
+        ("name", serde_json::json!("demo")),
+        ("version", serde_json::json!("1.0.0")),
+        ("description", serde_json::json!("the demo")),
+        ("scripts", scripts),
+        ("license", serde_json::json!("MIT")),
+        ("repository", serde_json::json!({"type":"git","url":"x"})),
+        ("dependencies", serde_json::json!({"left-pad":"1.3.0"})),
+    ]);
+
+    let tgz = build_tgz(&[Entry::File {
+        path: "package/package.json",
+        body: &original,
+        mode: 0o644,
+    }]);
+    let outcome = strip_npm_tarball(&tgz, &StripLimits::default())
+        .unwrap()
+        .expect("scripts present → Some");
+
+    let extracted = extract_tgz(&outcome.bytes);
+    let root = find(&extracted, "package/package.json");
+    let v: serde_json::Value = serde_json::from_slice(&root.body).unwrap();
+    let actual_keys: Vec<&str> = v.as_object().unwrap().keys().map(|s| s.as_str()).collect();
+    let expected_keys = vec![
+        "name",
+        "version",
+        "description",
+        "scripts",
+        "license",
+        "repository",
+        "dependencies",
+    ];
+    assert_eq!(
+        actual_keys, expected_keys,
+        "top-level key order must be preserved (preserve_order feature)"
+    );
+
+    // Scripts: only `test` should remain.
+    let scripts = v["scripts"].as_object().unwrap();
+    assert_eq!(
+        scripts.keys().collect::<Vec<_>>(),
+        vec!["test"],
+        "only non-lifecycle script should remain after strip"
+    );
+    assert_eq!(scripts["test"], "jest");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: nested package/node_modules/sub/package.json invariant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_node_modules_package_json_untouched() {
+    let root_pkg = br#"{"name":"root","scripts":{"postinstall":"root-evil","test":"keep"}}"#;
+    let nested_pkg = br#"{"name":"sub","scripts":{"postinstall":"nested-also-evil"}}"#;
+
+    let tgz = build_tgz(&[
+        Entry::File {
+            path: "package/package.json",
+            body: root_pkg,
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/node_modules/sub/package.json",
+            body: nested_pkg,
+            mode: 0o644,
+        },
+    ]);
+
+    let outcome = strip_npm_tarball(&tgz, &StripLimits::default())
+        .unwrap()
+        .expect("root scripts present → Some");
+    assert_eq!(outcome.stripped_stages, vec!["postinstall"]);
+
+    let extracted = extract_tgz(&outcome.bytes);
+
+    // Root package.json: postinstall gone, test stays.
+    let root = find(&extracted, "package/package.json");
+    let rv: serde_json::Value = serde_json::from_slice(&root.body).unwrap();
+    let rs = rv["scripts"].as_object().unwrap();
+    assert!(!rs.contains_key("postinstall"));
+    assert_eq!(rs["test"], "keep");
+
+    // Nested package.json: byte-identical to input. Pins the
+    // contract that strip only touches the *root* package.json.
+    let nested = find(&extracted, "package/node_modules/sub/package.json");
+    assert_eq!(
+        nested.body, nested_pkg,
+        "nested node_modules/.../package.json must NOT be modified"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: security limits table — every row trips a specific
+// StripError variant end-to-end. All fixtures include a root
+// package.json with a lifecycle script so the strip path doesn't
+// early-return via Ok(None) before the cap/path check is reached.
+// ---------------------------------------------------------------------------
+
+const ROOT_PKG_WITH_SCRIPT: &[u8] = br#"{"name":"x","scripts":{"postinstall":"a"}}"#;
+
+#[test]
+fn security_limit_max_entries_returns_too_many() {
+    // max_entries = 3 → root pkg.json + 3 padding entries = 4 > 3.
+    let entries = vec![
+        Entry::File {
+            path: "package/package.json",
+            body: ROOT_PKG_WITH_SCRIPT,
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/a.js",
+            body: b"a",
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/b.js",
+            body: b"b",
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/c.js",
+            body: b"c",
+            mode: 0o644,
+        },
+    ];
+    let tgz = build_tgz(&entries);
+    let limits = StripLimits {
+        max_entries: 3,
+        ..StripLimits::default()
+    };
+    let err = strip_npm_tarball(&tgz, &limits).unwrap_err();
+    assert!(
+        matches!(err, StripError::TooManyEntries(_)),
+        "want TooManyEntries, got {err:?}"
+    );
+}
+
+#[test]
+fn security_limit_max_single_entry_bytes_returns_too_large_entry() {
+    let huge_body = vec![b'x'; 8 * 1024];
+    let tgz = build_tgz(&[
+        Entry::File {
+            path: "package/package.json",
+            body: ROOT_PKG_WITH_SCRIPT,
+            mode: 0o644,
+        },
+        Entry::File {
+            path: "package/huge.bin",
+            body: &huge_body,
+            mode: 0o644,
+        },
+    ]);
+    // Set the cap below the huge entry's size but above pkg.json.
+    let limits = StripLimits {
+        max_single_entry_bytes: 1024,
+        ..StripLimits::default()
+    };
+    let err = strip_npm_tarball(&tgz, &limits).unwrap_err();
+    assert!(
+        matches!(err, StripError::TooLarge { kind: "entry", .. }),
+        "want TooLarge {{ kind: entry }}, got {err:?}"
+    );
+}
+
+#[test]
+fn security_bad_path_traversal_returns_bad_path() {
+    // tar::Builder::append_data rejects `..` paths at write time
+    // (defence in depth on its side), so this test uses
+    // RawPathRegular to bypass that and prove `validate_entry_path`
+    // in the strip pipeline catches the on-wire form anyway.
+    let tgz = build_tgz(&[
+        Entry::File {
+            path: "package/package.json",
+            body: ROOT_PKG_WITH_SCRIPT,
+            mode: 0o644,
+        },
+        Entry::RawPathRegular {
+            raw_path: "package/../../etc/passwd",
+            body: b"pwned",
+        },
+    ]);
+    let err = strip_npm_tarball(&tgz, &StripLimits::default()).unwrap_err();
+    assert!(
+        matches!(err, StripError::BadPath(_)),
+        "want BadPath, got {err:?}"
+    );
+}
+
+#[test]
+fn security_absolute_path_returns_bad_path() {
+    let tgz = build_tgz(&[
+        Entry::File {
+            path: "package/package.json",
+            body: ROOT_PKG_WITH_SCRIPT,
+            mode: 0o644,
+        },
+        Entry::RawPathRegular {
+            // tar::Builder::append_data + set_path both normalise
+            // away the leading `/`. Bypass with a raw write so the
+            // on-wire form actually reaches strip_npm_tarball.
+            raw_path: "/etc/passwd",
+            body: b"pwned",
+        },
+    ]);
+    let err = strip_npm_tarball(&tgz, &StripLimits::default()).unwrap_err();
+    assert!(
+        matches!(err, StripError::BadPath(_)),
+        "want BadPath, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: StripOutcome → StripCacheEntry::Stripped coupling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strip_outcome_maps_to_strip_cache_entry() {
+    let tgz = build_tgz(&[Entry::File {
+        path: "package/package.json",
+        body: br#"{"name":"x","scripts":{"postinstall":"a"}}"#,
+        mode: 0o644,
+    }]);
+    let outcome: StripOutcome = strip_npm_tarball(&tgz, &StripLimits::default())
+        .unwrap()
+        .expect("strip should report Some");
+
+    // Build the cache entry the same way `proxy.rs:626-635` does
+    // when a tarball strip completes.
+    let entry = StripCacheEntry::Stripped {
+        new_integrity: format!("sha512-{}", outcome.sha512_b64),
+        new_shasum: outcome.sha1_hex.clone(),
+        bytes: std::sync::Arc::new(outcome.bytes.clone()),
+    };
+
+    // Public accessors return the right values.
+    let integ = entry.new_integrity().expect("Stripped has integrity");
+    assert!(
+        integ.starts_with("sha512-"),
+        "new_integrity must carry the sha512- SRI prefix, got {integ}"
+    );
+    assert_eq!(
+        &integ["sha512-".len()..],
+        outcome.sha512_b64,
+        "SRI tail must equal outcome.sha512_b64 byte-for-byte"
+    );
+    assert_eq!(entry.new_shasum(), Some(outcome.sha1_hex.as_str()));
+
+    // Bytes round-trip via pattern match (no `bytes()` accessor on
+    // StripCacheEntry — pattern-match is the correct API per the
+    // round-2 review).
+    match entry {
+        StripCacheEntry::Stripped { ref bytes, .. } => {
+            assert_eq!(bytes.len(), outcome.bytes.len());
+            assert_eq!(bytes.as_slice(), outcome.bytes.as_slice());
+        }
+        StripCacheEntry::NoStripNeeded => panic!("expected Stripped variant"),
+    }
+}

--- a/crates/sakimori-proxy/tests/proxy_https_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_https_e2e.rs
@@ -1,0 +1,366 @@
+//! Real-network end-to-end with **HTTPS upstream**.
+//!
+//! Companion to `proxy_http_e2e.rs`. The HTTP file covers the
+//! plain-HTTP forwarding path. This file covers the TLS path that
+//! production npm / cargo / pip traffic actually uses: a CONNECT
+//! tunnel, hudsucker MITM with a leaf cert signed by the proxy's
+//! own CA, an HTTPS handshake against the upstream, and the npm
+//! packument rewriter still firing on the streamed body.
+//!
+//! Why a feature lives here too: the test depends on the proxy
+//! being willing to trust a self-signed upstream. That's also a
+//! genuine production gap (Verdaccio / Artifactory / GitHub
+//! Packages internal / Takumi Guard behind a private CA), so this
+//! PR also lands `ProxyConfig.extra_upstream_roots` + the
+//! `--upstream-ca-file` CLI flag. The two tests below double as
+//! load-bearing checks for that feature:
+//!
+//! - **positive**: with the extra root configured, the npm
+//!   packument is rewritten as expected.
+//! - **negative**: with no extra root, the same self-signed
+//!   upstream produces an upstream-failure status. Proves the
+//!   field is actually consulted (a regression that always
+//!   trusts self-signed upstreams would silently pass the
+//!   positive test).
+//!
+//! Plan reviewed + approved by Codex (3 rounds).
+
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use hudsucker::rustls as hud_rustls;
+use sakimori_proxy::ca::CaFiles;
+use sakimori_proxy::{ProxyConfig, RegistryHosts};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tmp_dir(tag: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "sakimori-https-e2e-{tag}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+/// rcgen-generated self-signed cert + key for `127.0.0.1`. Returns
+/// (PEM cert path, DER cert bytes, DER key bytes). The PEM path is
+/// what gets handed to `--upstream-ca-file`; the DER halves are
+/// what tokio-rustls needs to configure the mock upstream.
+struct SelfSigned {
+    cert_pem_path: std::path::PathBuf,
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
+}
+
+fn generate_self_signed_for_loopback(tag: &str) -> SelfSigned {
+    use rcgen::{CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, SanType};
+
+    let mut params = CertificateParams::default();
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "sakimori-test-upstream");
+    params.subject_alt_names = vec![
+        SanType::IpAddress(std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1))),
+        SanType::DnsName("localhost".try_into().unwrap()),
+    ];
+    // Make the cert valid for the next year, starting yesterday
+    // so wall-clock drift can't bite us.
+    let now = time::OffsetDateTime::now_utc();
+    params.not_before = now - time::Duration::days(1);
+    params.not_after = now + time::Duration::days(365);
+    // Leaf-only cert (no CA); self-signed via `params.self_signed`.
+    params.is_ca = IsCa::NoCa;
+
+    let key = KeyPair::generate().expect("rcgen keypair");
+    let cert = params.self_signed(&key).expect("rcgen self-signed cert");
+
+    let dir = tmp_dir(tag);
+    std::fs::create_dir_all(&dir).unwrap();
+    let cert_pem_path = dir.join("upstream-ca.pem");
+    std::fs::write(&cert_pem_path, cert.pem()).unwrap();
+    SelfSigned {
+        cert_pem_path,
+        cert_der: cert.der().to_vec(),
+        key_der: key.serialize_der(),
+    }
+}
+
+/// Spawn a TLS mock upstream on a random `127.0.0.1` port that
+/// serves the given JSON body for every request. Uses
+/// `tokio-rustls 0.25` + `hudsucker::rustls` (0.22) so the cert
+/// types match the proxy side.
+async fn spawn_mock_tls_upstream(cert: &SelfSigned, body: Vec<u8>) -> std::net::SocketAddr {
+    use hud_rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+    let cert_chain = vec![CertificateDer::from(cert.cert_der.clone())];
+    let key =
+        PrivateKeyDer::try_from(cert.key_der.clone()).expect("PrivateKeyDer accepts PKCS#8 DER");
+
+    let server_config = hud_rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert_chain, key)
+        .expect("rustls server config");
+    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = Arc::new(body);
+    tokio::spawn(async move {
+        loop {
+            let (sock, _peer) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            let acc = acceptor.clone();
+            let body = body.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acc.accept(sock).await else {
+                    return;
+                };
+                // Read the request until end-of-headers.
+                let mut buf = Vec::with_capacity(2048);
+                let mut tmp = [0u8; 1024];
+                loop {
+                    match tls.read(&mut tmp).await {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                            if buf.len() > 64 * 1024 {
+                                return;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = tls.write_all(resp.as_bytes()).await;
+                let _ = tls.write_all(&body).await;
+                let _ = tls.shutdown().await;
+            });
+        }
+    });
+    addr
+}
+
+/// Start `sakimori_proxy::run` on a random port. Returns
+/// `(proxy_addr, proxy_ca_pem_path)` — the second piece is what
+/// the test client must trust for the MITM leaf certs.
+async fn spawn_proxy(
+    extra_upstream_roots: Vec<std::path::PathBuf>,
+    npm_hosts: Vec<String>,
+) -> (std::net::SocketAddr, std::path::PathBuf) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config_dir = tmp_dir("proxy");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    // `CaFiles` is not Clone, so build it twice — once for the
+    // ProxyConfig and once for the return value the test client
+    // needs to point at.
+    let ca_pem_path = CaFiles::at(config_dir.clone()).cert_pem;
+
+    let mut cfg = ProxyConfig::default_dev().unwrap();
+    cfg.listen = addr;
+    cfg.min_age = Duration::from_secs(30 * 86_400);
+    cfg.ca_files = CaFiles::at(config_dir);
+    cfg.install_log_enabled = false;
+    cfg.registries = RegistryHosts {
+        npm: npm_hosts,
+        ..RegistryHosts::default()
+    };
+    cfg.extra_upstream_roots = extra_upstream_roots;
+
+    tokio::spawn(async move {
+        if let Err(e) = sakimori_proxy::run(cfg).await {
+            eprintln!("proxy exited: {e:#}");
+        }
+    });
+
+    // Wait for the listener.
+    let ready = Arc::new(Notify::new());
+    let ready2 = ready.clone();
+    tokio::spawn(async move {
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                ready2.notify_one();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(6), ready.notified())
+        .await
+        .expect("proxy did not come up");
+
+    (addr, ca_pem_path)
+}
+
+/// Synchronous HTTPS GET through `proxy_addr`, trusting only the
+/// MITM CA at `proxy_ca_pem`. The connector accepts any name in
+/// the leaf cert because hudsucker re-signs upstream names with
+/// the proxy CA, so the leaf's SAN exactly matches `target_url`'s
+/// host.
+fn https_get_through_proxy(
+    proxy_addr: std::net::SocketAddr,
+    proxy_ca_pem: &std::path::Path,
+    target_url: &str,
+) -> Result<(u16, Vec<u8>), String> {
+    use rustls::RootCertStore;
+
+    let pem_bytes = std::fs::read(proxy_ca_pem).map_err(|e| e.to_string())?;
+    let mut roots = RootCertStore::empty();
+    let mut cursor = std::io::Cursor::new(&pem_bytes);
+    for cert in rustls_pemfile::certs(&mut cursor) {
+        let cert = cert.map_err(|e| e.to_string())?;
+        roots.add(cert).map_err(|e| e.to_string())?;
+    }
+
+    let tls = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let proxy_spec = format!("http://{proxy_addr}");
+    let agent = ureq::AgentBuilder::new()
+        .tls_config(Arc::new(tls))
+        .proxy(ureq::Proxy::new(&proxy_spec).map_err(|e| e.to_string())?)
+        .timeout(Duration::from_secs(10))
+        .build();
+
+    match agent.get(target_url).call() {
+        Ok(r) => {
+            let status = r.status();
+            let mut buf = Vec::new();
+            use std::io::Read;
+            r.into_reader()
+                .take(4 * 1024 * 1024)
+                .read_to_end(&mut buf)
+                .map_err(|e| e.to_string())?;
+            Ok((status, buf))
+        }
+        Err(ureq::Error::Status(code, r)) => {
+            let mut buf = Vec::new();
+            use std::io::Read;
+            let _ = r.into_reader().take(4 * 1024 * 1024).read_to_end(&mut buf);
+            Ok((code, buf))
+        }
+        Err(other) => Err(format!("transport:{other:?}")),
+    }
+}
+
+fn synthetic_packument() -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "name": "demo",
+        "dist-tags": { "latest": "1.0.1" },
+        "versions": {
+            "1.0.0": { "name": "demo", "version": "1.0.0", "dist": {} },
+            "1.0.1": { "name": "demo", "version": "1.0.1", "dist": {} },
+        },
+        "time": {
+            "1.0.0": "2025-12-15T00:00:00Z",
+            "1.0.1": (chrono::Utc::now() - chrono::Duration::days(5))
+                .to_rfc3339(),
+        }
+    }))
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn https_packument_rewritten_when_upstream_ca_is_trusted() {
+    // Use `localhost` (DnsName SAN) rather than `127.0.0.1` (IP
+    // SAN) because hudsucker's per-host MITM leaf-signer issues
+    // certificates with a DnsName SAN derived from the CONNECT
+    // target — rustls 0.23 rejects an IP-literal client request
+    // against a DnsName SAN. `localhost` OS-resolves to
+    // 127.0.0.1 so the upstream and the proxy still find each
+    // other.
+    let cert = generate_self_signed_for_loopback("ca-pos");
+    let upstream = spawn_mock_tls_upstream(&cert, synthetic_packument()).await;
+
+    let (proxy_addr, proxy_ca_pem) =
+        spawn_proxy(vec![cert.cert_pem_path.clone()], vec!["localhost".into()]).await;
+
+    let url = format!("https://localhost:{}/demo", upstream.port());
+    let (status, body) = tokio::task::spawn_blocking(move || {
+        https_get_through_proxy(proxy_addr, &proxy_ca_pem, &url)
+    })
+    .await
+    .unwrap()
+    .expect("HTTPS GET should succeed when extra root is trusted");
+
+    assert_eq!(
+        status,
+        200,
+        "expected 200 OK, body: {:?}",
+        std::str::from_utf8(&body).unwrap_or("<binary>")
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&body).expect("body should be valid JSON");
+    let versions = parsed["versions"].as_object().unwrap();
+    assert!(versions.contains_key("1.0.0"));
+    assert!(
+        !versions.contains_key("1.0.1"),
+        "young version must be dropped over HTTPS too"
+    );
+    assert_eq!(parsed["dist-tags"]["latest"], "1.0.0");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn https_upstream_handshake_fails_without_extra_root() {
+    let cert = generate_self_signed_for_loopback("ca-neg");
+    let upstream = spawn_mock_tls_upstream(&cert, synthetic_packument()).await;
+
+    // Same setup as the positive test, MINUS the
+    // `extra_upstream_roots` argument. The self-signed upstream
+    // cert isn't in webpki-roots, so the proxy's handshake to the
+    // upstream must fail.
+    let (proxy_addr, proxy_ca_pem) = spawn_proxy(vec![], vec!["localhost".into()]).await;
+
+    let url = format!("https://localhost:{}/demo", upstream.port());
+    let (status, _body) = tokio::task::spawn_blocking(move || {
+        https_get_through_proxy(proxy_addr, &proxy_ca_pem, &url)
+    })
+    .await
+    .unwrap()
+    .expect("HTTPS GET should return an upstream-failure status, not a transport error");
+
+    // Hudsucker maps an upstream handshake failure to a 5xx
+    // bad-gateway-ish response. We don't pin the exact code
+    // because the error chain wording is unstable across rustls
+    // versions; the 5xx-shape assertion is what matters: the
+    // client never gets the upstream's body because the proxy
+    // couldn't trust the upstream cert.
+    assert!(
+        (500..=599).contains(&status),
+        "expected 5xx upstream-failure status when extra root is missing, got {status}"
+    );
+}
+
+// Silence "unused import" on Write if a future refactor stops
+// needing it — the helper currently does use `tls.write_all`.
+#[allow(dead_code)]
+fn _ensure_imports_used() -> std::io::Result<()> {
+    let mut sink = std::io::sink();
+    sink.write_all(b"")?;
+    Ok(())
+}

--- a/crates/sakimori-proxy/tests/proxy_https_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_https_e2e.rs
@@ -223,11 +223,12 @@ fn https_get_through_proxy(
     target_url: &str,
 ) -> Result<(u16, Vec<u8>), String> {
     use rustls::RootCertStore;
+    use rustls::pki_types::CertificateDer;
+    use rustls::pki_types::pem::PemObject;
 
     let pem_bytes = std::fs::read(proxy_ca_pem).map_err(|e| e.to_string())?;
     let mut roots = RootCertStore::empty();
-    let mut cursor = std::io::Cursor::new(&pem_bytes);
-    for cert in rustls_pemfile::certs(&mut cursor) {
+    for cert in CertificateDer::pem_slice_iter(&pem_bytes) {
         let cert = cert.map_err(|e| e.to_string())?;
         roots.add(cert).map_err(|e| e.to_string())?;
     }

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -850,6 +850,19 @@ pub struct ProxyStartArgs {
     /// ```
     #[arg(long = "registries-config", value_name = "FILE")]
     pub registries_config: Option<PathBuf>,
+    /// PEM-encoded CA certificate file to add to the rustls
+    /// upstream trust store. Repeatable. Needed when sakimori
+    /// proxies traffic to an internal mirror whose TLS chain is
+    /// signed by a private CA not present in the
+    /// `webpki-roots`-shipped trust store (Verdaccio, JFrog
+    /// Artifactory / Nexus / GitHub Packages internal,
+    /// Takumi Guard, …). Without this, the upstream handshake
+    /// fails with `UnknownIssuer` even when `--registries-config`
+    /// names the mirror's hostname. Each file is parsed at
+    /// startup; a missing file or zero-cert PEM hard-errors so
+    /// the trust hole can't open silently.
+    #[arg(long = "upstream-ca-file", value_name = "PATH")]
+    pub upstream_ca_file: Vec<PathBuf>,
 }
 
 fn parse_kv(s: &str) -> std::result::Result<(String, String), String> {
@@ -1197,6 +1210,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 lifecycle_strip_limits: sakimori_proxy::lifecycle::StripLimits::default(),
                 lifecycle_strip_cache_dir,
                 registries,
+                extra_upstream_roots: args.upstream_ca_file,
             };
             sakimori_proxy::run(cfg).await?;
             Ok(())


### PR DESCRIPTION
## Summary

Adds the integration-tier test for `--lifecycle-policy strip` (the Shai-Hulud npm worm defence) that existing unit tests can't reach. The strip path's unit tests today cover single-entry happy paths, hash recomputation, no-op behaviour, the compressed/decompressed caps, and `validate_entry_path` in isolation — but **nothing extracts the rewriter's output and asserts the resulting tarball is structurally consumable by tar**. That gap is the one that bites users at install-time: silent failures (wrong tar headers, gzip framing off-by-one, hash mismatch, dropped symlinks) only surface when npm rejects the stripped tarball, and the user blames sakimori for breaking their build.

The plan was iterated with **Codex (3 rounds, approved on round 3)**. Codex caught:
- A `bytes()` accessor that doesn't exist on `StripCacheEntry`
- An early-return trap in the security-limits fixtures (no lifecycle scripts → `Ok(None)` before any cap check runs)
- `tar::Builder::append_data` rejecting `..` and absolute paths at write time, so a hand-built tar header is needed to exercise the on-wire form

## What this PR adds

New file `crates/sakimori-proxy/tests/lifecycle_strip_roundtrip.rs` — 8 tests across 7 contracts:

1. **`roundtrip_preserves_structure_modes_and_links`** — multi-entry tarball (regular file, executable at `0o755`, nested path, symlink, hardlink, directory) round-tripped through strip + re-extract. Asserts per-entry `entry_type`, `mode`, body bytes, and link target byte-for-byte. Pins the "preserve, don't validate" link contract.
2. **`package_json_top_level_key_order_preserved`** — fixture built via ordered `serde_json::Map`; after strip, the full ordered top-level key sequence must survive. Proves `serde_json` `preserve_order` is wired; a regression to `BTreeMap` would fail loudly.
3. **`nested_node_modules_package_json_untouched`** — only the **root** `package/package.json` is modified; `package/node_modules/sub/package.json` with its own postinstall arrives byte-identical. Pins the `path.components().count() == 2` contract at `lifecycle.rs:472`.
4. **Security limits table** (4 tests). Every fixture includes a root `package.json` with at least one lifecycle script so the strip path actually walks past the no-op early-return into the cap/path enforcement:
   - `max_entries` → `StripError::TooManyEntries(_)`
   - `max_single_entry_bytes` → `StripError::TooLarge { kind: "entry", .. }`
   - traversal `package/../../etc/passwd` → `StripError::BadPath(_)`
   - absolute `/etc/passwd` → `StripError::BadPath(_)`

   The two `BadPath` rows write directly into the tar header's 100-byte name field via a `RawPathRegular` escape hatch — `tar::Header::set_path` rejects both shapes, so we need the on-wire form to actually reach `validate_entry_path` in the strip pipeline.
5. **`strip_outcome_maps_to_strip_cache_entry`** — wraps a real `StripOutcome` into `StripCacheEntry::Stripped` the same way `proxy.rs:626-635` does and asserts the `new_integrity()` / `new_shasum()` / `Stripped { bytes, .. }` contract. Pins the wire shape between rewriter and cache.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — workspace 618 → 626, sakimori-proxy integration tests 13 → 21