### PR TITLE
feat(proxy): speculative pre-strip every dist-tag, not just `latest`

### DIFF
--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -1306,21 +1306,30 @@ fn strip_failure_response(
 
 /// Speculative pre-strip on the post-rewrite packument. Called from
 /// the npm packument response branch when `--lifecycle-policy strip`
-/// is on. Finds the version that `dist-tags.latest` resolves to,
-/// fetches its tarball directly from the upstream registry (bypassing
-/// the proxy itself to avoid a recursion), runs `strip_npm_tarball`,
-/// populates the strip cache, and reapplies the cache to the
-/// packument so npm receives integrity values that match the bytes
-/// the tarball handler will serve. Bounded by a 10-second wall-clock
-/// budget — on any failure we leave the packument unchanged and let
-/// the lazy tarball-path strip take over.
+/// is on. Iterates over every entry in `dist-tags` (deduped by
+/// target version, `latest` always first, capped at
+/// [`MAX_PRE_STRIP_TAGS`]), fetches each version's tarball directly
+/// from the upstream registry (bypassing the proxy itself to avoid a
+/// recursion), runs `strip_npm_tarball`, populates the strip cache,
+/// and reapplies the cache to the packument so npm receives
+/// integrity values that match the bytes the tarball handler will
+/// serve. Per-version fetch is bounded by [`PRE_STRIP_PER_TARBALL_TIMEOUT`];
+/// the whole multi-tag fan-out is bounded by
+/// [`PRE_STRIP_TOTAL_BUDGET`]. Failures stay best-effort: leave that
+/// version's metadata untouched and let the lazy tarball-path strip
+/// apply on first install (which costs a single `EINTEGRITY`-then-
+/// retry round-trip).
 ///
-/// Only the `latest` tag is pre-stripped. Explicit pinned-version
-/// installs (`npm install pkg@1.2.3` for a non-latest version) hit
-/// the tarball handler's lazy path, populate the cache there, and
-/// then succeed on retry — the first attempt fails with EINTEGRITY
-/// because the packument advertised the original hash. Documented
-/// in CLAUDE.md roadmap #15.
+/// **Out of scope**: explicit pinned-version installs
+/// (`npm install pkg@1.2.3` for a version that isn't in
+/// `dist-tags`). The proxy has no way to predict the user's chosen
+/// pin without intercepting the install command. Documented in
+/// CLAUDE.md roadmap #15.
+const MAX_PRE_STRIP_TAGS: usize = 8;
+const PRE_STRIP_CONCURRENCY: usize = 4;
+const PRE_STRIP_PER_TARBALL_TIMEOUT: Duration = Duration::from_secs(10);
+const PRE_STRIP_TOTAL_BUDGET: Duration = Duration::from_secs(20);
+
 async fn speculative_pre_strip_packument(
     rewritten: Vec<u8>,
     strip_cache: std::sync::Arc<crate::strip_cache::StripCache>,
@@ -1341,124 +1350,245 @@ async fn speculative_pre_strip_packument(
     if lifecycle_allow.contains(&name) {
         return rewritten;
     }
-    let Some(latest) = obj
-        .get("dist-tags")
-        .and_then(|t| t.get("latest"))
-        .and_then(|v| v.as_str())
-        .map(String::from)
-    else {
+    let targets = collect_pre_strip_targets(obj);
+    if targets.is_empty() {
         return rewritten;
-    };
-    let (tarball_url, orig_integrity) = {
-        let Some(versions) = obj.get("versions").and_then(|v| v.as_object()) else {
-            return rewritten;
-        };
-        let Some(meta) = versions.get(&latest) else {
-            return rewritten;
-        };
-        let Some(dist) = meta.get("dist") else {
-            return rewritten;
-        };
-        let url = dist
-            .get("tarball")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-        let integ = dist
-            .get("integrity")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-        match (url, integ) {
-            (Some(u), Some(i)) => (u, i),
-            _ => return rewritten,
-        }
-    };
-    let key = crate::strip_cache::StripKey {
-        name: name.clone(),
-        version: latest.clone(),
-        orig_integrity: orig_integrity.clone(),
-    };
-    if strip_cache.get(&key).is_none() {
-        let url = tarball_url.clone();
+    }
+
+    // Bounded concurrency fan-out. JoinSet owns each task; we drain
+    // it under an overall wall-clock budget so a hostile upstream
+    // cannot blow up packument latency.
+    let deadline = tokio::time::Instant::now() + PRE_STRIP_TOTAL_BUDGET;
+    let mut iter = targets.into_iter();
+    let mut joins: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+    let spawn_one = |joins: &mut tokio::task::JoinSet<()>, t: PreStripTarget| {
+        let cache = strip_cache.clone();
+        let limits = strip_limits;
         let ua = user_agent.clone();
-        let fetch = tokio::time::timeout(
-            Duration::from_secs(10),
-            tokio::task::spawn_blocking(move || -> std::result::Result<Vec<u8>, String> {
-                use std::io::Read;
-                let agent = ureq::AgentBuilder::new()
-                    .user_agent(&ua)
-                    .timeout(Duration::from_secs(8))
-                    .build();
-                let resp = agent.get(&url).call().map_err(|e| e.to_string())?;
-                let mut buf = Vec::new();
-                // Cap reads so a malicious upstream cannot bleed
-                // memory by sending an unbounded body.
-                resp.into_reader()
-                    .take(128 * 1024 * 1024)
-                    .read_to_end(&mut buf)
-                    .map_err(|e| e.to_string())?;
-                Ok(buf)
-            }),
-        )
-        .await;
-        let bytes = match fetch {
-            Ok(Ok(Ok(b))) => b,
-            Ok(Ok(Err(e))) => {
-                log::warn!(
-                    "lifecycle(strip,speculative): upstream fetch failed for {name}@{latest}: {e}",
-                );
-                return rewritten;
-            }
-            Ok(Err(e)) => {
-                log::warn!(
-                    "lifecycle(strip,speculative): spawn_blocking join failed for {name}@{latest}: {e}",
-                );
-                return rewritten;
-            }
-            Err(_) => {
-                log::warn!(
-                    "lifecycle(strip,speculative): upstream fetch timed out for {name}@{latest} (10s budget)",
-                );
-                return rewritten;
-            }
-        };
-        let actual = sri_sha512_of(&bytes);
-        if actual != orig_integrity {
-            log::warn!(
-                "lifecycle(strip,speculative): {name}@{latest} bytes don't match advertised integrity (got {}, expected {}); skipping cache write",
-                actual,
-                orig_integrity,
-            );
-            return rewritten;
+        joins.spawn(async move {
+            pre_strip_one_version(t, cache, limits, ua).await;
+        });
+    };
+    for _ in 0..PRE_STRIP_CONCURRENCY {
+        if let Some(t) = iter.next() {
+            spawn_one(&mut joins, t);
         }
-        let entry = match crate::lifecycle::strip_npm_tarball(&bytes, &strip_limits) {
-            Ok(Some(out)) => {
-                log::info!(
-                    "lifecycle(strip,speculative): cached {name}@{latest} (removed [{}])",
-                    out.stripped_stages.join(", "),
-                );
-                crate::strip_cache::StripCacheEntry::Stripped {
-                    new_integrity: format!("sha512-{}", out.sha512_b64),
-                    new_shasum: out.sha1_hex,
-                    bytes: std::sync::Arc::new(out.bytes),
+    }
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            joins.abort_all();
+            log::warn!(
+                "lifecycle(strip,speculative): {}: overall budget exhausted, {} task(s) aborted",
+                name,
+                joins.len(),
+            );
+            break;
+        }
+        let remaining = deadline - now;
+        match tokio::time::timeout(remaining, joins.join_next()).await {
+            Ok(Some(_)) => {
+                if let Some(t) = iter.next() {
+                    spawn_one(&mut joins, t);
                 }
             }
-            Ok(None) => {
-                log::debug!(
-                    "lifecycle(strip,speculative): {name}@{latest} carries no lifecycle scripts"
-                );
-                crate::strip_cache::StripCacheEntry::NoStripNeeded
-            }
-            Err(e) => {
+            Ok(None) => break, // all done
+            Err(_) => {
+                joins.abort_all();
                 log::warn!(
-                    "lifecycle(strip,speculative): rewriter error for {name}@{latest}: {e} — leaving packument untouched (lazy path will apply --lifecycle-strip-on-failure)",
+                    "lifecycle(strip,speculative): {}: overall budget exhausted while waiting, {} task(s) aborted",
+                    name,
+                    joins.len(),
                 );
-                return rewritten;
+                break;
             }
-        };
-        strip_cache.insert(key, entry);
+        }
     }
+
     crate::rewrite_npm::apply_strip_cache_to_packument(obj, &strip_cache);
     serde_json::to_vec(&doc).unwrap_or(rewritten)
+}
+
+#[derive(Debug, Clone)]
+struct PreStripTarget {
+    name: String,
+    version: String,
+    tarball_url: String,
+    orig_integrity: String,
+    /// Comma-joined list of dist-tag names pointing at this version
+    /// (e.g. `latest`, `latest,next`). Logged for operator visibility.
+    tags: String,
+}
+
+/// Walk `dist-tags`, dedupe by target version, gather each version's
+/// `(tarball, integrity)` from the rewritten packument. Returns an
+/// ordered list with the `latest` tag first (when present) and the
+/// remainder in deterministic dist-tag insertion order; capped at
+/// [`MAX_PRE_STRIP_TAGS`] to bound the fan-out against a registry
+/// that ships an unreasonable number of tags.
+fn collect_pre_strip_targets(
+    packument: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<PreStripTarget> {
+    let name = packument
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let Some(tags) = packument.get("dist-tags").and_then(|v| v.as_object()) else {
+        return Vec::new();
+    };
+    let Some(versions) = packument.get("versions").and_then(|v| v.as_object()) else {
+        return Vec::new();
+    };
+
+    // Preserve dist-tags insertion order (serde_json::Map is built
+    // with `preserve_order` workspace-wide) but always pull `latest`
+    // to the front so it gets the first concurrency slot.
+    let mut ordered: Vec<(&String, &serde_json::Value)> = tags.iter().collect();
+    if let Some(idx) = ordered.iter().position(|(k, _)| k.as_str() == "latest") {
+        let latest = ordered.remove(idx);
+        ordered.insert(0, latest);
+    }
+
+    let mut by_version: std::collections::BTreeMap<String, PreStripTarget> = Default::default();
+    let mut order: Vec<String> = Vec::new();
+    for (tag, target) in ordered {
+        let Some(ver) = target.as_str() else { continue };
+        let Some(meta) = versions.get(ver) else {
+            continue;
+        };
+        let Some(dist) = meta.get("dist") else {
+            continue;
+        };
+        let Some(url) = dist.get("tarball").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(integ) = dist.get("integrity").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if let Some(existing) = by_version.get_mut(ver) {
+            // Same version, additional tag → just record the tag.
+            existing.tags.push(',');
+            existing.tags.push_str(tag);
+            continue;
+        }
+        order.push(ver.to_string());
+        by_version.insert(
+            ver.to_string(),
+            PreStripTarget {
+                name: name.clone(),
+                version: ver.to_string(),
+                tarball_url: url.to_string(),
+                orig_integrity: integ.to_string(),
+                tags: tag.clone(),
+            },
+        );
+    }
+
+    order
+        .into_iter()
+        .take(MAX_PRE_STRIP_TAGS)
+        .filter_map(|v| by_version.remove(&v))
+        .collect()
+}
+
+async fn pre_strip_one_version(
+    t: PreStripTarget,
+    strip_cache: std::sync::Arc<crate::strip_cache::StripCache>,
+    strip_limits: crate::lifecycle::StripLimits,
+    user_agent: String,
+) {
+    let PreStripTarget {
+        name,
+        version,
+        tarball_url,
+        orig_integrity,
+        tags,
+    } = t;
+    let key = crate::strip_cache::StripKey {
+        name: name.clone(),
+        version: version.clone(),
+        orig_integrity: orig_integrity.clone(),
+    };
+    if strip_cache.get(&key).is_some() {
+        return;
+    }
+    let url = tarball_url.clone();
+    let ua = user_agent.clone();
+    let fetch = tokio::time::timeout(
+        PRE_STRIP_PER_TARBALL_TIMEOUT,
+        tokio::task::spawn_blocking(move || -> std::result::Result<Vec<u8>, String> {
+            use std::io::Read;
+            let agent = ureq::AgentBuilder::new()
+                .user_agent(&ua)
+                .timeout(Duration::from_secs(8))
+                .build();
+            let resp = agent.get(&url).call().map_err(|e| e.to_string())?;
+            let mut buf = Vec::new();
+            // Cap reads so a malicious upstream cannot bleed
+            // memory by sending an unbounded body.
+            resp.into_reader()
+                .take(128 * 1024 * 1024)
+                .read_to_end(&mut buf)
+                .map_err(|e| e.to_string())?;
+            Ok(buf)
+        }),
+    )
+    .await;
+    let bytes = match fetch {
+        Ok(Ok(Ok(b))) => b,
+        Ok(Ok(Err(e))) => {
+            log::warn!(
+                "lifecycle(strip,speculative): upstream fetch failed for {name}@{version} (tags={tags}): {e}",
+            );
+            return;
+        }
+        Ok(Err(e)) => {
+            log::warn!(
+                "lifecycle(strip,speculative): spawn_blocking join failed for {name}@{version} (tags={tags}): {e}",
+            );
+            return;
+        }
+        Err(_) => {
+            log::warn!(
+                "lifecycle(strip,speculative): upstream fetch timed out for {name}@{version} (tags={tags}, 10s budget)",
+            );
+            return;
+        }
+    };
+    let actual = sri_sha512_of(&bytes);
+    if actual != orig_integrity {
+        log::warn!(
+            "lifecycle(strip,speculative): {name}@{version} (tags={tags}) bytes don't match advertised integrity (got {actual}, expected {orig_integrity}); skipping cache write",
+        );
+        return;
+    }
+    let entry = match crate::lifecycle::strip_npm_tarball(&bytes, &strip_limits) {
+        Ok(Some(out)) => {
+            log::info!(
+                "lifecycle(strip,speculative): cached {name}@{version} (tags={tags}, removed [{}])",
+                out.stripped_stages.join(", "),
+            );
+            crate::strip_cache::StripCacheEntry::Stripped {
+                new_integrity: format!("sha512-{}", out.sha512_b64),
+                new_shasum: out.sha1_hex,
+                bytes: std::sync::Arc::new(out.bytes),
+            }
+        }
+        Ok(None) => {
+            log::debug!(
+                "lifecycle(strip,speculative): {name}@{version} (tags={tags}) carries no lifecycle scripts",
+            );
+            crate::strip_cache::StripCacheEntry::NoStripNeeded
+        }
+        Err(e) => {
+            log::warn!(
+                "lifecycle(strip,speculative): rewriter error for {name}@{version} (tags={tags}): {e} — leaving packument untouched (lazy path will apply --lifecycle-strip-on-failure)",
+            );
+            return;
+        }
+    };
+    strip_cache.insert(key, entry);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sakimori-proxy/tests/proxy_multitag_prestrip_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_multitag_prestrip_e2e.rs
@@ -1,0 +1,469 @@
+//! Multi-tag speculative pre-strip e2e.
+//!
+//! Pins the contract added when `speculative_pre_strip_packument`
+//! grew past `dist-tags.latest` to cover **every entry in
+//! `dist-tags`**, deduped by target version, capped at
+//! `MAX_PRE_STRIP_TAGS`. The motivating limitation in CLAUDE.md
+//! roadmap #15: `npm install pkg@next` / `pkg@beta` for a non-
+//! `latest` version used to hit the tarball handler's lazy strip
+//! path, fail the first attempt with `EINTEGRITY` (because the
+//! packument advertised the original hash), and succeed on retry
+//! after the cache warmed. With multi-tag pre-strip, the packument
+//! that npm sees already carries the rewritten integrity for every
+//! tagged version, so first-attempt installs succeed.
+//!
+//! Plan reviewed by Codex (one round). Key guarantees the test
+//! enforces:
+//!
+//! 1. Pre-strip runs for **all** dist-tags, not just `latest`.
+//! 2. The packument response carries rewritten
+//!    `dist.integrity` / `dist.shasum` for each tagged version.
+//! 3. Subsequent tarball fetches through the proxy return the
+//!    *stripped* body whose sha512 equals the rewritten integrity
+//!    — i.e. npm's first install attempt would now succeed.
+//! 4. `dist.attestations` is dropped for stripped entries (the
+//!    provenance signature is over the original bytes; keeping it
+//!    would mislead `npm install --provenance`).
+//! 5. Two tags pointing at the same version are deduped: only one
+//!    pre-strip fires for that version.
+
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use sakimori_proxy::ca::CaFiles;
+use sakimori_proxy::lifecycle::LifecyclePolicy;
+use sakimori_proxy::{ProxyConfig, RegistryHosts};
+use sha2::{Digest, Sha512};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+fn tmp_dir(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::AtomicU64;
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "sakimori-multitag-e2e-{tag}-{}-{nanos}-{seq}",
+        std::process::id()
+    ))
+}
+
+/// Build a minimal `package/<pkg>` tarball whose `package.json` ships
+/// a `postinstall` script — i.e. the strip path will rewrite it.
+fn malicious_tarball(name: &str, version: &str, script_body: &str) -> Vec<u8> {
+    let pkg_json = format!(
+        r#"{{"name":"{name}","version":"{version}","scripts":{{"postinstall":"{script_body}","test":"jest"}}}}"#
+    );
+    let index_js = format!("// {name}@{version}\nconsole.log('hi');\n");
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for (path, body) in [
+            ("package/package.json", pkg_json.as_bytes()),
+            ("package/index.js", index_js.as_bytes()),
+        ] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder.append_data(&mut header, path, body).unwrap();
+        }
+        builder.finish().unwrap();
+    }
+    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
+    gz.write_all(&tar_bytes).unwrap();
+    gz.finish().unwrap()
+}
+
+fn sri_sha512(bytes: &[u8]) -> String {
+    let mut h = Sha512::new();
+    h.update(bytes);
+    format!("sha512-{}", B64.encode(h.finalize()))
+}
+
+/// Synthetic packument shaped enough like an npm response for the
+/// rewriter + speculative pre-strip path to fire. Three dist-tags,
+/// two distinct target versions (`latest` and `dup` both point at
+/// `2.0.0`; `next` points at `1.0.0`). Both versions ship a
+/// `dist.attestations` block so we can prove it gets dropped post-
+/// strip. Publish times are old enough to survive the default
+/// `min_age = 30d`.
+fn synthetic_packument(upstream_origin: &str, tgz_v1: &[u8], tgz_v2: &[u8]) -> Vec<u8> {
+    let int_v1 = sri_sha512(tgz_v1);
+    let int_v2 = sri_sha512(tgz_v2);
+    serde_json::to_vec(&serde_json::json!({
+        "name": "demo",
+        "dist-tags": {
+            "latest": "2.0.0",
+            "next": "1.0.0",
+            // Same version as latest — must dedupe so we don't
+            // fire pre-strip twice for 2.0.0.
+            "dup": "2.0.0",
+        },
+        "versions": {
+            "1.0.0": {
+                "name": "demo",
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!("{upstream_origin}/demo/-/demo-1.0.0.tgz"),
+                    "integrity": int_v1,
+                    "shasum": "deadbeef0000000000000000000000000000beef",
+                    "attestations": {
+                        "url": "https://example.invalid/attestation-1",
+                        "provenance": {"predicateType": "x"},
+                    },
+                },
+            },
+            "2.0.0": {
+                "name": "demo",
+                "version": "2.0.0",
+                "dist": {
+                    "tarball": format!("{upstream_origin}/demo/-/demo-2.0.0.tgz"),
+                    "integrity": int_v2,
+                    "shasum": "deadbeef0000000000000000000000000000cafe",
+                    "attestations": {
+                        "url": "https://example.invalid/attestation-2",
+                        "provenance": {"predicateType": "x"},
+                    },
+                },
+            },
+        },
+        "time": {
+            "1.0.0": "2025-01-15T00:00:00Z",
+            "2.0.0": "2025-08-15T00:00:00Z",
+        }
+    }))
+    .unwrap()
+}
+
+/// Per-test mock upstream that:
+///   * routes `GET /demo`         → packument bytes
+///   * routes `GET /demo/-/demo-1.0.0.tgz` → v1 tarball
+///   * routes `GET /demo/-/demo-2.0.0.tgz` → v2 tarball
+///
+/// Counts each tarball fetch in a returned atomic so the test can
+/// assert dedup ("2.0.0 fetched exactly once even though it's
+/// pointed at by two dist-tags").
+struct UpstreamHandles {
+    addr: std::net::SocketAddr,
+    fetch_count_v1: Arc<AtomicUsize>,
+    fetch_count_v2: Arc<AtomicUsize>,
+}
+
+async fn spawn_mock_upstream(
+    packument: Arc<Vec<u8>>,
+    tgz_v1: Arc<Vec<u8>>,
+    tgz_v2: Arc<Vec<u8>>,
+) -> UpstreamHandles {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let fetch_count_v1 = Arc::new(AtomicUsize::new(0));
+    let fetch_count_v2 = Arc::new(AtomicUsize::new(0));
+    let c1 = fetch_count_v1.clone();
+    let c2 = fetch_count_v2.clone();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _peer) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            let packument = packument.clone();
+            let tgz_v1 = tgz_v1.clone();
+            let tgz_v2 = tgz_v2.clone();
+            let c1 = c1.clone();
+            let c2 = c2.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::with_capacity(2048);
+                let mut tmp = [0u8; 1024];
+                loop {
+                    match sock.read(&mut tmp).await {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                            if buf.len() > 64 * 1024 {
+                                return;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+                let request_line = std::str::from_utf8(&buf)
+                    .ok()
+                    .and_then(|s| s.lines().next())
+                    .unwrap_or("")
+                    .to_string();
+                let path = request_line.split_whitespace().nth(1).unwrap_or("/");
+
+                let (body, ct): (Arc<Vec<u8>>, &str) = if path.ends_with("/demo-1.0.0.tgz") {
+                    c1.fetch_add(1, Ordering::Relaxed);
+                    (tgz_v1, "application/octet-stream")
+                } else if path.ends_with("/demo-2.0.0.tgz") {
+                    c2.fetch_add(1, Ordering::Relaxed);
+                    (tgz_v2, "application/octet-stream")
+                } else if path == "/demo" || path.ends_with("/demo") {
+                    (packument, "application/json")
+                } else {
+                    let resp =
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.shutdown().await;
+                    return;
+                };
+                let resp_head = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {ct}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(resp_head.as_bytes()).await;
+                let _ = sock.write_all(&body).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    UpstreamHandles {
+        addr,
+        fetch_count_v1,
+        fetch_count_v2,
+    }
+}
+
+async fn spawn_proxy(persist_dir: std::path::PathBuf) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config_dir = tmp_dir("proxy");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let mut cfg = ProxyConfig::default_dev().unwrap();
+    cfg.listen = addr;
+    cfg.ca_files = CaFiles::at(config_dir);
+    cfg.install_log_enabled = false;
+    cfg.registries = RegistryHosts {
+        npm: vec!["127.0.0.1".into()],
+        ..RegistryHosts::default()
+    };
+    cfg.lifecycle_policy = Some(LifecyclePolicy::Strip);
+    cfg.lifecycle_strip_cache_dir = Some(persist_dir);
+
+    tokio::spawn(async move {
+        if let Err(e) = sakimori_proxy::run(cfg).await {
+            eprintln!("proxy exited: {e:#}");
+        }
+    });
+
+    let ready = Arc::new(Notify::new());
+    let ready2 = ready.clone();
+    tokio::spawn(async move {
+        for _ in 0..200 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                ready2.notify_one();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(6), ready.notified())
+        .await
+        .expect("proxy did not come up");
+    addr
+}
+
+fn http_get(proxy: std::net::SocketAddr, url: &str) -> (u16, Vec<u8>) {
+    let proxy_spec = format!("http://{proxy}");
+    let agent = ureq::AgentBuilder::new()
+        .proxy(ureq::Proxy::new(&proxy_spec).unwrap())
+        .timeout(Duration::from_secs(15))
+        .build();
+    let resp = agent.get(url).call().expect("proxy GET");
+    let status = resp.status();
+    let mut buf = Vec::new();
+    use std::io::Read;
+    resp.into_reader()
+        .take(8 * 1024 * 1024)
+        .read_to_end(&mut buf)
+        .unwrap();
+    (status, buf)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pre_strip_rewrites_all_dist_tag_versions_in_packument() {
+    let tgz_v1 = malicious_tarball("demo", "1.0.0", "echo evil-v1");
+    let tgz_v2 = malicious_tarball("demo", "2.0.0", "echo evil-v2");
+    let orig_int_v1 = sri_sha512(&tgz_v1);
+    let orig_int_v2 = sri_sha512(&tgz_v2);
+
+    let persist_dir = tmp_dir("cache");
+    let proxy = spawn_proxy(persist_dir.clone()).await;
+
+    let upstream = spawn_mock_upstream(
+        Arc::new(Vec::new()), // placeholder; filled in below once we know the origin
+        Arc::new(tgz_v1.clone()),
+        Arc::new(tgz_v2.clone()),
+    )
+    .await;
+    let origin = format!("http://127.0.0.1:{}", upstream.addr.port());
+
+    // The packument has to embed the upstream's port in its
+    // tarball URLs — re-spawn the upstream with the real packument
+    // now that we know the origin. (Spawning twice is simpler than
+    // threading the origin into the synthetic_packument call site
+    // before the listener binds, and the second upstream replaces
+    // the first on its own socket without conflict.)
+    let packument = synthetic_packument(&origin, &tgz_v1, &tgz_v2);
+    let upstream = spawn_mock_upstream(
+        Arc::new(packument),
+        Arc::new(tgz_v1.clone()),
+        Arc::new(tgz_v2.clone()),
+    )
+    .await;
+    let origin = format!("http://127.0.0.1:{}", upstream.addr.port());
+
+    // Fetch the packument through the proxy. The npm rewriter +
+    // speculative pre-strip both run in `handle_response`.
+    let url = format!("{origin}/demo");
+    let (status, body) = tokio::task::spawn_blocking(move || http_get(proxy, &url))
+        .await
+        .unwrap();
+    assert_eq!(status, 200);
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&body).expect("packument response must parse as JSON");
+
+    // ---- Assertion 1: both tagged versions had their integrity rewritten.
+    let versions = parsed["versions"]
+        .as_object()
+        .expect("versions object survives rewrite");
+    for ver in ["1.0.0", "2.0.0"] {
+        let meta = versions
+            .get(ver)
+            .unwrap_or_else(|| panic!("version {ver} missing from rewritten packument"));
+        let new_int = meta["dist"]["integrity"]
+            .as_str()
+            .unwrap_or_else(|| panic!("version {ver} missing dist.integrity"));
+        let orig = if ver == "1.0.0" {
+            &orig_int_v1
+        } else {
+            &orig_int_v2
+        };
+        assert_ne!(
+            new_int, orig,
+            "dist.integrity for {ver} must be rewritten post-strip (original was {orig}, response still says {new_int})",
+        );
+        assert!(
+            new_int.starts_with("sha512-"),
+            "rewritten integrity must keep the sha512- SRI prefix, got {new_int}",
+        );
+
+        // ---- Assertion 4: attestations dropped for stripped entries.
+        assert!(
+            meta["dist"].get("attestations").is_none(),
+            "dist.attestations for {ver} must be removed post-strip (signature is over the original bytes; keeping it would mislead `npm install --provenance`)",
+        );
+    }
+
+    // ---- Assertion 2: dist-tags survive (all three).
+    let tags = parsed["dist-tags"]
+        .as_object()
+        .expect("dist-tags survive rewrite");
+    assert_eq!(tags["latest"], "2.0.0");
+    assert_eq!(tags["next"], "1.0.0");
+    assert_eq!(tags["dup"], "2.0.0");
+
+    // ---- Assertion 3: subsequent tarball fetches return stripped
+    // bytes whose sha512 equals the rewritten integrity. This is
+    // the bit that proves npm's first-attempt install would now
+    // succeed without an EINTEGRITY retry.
+    for (ver, expected_new_int) in [
+        (
+            "1.0.0",
+            versions["1.0.0"]["dist"]["integrity"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        ),
+        (
+            "2.0.0",
+            versions["2.0.0"]["dist"]["integrity"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+        ),
+    ] {
+        let url = format!("{origin}/demo/-/demo-{ver}.tgz");
+        let (status, body) = tokio::task::spawn_blocking(move || http_get(proxy, &url))
+            .await
+            .unwrap();
+        assert_eq!(status, 200, "tarball fetch for {ver}");
+        let actual = sri_sha512(&body);
+        assert_eq!(
+            actual, expected_new_int,
+            "tarball body for {ver} must hash to the integrity the rewritten packument advertised",
+        );
+        // Confirm body is actually stripped (postinstall removed
+        // from the embedded package.json).
+        let pkg_json_str = extract_root_package_json(&body);
+        let v: serde_json::Value = serde_json::from_str(&pkg_json_str).unwrap();
+        let scripts = v["scripts"].as_object().expect("scripts present");
+        assert!(
+            !scripts.contains_key("postinstall"),
+            "tarball for {ver} must have postinstall stripped",
+        );
+        assert_eq!(scripts["test"], "jest", "non-lifecycle script must survive");
+    }
+
+    // ---- Assertion 5: dedup. Two dist-tags (`latest`, `dup`) both
+    // pointed at 2.0.0. The upstream should have served exactly
+    // one *speculative* fetch for 2.0.0 plus one client-driven
+    // tarball fetch later = 2 total. v1 was tagged once → 1
+    // speculative + 1 client-driven = 2 total. So we should never
+    // see >2 fetches per version. Catches a regression where
+    // dedup gets dropped and every dist-tag spawns its own
+    // pre-strip task.
+    assert!(
+        upstream.fetch_count_v1.load(Ordering::Relaxed) <= 2,
+        "v1 was fetched too many times — dedup or extra speculative fetch regression",
+    );
+    assert!(
+        upstream.fetch_count_v2.load(Ordering::Relaxed) <= 2,
+        "v2 was fetched too many times — `latest`+`dup` should dedupe, not double-fetch",
+    );
+}
+
+/// Pull the root `package/package.json` body out of a gzipped tar
+/// without depending on the strip-path internals.
+fn extract_root_package_json(tgz: &[u8]) -> String {
+    use flate2::read::GzDecoder;
+    let mut archive = tar::Archive::new(GzDecoder::new(tgz));
+    for entry in archive.entries().unwrap() {
+        let mut e = entry.unwrap();
+        let p = e.path().unwrap();
+        if p.to_str() == Some("package/package.json") {
+            let mut s = String::new();
+            use std::io::Read;
+            e.read_to_string(&mut s).unwrap();
+            return s;
+        }
+    }
+    panic!("package/package.json not found in tarball");
+}


### PR DESCRIPTION
## Summary

- `speculative_pre_strip_packument` now iterates **every** entry in `dist-tags`, deduped by target version, capped at 8, with `latest` first. Closes the EINTEGRITY-on-first-attempt limitation for `npm install pkg@next` / `pkg@beta` / `pkg@lts` documented in CLAUDE.md roadmap #15.
- Per-version work runs concurrently via `tokio::JoinSet` (up to 4 in flight) under a 20s overall deadline. Per-fetch budget stays at 10s. Failures stay best-effort and fall through to the existing lazy tarball-path strip.
- True pinned-version installs (`pkg@1.2.3` for a version not in `dist-tags`) remain out of scope — proxy cannot predict the user's pin.

## Plan review

Consulted Codex once before implementing. Three notes incorporated:

1. Dedupe before spawn (covers same-version-multiple-tags and same-tarball cases).
2. Cap distinct pre-strip targets (`MAX_PRE_STRIP_TAGS=8`, `latest` first).
3. Cache insertion races are tolerated by `StripCache::insert` semantics.

## Test plan

New `crates/sakimori-proxy/tests/proxy_multitag_prestrip_e2e.rs` drives a full proxy round trip with three dist-tags (`latest=2.0.0`, `next=1.0.0`, `dup=2.0.0` to exercise dedupe):

- [x] Both tagged versions' `dist.integrity` rewritten in the packument response
- [x] `dist.attestations` dropped post-strip (provenance signature is over the original bytes)
- [x] Follow-up tarball fetches return bodies whose sha512 matches the rewritten integrity — npm's first install attempt would now succeed
- [x] Upstream sees ≤2 fetches per version (no double-fetch from un-deduped tags)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green (274 lib tests + all integration tests)