### PR TITLE
feat(installs): log direct git-source fetches with provenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,8 +295,25 @@ the canonical public hosts, list the internal hosts under
    half landed: the proxy's pinned-install path now appends every
    resolved fetch to `~/.sakimori/installs.jsonl`
    (`InstallEvent { ecosystem, name, version, resolved_at,
-   execution_mode, user_agent }` — `project_path` and richer
-   attribution come next), and `sakimori advisories scan` reads
+   execution_mode, user_agent, git? }` — `project_path` and richer
+   attribution come next; the optional `git: GitProvenance { url,
+   requested_ref, resolved_commit, commit_source }` block carries
+   git-fetch traceability when `ecosystem == "git"`, populated by
+   the github.com / codeload.github.com / api.github.com URL
+   classifier in `sakimori_proxy::git_fetch`. Covers `npm install
+   github:owner/repo` (codeload tarballs), `cargo`'s `git = "..."`
+   and `pip install git+https://...` (clone-protocol discovery at
+   `<repo>.git/info/refs?service=git-upload-pack`), and REST
+   tarball/zipball fetches. When the URL ref is a 40-hex SHA the
+   classifier records it as `resolved_commit` with
+   `commit_source: "url"`; tag/branch refs leave
+   `resolved_commit` unset and the follow-up via codeload's
+   `ETag` header / git-upload-pack pkt-line parsing is the
+   tracked next slice). Git events are skipped by `deps check`
+   (no publish-time semantics), OSV scan (no clean ecosystem
+   mapping for arbitrary repo URLs), and typosquat lookups — the
+   value is post-hoc auditing of "what was actually fetched", not
+   age-gating. `sakimori advisories scan` reads
    that log, dedupes by `(eco, name, version)`, and batch-queries
    [OSV.dev](https://osv.dev)'s `POST /v1/querybatch` for matching
    advisories. Hits exit non-zero so it slots into cron / CI.

--- a/crates/sakimori-core/src/deps/lockfile/mod.rs
+++ b/crates/sakimori-core/src/deps/lockfile/mod.rs
@@ -33,6 +33,12 @@ pub fn parse(eco: Ecosystem, path: &Path) -> Result<Vec<Package>> {
         Ecosystem::Crates => cargo::parse(path),
         Ecosystem::Pypi => pypi::parse(path),
         Ecosystem::Nuget => nuget::parse(path),
+        // No lockfile shape is detected as `Git`; the variant only
+        // shows up via the proxy's install logger.
+        Ecosystem::Git => anyhow::bail!(
+            "git ecosystem has no lockfile parser — git deps are observed at fetch time, \
+             not parsed from a lockfile"
+        ),
     }
 }
 

--- a/crates/sakimori-core/src/deps/mod.rs
+++ b/crates/sakimori-core/src/deps/mod.rs
@@ -37,6 +37,12 @@ pub enum Ecosystem {
     Crates,
     Pypi,
     Nuget,
+    /// Direct git-source dependency (e.g. `npm install github:o/r`,
+    /// `cargo` `git = "..."`, `pip install git+https://...`). Has no
+    /// publish-time semantics — only used by the proxy's install
+    /// logger so post-hoc auditing knows what was fetched. Skipped by
+    /// `deps check`, OSV scan, and typosquat lookups.
+    Git,
 }
 
 impl Ecosystem {
@@ -46,6 +52,7 @@ impl Ecosystem {
             Ecosystem::Crates => "crates",
             Ecosystem::Pypi => "pypi",
             Ecosystem::Nuget => "nuget",
+            Ecosystem::Git => "git",
         }
     }
 }
@@ -208,6 +215,11 @@ fn fetch_published(
         Ecosystem::Crates => registry::crates::published(name, version, user_agent)?,
         Ecosystem::Pypi => registry::pypi::published(name, version, user_agent)?,
         Ecosystem::Nuget => registry::nuget::published(name, version, user_agent)?,
+        // Git deps have no registry publish-time. Lockfile parsers
+        // already skip them, so reaching this arm means a caller
+        // hand-built a Git Package — return None ("don't know") rather
+        // than crash so deps check can carry on with the rest.
+        Ecosystem::Git => None,
     };
     if let (Some(dt), Some(c)) = (result, cache) {
         c.put(eco, name, version, dt);

--- a/crates/sakimori-core/src/installs.rs
+++ b/crates/sakimori-core/src/installs.rs
@@ -40,6 +40,36 @@ pub enum ExecutionMode {
     Unknown,
 }
 
+/// Extra provenance for `Ecosystem::Git` events — packages fetched
+/// directly from a git host (github.com / codeload / api.github.com)
+/// rather than a package registry. None of this is meaningful for
+/// registry installs and the field stays `None` for them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitProvenance {
+    /// Full URL the proxy saw, with the query string stripped (path
+    /// alone carries enough info to reconstruct the fetch and the
+    /// query may include short-lived auth tokens).
+    pub url: String,
+    /// Requested ref as it appeared in the URL — a 40-hex SHA, a tag
+    /// (`v1.2.3`), a branch (`main`), or `HEAD` for clone-protocol
+    /// discovery. `None` when the host endpoint defaults to the
+    /// repository's default branch (e.g. `/repos/o/r/tarball` with no
+    /// trailing ref).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_ref: Option<String>,
+    /// 40-hex commit SHA when extractable. Populated today only when
+    /// `requested_ref` is itself a 40-hex SHA; future iterations can
+    /// extract it from codeload's `ETag` header or git-upload-pack
+    /// pkt-line responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
+    /// Where `resolved_commit` came from — `"url"` today, `"etag"` /
+    /// `"upload-pack"` reserved for follow-ups. `None` when
+    /// `resolved_commit` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_source: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallEvent {
     pub ecosystem: String,
@@ -55,6 +85,9 @@ pub struct InstallEvent {
     /// chain reconstructable after the fact.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_agent: Option<String>,
+    /// Git-fetch provenance. `Some` exactly when `ecosystem == "git"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git: Option<GitProvenance>,
 }
 
 impl InstallEvent {
@@ -67,7 +100,13 @@ impl InstallEvent {
             execution_mode: ExecutionMode::Unknown,
             project_path: None,
             user_agent: None,
+            git: None,
         }
+    }
+
+    pub fn with_git(mut self, git: GitProvenance) -> Self {
+        self.git = Some(git);
+        self
     }
 
     pub fn with_mode(mut self, mode: ExecutionMode) -> Self {

--- a/crates/sakimori-proxy/src/decision.rs
+++ b/crates/sakimori-proxy/src/decision.rs
@@ -245,6 +245,10 @@ impl AgeOracle for RegistryOracle {
             Ecosystem::Npm => registry::npm::published(name, version, &self.user_agent),
             Ecosystem::Pypi => registry::pypi::published(name, version, &self.user_agent),
             Ecosystem::Nuget => registry::nuget::published(name, version, &self.user_agent),
+            // Git deps never reach the decider (the parsers don't
+            // classify github.com traffic as Pinned), but the match
+            // must stay exhaustive.
+            Ecosystem::Git => Ok(None),
         }
     }
 }

--- a/crates/sakimori-proxy/src/git_fetch.rs
+++ b/crates/sakimori-proxy/src/git_fetch.rs
@@ -1,0 +1,320 @@
+//! Classify HTTP traffic to git hosting providers (GitHub today;
+//! GitLab / Bitbucket as follow-ups) so the proxy can record direct
+//! git-source installs in `installs.jsonl`.
+//!
+//! Three URL shapes are recognised:
+//!
+//! 1. **codeload tarball/zipball** — `https://codeload.github.com/
+//!    <owner>/<repo>/{tar.gz,zip,legacy.tar.gz,legacy.zip}/<ref>`.
+//!    What `npm install github:owner/repo` actually fetches; ref in
+//!    the last path segment is a 40-hex SHA, a tag, or a branch.
+//! 2. **GitHub REST tarball/zipball** — `https://api.github.com/
+//!    repos/<owner>/<repo>/{tarball,zipball}[/<ref>]`. Used by `go
+//!    get` and various script downloaders; ref optional (defaults to
+//!    the repo's default branch when absent).
+//! 3. **smart-HTTP clone discovery** — `GET /<owner>/<repo>.git/
+//!    info/refs?service=git-upload-pack` on `github.com`. The first
+//!    request of every `git clone` over HTTPS, which means
+//!    `cargo`'s `git = "..."` deps, `pip install git+https://...`,
+//!    and `git submodule update`. The follow-up `POST
+//!    /<owner>/<repo>.git/git-upload-pack` carries the resolved
+//!    SHAs but is intentionally NOT classified here — logging both
+//!    would double-count the same install. The info/refs hit is
+//!    enough to record "this repo was cloned"; resolving the
+//!    specific commit needs pkt-line parsing of the upload-pack
+//!    body, which is a follow-up.
+//!
+//! Fail-quiet: any URL the patterns don't recognise returns `None`
+//! and the caller skips logging. The classifier never errors — a
+//! mis-classification just means a missed log line, not a broken
+//! install.
+
+/// A classified git fetch. `requested_ref` is `None` for endpoints
+/// that default to the repository's default branch (today: only
+/// `api.github.com` tarball/zipball without a trailing ref).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitFetch {
+    pub host: String,
+    pub owner: String,
+    pub repo: String,
+    pub requested_ref: Option<String>,
+    /// Canonical `host + path` for the `GitProvenance.url` field.
+    /// Query string is stripped because (a) tokens may be embedded
+    /// in it and (b) the path alone is enough to reconstruct the
+    /// fetch.
+    pub url: String,
+    /// What the proxy is observing — drives whether the version
+    /// field on the emitted InstallEvent should be the ref (tarball
+    /// pulls) or `"HEAD"` (clone-protocol discovery, which doesn't
+    /// yet bind to a specific ref).
+    pub kind: GitFetchKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitFetchKind {
+    /// Single-archive download — codeload or REST tarball/zipball.
+    Archive,
+    /// `info/refs?service=git-upload-pack` — clone is starting.
+    CloneDiscovery,
+}
+
+impl GitFetch {
+    /// `<host>/<owner>/<repo>` — the Go-module-style identifier we
+    /// store as `InstallEvent::name`. Lowercased so `Github.com` and
+    /// `github.com` collapse into the same entry.
+    pub fn name(&self) -> String {
+        format!(
+            "{}/{}/{}",
+            self.host.to_ascii_lowercase(),
+            self.owner,
+            self.repo
+        )
+    }
+
+    /// `true` when [`Self::requested_ref`] is a 40-character lower-
+    /// hex string. The proxy treats that ref as the resolved commit
+    /// SHA and populates `GitProvenance::resolved_commit`
+    /// accordingly.
+    pub fn ref_is_commit_sha(&self) -> bool {
+        self.requested_ref
+            .as_deref()
+            .map(is_full_sha)
+            .unwrap_or(false)
+    }
+}
+
+/// Best-effort classification. Returns `None` when the URL doesn't
+/// match any of the three recognised shapes.
+pub fn classify(host: &str, path_and_query: &str) -> Option<GitFetch> {
+    let host_lc = host.to_ascii_lowercase();
+    // Strip query string — kept separately if a future caller wants
+    // it but never folded into the recorded URL.
+    let path = path_and_query.split('?').next().unwrap_or(path_and_query);
+    match host_lc.as_str() {
+        "codeload.github.com" => parse_codeload(&host_lc, path),
+        "api.github.com" => parse_api_github(&host_lc, path),
+        "github.com" => parse_github_clone(&host_lc, path),
+        _ => None,
+    }
+}
+
+fn parse_codeload(host: &str, path: &str) -> Option<GitFetch> {
+    // /<owner>/<repo>/{tar.gz,zip,legacy.tar.gz,legacy.zip}/<ref>
+    let segs: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+    if segs.len() < 4 {
+        return None;
+    }
+    let (owner, repo, kind) = (segs[0], segs[1], segs[2]);
+    if !matches!(kind, "tar.gz" | "zip" | "legacy.tar.gz" | "legacy.zip") {
+        return None;
+    }
+    // ref may itself contain `/` (branch like `feat/x`). Re-join the
+    // tail.
+    let r = segs[3..].join("/");
+    if owner.is_empty() || repo.is_empty() || r.is_empty() {
+        return None;
+    }
+    Some(GitFetch {
+        host: host.to_string(),
+        owner: owner.to_string(),
+        repo: strip_git_suffix(repo).to_string(),
+        requested_ref: Some(r),
+        url: format!("{host}{path}"),
+        kind: GitFetchKind::Archive,
+    })
+}
+
+fn parse_api_github(host: &str, path: &str) -> Option<GitFetch> {
+    // /repos/<owner>/<repo>/{tarball,zipball}[/<ref>]
+    let segs: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+    if segs.len() < 4 || segs[0] != "repos" {
+        return None;
+    }
+    let (owner, repo, kind) = (segs[1], segs[2], segs[3]);
+    if !matches!(kind, "tarball" | "zipball") {
+        return None;
+    }
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    let r = if segs.len() > 4 {
+        let tail = segs[4..].join("/");
+        if tail.is_empty() { None } else { Some(tail) }
+    } else {
+        None
+    };
+    Some(GitFetch {
+        host: host.to_string(),
+        owner: owner.to_string(),
+        repo: strip_git_suffix(repo).to_string(),
+        requested_ref: r,
+        url: format!("{host}{path}"),
+        kind: GitFetchKind::Archive,
+    })
+}
+
+fn parse_github_clone(host: &str, path: &str) -> Option<GitFetch> {
+    // /<owner>/<repo>.git/info/refs (query has already been stripped)
+    let rest = path.trim_start_matches('/');
+    let info_refs_suffix = ".git/info/refs";
+    let prefix = rest.strip_suffix(info_refs_suffix)?;
+    let mut parts = prefix.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    // Extra segments → not the smart-HTTP discovery endpoint we want.
+    if parts.next().is_some() {
+        return None;
+    }
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some(GitFetch {
+        host: host.to_string(),
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        // Ref is not yet bound at info/refs time — the server
+        // advertises every ref and the client chooses afterward.
+        requested_ref: None,
+        url: format!("{host}{path}"),
+        kind: GitFetchKind::CloneDiscovery,
+    })
+}
+
+fn strip_git_suffix(s: &str) -> &str {
+    s.strip_suffix(".git").unwrap_or(s)
+}
+
+fn is_full_sha(s: &str) -> bool {
+    s.len() == 40
+        && s.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codeload_targz_with_sha_ref() {
+        let g = classify(
+            "codeload.github.com",
+            "/octocat/Hello-World/tar.gz/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+        )
+        .unwrap();
+        assert_eq!(g.host, "codeload.github.com");
+        assert_eq!(g.owner, "octocat");
+        assert_eq!(g.repo, "Hello-World");
+        assert_eq!(
+            g.requested_ref.as_deref(),
+            Some("7fd1a60b01f91b314f59955a4e4d4e80d8edf11d")
+        );
+        assert!(g.ref_is_commit_sha());
+        assert_eq!(g.kind, GitFetchKind::Archive);
+        assert_eq!(g.name(), "codeload.github.com/octocat/Hello-World");
+    }
+
+    #[test]
+    fn codeload_zip_with_branch_ref_containing_slash() {
+        let g = classify("codeload.github.com", "/o/r/zip/feat/new-thing").unwrap();
+        assert_eq!(g.requested_ref.as_deref(), Some("feat/new-thing"));
+        assert!(!g.ref_is_commit_sha());
+    }
+
+    #[test]
+    fn codeload_strips_dot_git_from_repo() {
+        let g = classify("codeload.github.com", "/o/r.git/tar.gz/main").unwrap();
+        assert_eq!(g.repo, "r");
+    }
+
+    #[test]
+    fn codeload_rejects_unknown_archive_type() {
+        assert!(classify("codeload.github.com", "/o/r/bz2/main").is_none());
+    }
+
+    #[test]
+    fn codeload_rejects_missing_ref() {
+        assert!(classify("codeload.github.com", "/o/r/tar.gz/").is_none());
+        assert!(classify("codeload.github.com", "/o/r/tar.gz").is_none());
+    }
+
+    #[test]
+    fn api_github_tarball_with_ref() {
+        let g = classify("api.github.com", "/repos/o/r/tarball/v1.2.3").unwrap();
+        assert_eq!(g.host, "api.github.com");
+        assert_eq!(g.requested_ref.as_deref(), Some("v1.2.3"));
+        assert!(!g.ref_is_commit_sha());
+    }
+
+    #[test]
+    fn api_github_zipball_without_ref_defaults_to_default_branch() {
+        let g = classify("api.github.com", "/repos/o/r/zipball").unwrap();
+        assert_eq!(g.requested_ref, None);
+    }
+
+    #[test]
+    fn api_github_ignores_non_archive_paths() {
+        assert!(classify("api.github.com", "/repos/o/r/contents/foo").is_none());
+        assert!(classify("api.github.com", "/users/o").is_none());
+    }
+
+    #[test]
+    fn github_clone_discovery_endpoint() {
+        let g = classify(
+            "github.com",
+            "/rust-lang/cargo.git/info/refs?service=git-upload-pack",
+        )
+        .unwrap();
+        assert_eq!(g.host, "github.com");
+        assert_eq!(g.owner, "rust-lang");
+        assert_eq!(g.repo, "cargo");
+        assert_eq!(g.requested_ref, None);
+        assert_eq!(g.kind, GitFetchKind::CloneDiscovery);
+        // Query string is intentionally stripped from the stored URL
+        // — tokens may be embedded there and the path alone is
+        // enough to reconstruct the fetch.
+        assert_eq!(g.url, "github.com/rust-lang/cargo.git/info/refs");
+    }
+
+    #[test]
+    fn github_post_upload_pack_is_not_classified() {
+        // Intentionally skipped — see module comment. Logging both
+        // info/refs (GET) and git-upload-pack (POST) would
+        // double-count the same clone.
+        assert!(classify("github.com", "/o/r.git/git-upload-pack").is_none());
+    }
+
+    #[test]
+    fn github_rejects_non_clone_paths() {
+        assert!(classify("github.com", "/o/r").is_none());
+        assert!(classify("github.com", "/o/r/info/refs").is_none()); // missing .git
+        assert!(classify("github.com", "/o/r.git/info/packs").is_none());
+    }
+
+    #[test]
+    fn classify_is_case_insensitive_on_host() {
+        assert!(classify("Codeload.GitHub.com", "/o/r/tar.gz/main").is_some());
+        assert!(classify("API.github.com", "/repos/o/r/tarball/main").is_some());
+    }
+
+    #[test]
+    fn unknown_host_returns_none() {
+        assert!(classify("gitlab.com", "/o/r/-/archive/main/r-main.tar.gz").is_none());
+        assert!(classify("bitbucket.org", "/o/r/get/main.tar.gz").is_none());
+    }
+
+    #[test]
+    fn full_sha_detection_rejects_short_and_mixed_case() {
+        assert!(is_full_sha("abcdef0123456789abcdef0123456789abcdef01"));
+        assert!(!is_full_sha("abcdef")); // too short
+        assert!(!is_full_sha("ABCDEF0123456789ABCDEF0123456789ABCDEF01")); // uppercase
+        assert!(!is_full_sha("g".repeat(40).as_str())); // non-hex
+    }
+
+    #[test]
+    fn query_string_is_stripped_from_url() {
+        let g = classify("codeload.github.com", "/o/r/tar.gz/main?token=abc").unwrap();
+        // The classifier folds query-bearing URLs the same way as
+        // bare ones — the stored URL has no `?…` suffix.
+        assert!(!g.url.contains('?'));
+    }
+}

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod ca;
 pub mod daemon;
 pub mod decision;
+pub mod git_fetch;
 pub mod host_allow;
 pub mod install;
 pub mod lifecycle;

--- a/crates/sakimori-proxy/src/osv.rs
+++ b/crates/sakimori-proxy/src/osv.rs
@@ -94,7 +94,9 @@ impl OsvClient {
     }
 
     fn fetch(&self, eco: Ecosystem, name: &str, version: &str) -> Result<Vec<String>> {
-        let eco_str = eco_to_osv(eco);
+        let Some(eco_str) = eco_to_osv(eco) else {
+            return Ok(Vec::new());
+        };
         let body = serde_json::json!({
             "package": { "name": name, "ecosystem": eco_str },
             "version": version,
@@ -177,14 +179,19 @@ fn is_malicious(v: &OsvVuln) -> bool {
     summary.contains("malicious") || details.contains("malicious")
 }
 
-fn eco_to_osv(eco: Ecosystem) -> &'static str {
+fn eco_to_osv(eco: Ecosystem) -> Option<&'static str> {
     // OSV's ecosystem strings:
     //   https://ossf.github.io/osv-schema/#affectedpackage-field
     match eco {
-        Ecosystem::Crates => "crates.io",
-        Ecosystem::Npm => "npm",
-        Ecosystem::Pypi => "PyPI",
-        Ecosystem::Nuget => "NuGet",
+        Ecosystem::Crates => Some("crates.io"),
+        Ecosystem::Npm => Some("npm"),
+        Ecosystem::Pypi => Some("PyPI"),
+        Ecosystem::Nuget => Some("NuGet"),
+        // Git deps have no OSV ecosystem mapping (a github.com/o/r
+        // path could be Go, but it could also be any of a dozen
+        // ecosystems that happen to host their canonical source there
+        // — we'd be guessing). Return None and let the caller skip.
+        Ecosystem::Git => None,
     }
 }
 
@@ -250,10 +257,11 @@ mod tests {
 
     #[test]
     fn ecosystem_mapping_matches_osv_schema() {
-        assert_eq!(eco_to_osv(Ecosystem::Crates), "crates.io");
-        assert_eq!(eco_to_osv(Ecosystem::Npm), "npm");
-        assert_eq!(eco_to_osv(Ecosystem::Pypi), "PyPI");
-        assert_eq!(eco_to_osv(Ecosystem::Nuget), "NuGet");
+        assert_eq!(eco_to_osv(Ecosystem::Crates), Some("crates.io"));
+        assert_eq!(eco_to_osv(Ecosystem::Npm), Some("npm"));
+        assert_eq!(eco_to_osv(Ecosystem::Pypi), Some("PyPI"));
+        assert_eq!(eco_to_osv(Ecosystem::Nuget), Some("NuGet"));
+        assert_eq!(eco_to_osv(Ecosystem::Git), None);
     }
 
     #[test]

--- a/crates/sakimori-proxy/src/otlp.rs
+++ b/crates/sakimori-proxy/src/otlp.rs
@@ -125,6 +125,18 @@ fn build_payload(event: &InstallEvent, service_name: &str, service_version: &str
     if let Some(ua) = event.user_agent.as_deref() {
         attrs.push(attr_str("package.user_agent", ua));
     }
+    if let Some(g) = event.git.as_ref() {
+        attrs.push(attr_str("package.git.url", &g.url));
+        if let Some(r) = g.requested_ref.as_deref() {
+            attrs.push(attr_str("package.git.requested_ref", r));
+        }
+        if let Some(c) = g.resolved_commit.as_deref() {
+            attrs.push(attr_str("package.git.resolved_commit", c));
+        }
+        if let Some(s) = g.commit_source.as_deref() {
+            attrs.push(attr_str("package.git.commit_source", s));
+        }
+    }
 
     json!({
         "resourceLogs": [{

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -18,7 +18,8 @@ use hudsucker::{
     rcgen::KeyPair,
 };
 
-use sakimori_core::installs::{ExecutionMode, InstallEvent, InstallLogger};
+use sakimori_core::deps::Ecosystem;
+use sakimori_core::installs::{ExecutionMode, GitProvenance, InstallEvent, InstallLogger};
 
 use crate::ca::{CaFiles, ensure_ca, trust_instructions};
 use crate::decision::{AgeOracle, Decider, Decision};
@@ -626,6 +627,49 @@ struct SakimoriHandler {
 }
 
 impl SakimoriHandler {
+    /// Build and emit an `InstallEvent` for a classified git fetch.
+    /// Mirrors the registry-fetch logging branch in `handle_request`
+    /// but with `Ecosystem::Git` and a `GitProvenance` block carrying
+    /// the URL, the requested ref, and (when the ref is itself a
+    /// 40-hex SHA) the resolved commit.
+    ///
+    /// Best-effort: log-write failures are warned about but never
+    /// surfaced to the upstream fetch — a broken log must not break
+    /// `cargo build` / `npm install`.
+    fn log_git_fetch(&self, fetch: &crate::git_fetch::GitFetch, user_agent: &str) {
+        // version field: the ref the client asked for. For
+        // clone-protocol discovery (no ref bound yet) and api.github
+        // tarballs without an explicit ref, fall back to "HEAD" so
+        // consumers don't trip on an empty version string.
+        let version = fetch.requested_ref.clone().unwrap_or_else(|| "HEAD".into());
+        let (resolved_commit, commit_source) = if fetch.ref_is_commit_sha() {
+            (fetch.requested_ref.clone(), Some("url".to_string()))
+        } else {
+            (None, None)
+        };
+        let provenance = GitProvenance {
+            url: fetch.url.clone(),
+            requested_ref: fetch.requested_ref.clone(),
+            resolved_commit,
+            commit_source,
+        };
+        let mode = classify_execution_mode(user_agent);
+        let mut ev = InstallEvent::new(Ecosystem::Git, fetch.name(), version)
+            .with_mode(mode)
+            .with_git(provenance);
+        if !user_agent.is_empty() {
+            ev = ev.with_user_agent(user_agent);
+        }
+        if let Some(logger) = self.install_logger.as_ref()
+            && let Err(e) = logger.record(&ev)
+        {
+            log::warn!("install log write failed (git fetch): {e:#}");
+        }
+        if let Some(exporter) = self.otlp_exporter.as_ref() {
+            exporter.dispatch(&ev);
+        }
+    }
+
     /// Buffer the tarball body, inspect `package.json` for
     /// install-time lifecycle scripts, then either audit-log + pass
     /// through (Audit) or return 403 (Block).
@@ -942,6 +986,28 @@ impl HttpHandler for SakimoriHandler {
             .next()
             .unwrap_or("")
             .to_string();
+        // Git-fetch logging runs before `should_intercept` because
+        // github.com / codeload.github.com / api.github.com are NOT
+        // registry hosts — they'd otherwise be CONNECT-tunnelled
+        // opaquely and the `installs.jsonl` log would never see direct
+        // git deps (`npm install github:o/r`, `cargo` `git = "..."`,
+        // `pip install git+https://...`). We never modify the request
+        // or response; the log line is the only side effect.
+        if self.install_logger.is_some() || self.otlp_exporter.is_some() {
+            let raw_path = req
+                .uri()
+                .path_and_query()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_else(|| "/".into());
+            if let Some(fetch) = crate::git_fetch::classify(&host, &raw_path) {
+                let ua = req
+                    .headers()
+                    .get(http::header::USER_AGENT)
+                    .and_then(|h| h.to_str().ok())
+                    .unwrap_or("");
+                self.log_git_fetch(&fetch, ua);
+            }
+        }
         if !should_intercept(&host, &self.parsers) {
             self.last_host = None;
             self.last_path = None;

--- a/crates/sakimori-proxy/src/typosquat.rs
+++ b/crates/sakimori-proxy/src/typosquat.rs
@@ -192,6 +192,10 @@ fn top_list_for(eco: Ecosystem) -> &'static [&'static str] {
         Ecosystem::Npm => NPM_TOP,
         Ecosystem::Pypi => PYPI_TOP,
         Ecosystem::Nuget => NUGET_TOP,
+        // No typosquat list for git deps — a repo name like
+        // `github.com/owner/repo` is not part of any package
+        // registry's top-N download ranking.
+        Ecosystem::Git => &[],
     }
 }
 
@@ -233,6 +237,9 @@ impl MirrorLists {
             Ecosystem::Npm => &self.npm,
             Ecosystem::Pypi => &self.pypi,
             Ecosystem::Nuget => &self.nuget,
+            // Git deps aren't part of the mirrored top-N — see
+            // `top_list_for`.
+            Ecosystem::Git => &[],
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `Ecosystem::Git` variant + `GitProvenance { url, requested_ref, resolved_commit, commit_source }` on `InstallEvent` so the proxy records direct git-source installs (`npm install github:o/r`, cargo `git = "..."`, `pip install git+https://...`, REST tarball/zipball pulls) that previously passed through opaquely.
- New `sakimori_proxy::git_fetch` classifier recognises three URL shapes — codeload tarball/zipball, `api.github.com` REST tarball/zipball, and smart-HTTP clone discovery (`<repo>.git/info/refs`) — and runs **before** `should_intercept` so non-registry hosts are still logged. 40-hex refs are recorded as `resolved_commit` with `commit_source: "url"`; tag/branch refs leave it unset for a follow-up via ETag / pkt-line parsing.
- OTLP payload gains `package.git.{url,requested_ref,resolved_commit,commit_source}` attributes when present.

Git events are deliberately **skipped** by `deps check` (no publish-time semantics), OSV scan (no clean ecosystem mapping for arbitrary repo URLs), and typosquat lookups — the value is post-hoc auditing of "what was actually fetched", not age-gating.

Roadmap context: closes the "git deps bypass the install log" gap surfaced while reviewing private-registry / GitHub-repo coverage (CLAUDE.md roadmap #6).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (all green)
- [x] 13 unit tests in `git_fetch.rs` covering: codeload SHA / branch-with-slash / `.git` suffix stripping / unknown archive type / missing ref; api.github tarball with ref / zipball without ref / non-archive paths; github clone discovery / rejected POST upload-pack / rejected non-clone paths; case-insensitive host; unknown host; 40-hex SHA detection (length / case / non-hex); query-string stripping
- [ ] Manual proxy run: `npm install github:sindresorhus/leftpad-detector` and confirm `~/.sakimori/installs.jsonl` gains a `{"ecosystem":"git", "git":{...}}` entry

## Follow-ups (tracked in CLAUDE.md)
- Resolve tag/branch refs to SHAs via codeload `ETag` header / git-upload-pack pkt-line parsing
- GitLab / Bitbucket URL shape support
- Private-git-host configuration alongside `--npm-registry` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)