### PR TITLE
feat(proxy,installs): .vsix lifecycle gate + editor-extension inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1117,15 +1117,33 @@ and lights up the most existing detection for free.
     return the default Inspection, defence does not fabricate
     denials on malformed-but-legitimate artefacts.
 
-    Still pending: proxy integration (recognise the
-    `.../vsextensions/<pub>/<ext>/<ver>/vspackage` URL shape in
-    `classify_response`, dispatch `LifecyclePolicy::{Audit,Block}`
-    on the inspected result), strip mode (rewrite
-    `activationEvents` + recompute the Marketplace integrity
-    hash), and `.crx` audit. `main` JS body scanning belongs
-    naturally in `iocs::ContentNeedle` rather than here. `.crx`
-    is signed end-to-end so strip is impossible by design;
-    audit/block only.
+    Proxy integration landed in this slice: `parse_vsix_download_path`
+    recognises both the canonical Marketplace shape
+    (`/_apis/public/gallery/publishers/<pub>/vsextensions/<ext>/<ver>/vspackage`)
+    and OpenVSX's REST shape (`/api/<ns>/<ext>/<ver>/file/<…>.vsix`).
+    When `--lifecycle-policy` is on and the response is for a
+    matching URL on a configured `vscode_marketplace` host, the proxy
+    buffers the `.vsix` bytes, runs `vsix_inspect::inspect_vsix`, and
+    in **Audit** mode logs the manifest (publisher, name, version,
+    `activationEvents`, `main`) for any extension that fires on
+    startup; in **Block** mode returns 403 with
+    `x-sakimori-deny: lifecycle-vsix` when `fires_on_startup` is true
+    (the wildcard `"*"` and `onStartupFinished` activation
+    primitives). Lazy activation (`onCommand:…`, `onLanguage:…`,
+    `workspaceContains:…`, no `activationEvents` at all) passes
+    through. Allow-list keys are canonical `publisher.name`
+    identifiers, case-insensitive — same shape VS Code itself uses.
+    `Strip` policy on `.vsix` falls back to `Block` semantics: the
+    Marketplace integrity hash the editor verifies covers the
+    archive bytes, so an in-place rewrite would be rejected.
+
+    Still pending: strip mode is effectively out of scope (the
+    Marketplace integrity hash + Microsoft signed-package flow
+    cover the archive bytes, so an in-place rewrite would be
+    rejected). `.crx` (Chrome extensions) audit is still pending;
+    `.crx` is signed end-to-end so strip is impossible by design,
+    audit/block only. `main` JS body scanning belongs naturally in
+    `iocs::ContentNeedle` rather than here.
 
 22. **Extension installs in the `InstallEvent` inventory.**
     Extend the `Ecosystem` enum (Roadmap #6) with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1146,16 +1146,33 @@ and lights up the most existing detection for free.
     `iocs::ContentNeedle` rather than here.
 
 22. **Extension installs in the `InstallEvent` inventory.**
-    Extend the `Ecosystem` enum (Roadmap #6) with
-    `VscodeExtension` / `ChromeExtension`. The proxy logger
-    already runs on every allowed install path; once #20 lands,
-    the Marketplace fetch matches an ecosystem and gets appended
-    to `~/.sakimori/installs.jsonl` and (if configured) dispatched
-    via `/ingest` and OTLP. `sakimori advisories scan` then
-    queries OSV/GHSA for advisories against extension IDs and
-    surfaces past installs — the same retroactive-CVE story
-    Dependabot/Snyk fundamentally can't tell because they're
-    repo-lockfile-bound.
+    ✅ VS Code half implemented. `Ecosystem::VscodeExtension`
+    (label `"vscode-extension"`) is now a sibling of `Git` in
+    `sakimori-core::deps`. The proxy recognises pinned `.vsix`
+    download URLs on configured `vscode_marketplace` hosts (the
+    canonical Marketplace `/_apis/.../vspackage` shape and OpenVSX
+    `/api/<ns>/<ext>/<ver>/file/<…>.vsix`) and emits an
+    `InstallEvent` with name = `publisher.extension` for every
+    fetch, regardless of `--lifecycle-policy`. The same event
+    flows through `install_logger` (`~/.sakimori/installs.jsonl`)
+    and the OTLP exporter when configured. `Decider` /
+    `KnownBadOracle` / typosquat / OSV exhaustive matches all
+    return None — the variant carries no publish-time, OSV
+    ecosystem, or top-N typosquat list, the same way `Git` does.
+
+    `sakimori advisories scan` already iterates every
+    `InstallEvent` in the log and queries OSV. Because
+    `eco_to_osv(VscodeExtension)` returns `None`, those entries
+    are silently skipped today — once OSV.dev publishes a
+    `vscode-marketplace` ecosystem (or we mirror GitHub Advisory
+    Database's VSCode advisories), the JOIN will light up with
+    zero further proxy changes.
+
+    `ChromeExtension` is still pending and gated on roadmap #20's
+    Chrome Web Store half (no inline publish-time means the
+    update endpoint needs an out-of-band lookup we haven't built).
+    Once that lands the same `InstallEvent` pattern extends
+    naturally.
 
 23. **Workspace `.vscode/` / `.cursor/` as known-IOC surface.**
     ✅ first rule landed in catalog v2026.05.21:

--- a/crates/sakimori-core/src/deps/lockfile/mod.rs
+++ b/crates/sakimori-core/src/deps/lockfile/mod.rs
@@ -39,6 +39,13 @@ pub fn parse(eco: Ecosystem, path: &Path) -> Result<Vec<Package>> {
             "git ecosystem has no lockfile parser — git deps are observed at fetch time, \
              not parsed from a lockfile"
         ),
+        // VS Code / OpenVSX extensions are observed at fetch time
+        // through the proxy, the same way `Git` is — no lockfile
+        // shape exists today.
+        Ecosystem::VscodeExtension => anyhow::bail!(
+            "vscode-extension ecosystem has no lockfile parser — editor extensions are \
+             observed at fetch time, not parsed from a lockfile"
+        ),
     }
 }
 

--- a/crates/sakimori-core/src/deps/mod.rs
+++ b/crates/sakimori-core/src/deps/mod.rs
@@ -43,6 +43,16 @@ pub enum Ecosystem {
     /// logger so post-hoc auditing knows what was fetched. Skipped by
     /// `deps check`, OSV scan, and typosquat lookups.
     Git,
+    /// VS Code / OpenVSX editor extension (`.vsix`) install. Name is
+    /// the canonical `publisher.extension` identifier. Has no
+    /// publish-time semantics here (publish dates come from the
+    /// Marketplace `lastUpdated` field which the `extensionquery`
+    /// rewriter handles separately) — only used by the proxy's
+    /// install logger so post-hoc auditing knows which extensions
+    /// landed on the runner / developer laptop. Skipped by
+    /// `deps check`, OSV scan, and typosquat lookups for the same
+    /// reason `Git` is — no clean version-graph to query.
+    VscodeExtension,
 }
 
 impl Ecosystem {
@@ -53,6 +63,7 @@ impl Ecosystem {
             Ecosystem::Pypi => "pypi",
             Ecosystem::Nuget => "nuget",
             Ecosystem::Git => "git",
+            Ecosystem::VscodeExtension => "vscode-extension",
         }
     }
 }
@@ -220,6 +231,13 @@ fn fetch_published(
         // hand-built a Git Package — return None ("don't know") rather
         // than crash so deps check can carry on with the rest.
         Ecosystem::Git => None,
+        // VSCode/OpenVSX extensions: the Marketplace's `lastUpdated`
+        // field is the source of truth, served via `extensionquery`.
+        // `deps check` doesn't ingest those today (no lockfile shape
+        // for editor extensions), so reaching this arm means a caller
+        // hand-built a VscodeExtension Package — return None for the
+        // same fail-soft reason as Git.
+        Ecosystem::VscodeExtension => None,
     };
     if let (Some(dt), Some(c)) = (result, cache) {
         c.put(eco, name, version, dt);

--- a/crates/sakimori-proxy/src/decision.rs
+++ b/crates/sakimori-proxy/src/decision.rs
@@ -249,6 +249,12 @@ impl AgeOracle for RegistryOracle {
             // classify github.com traffic as Pinned), but the match
             // must stay exhaustive.
             Ecosystem::Git => Ok(None),
+            // VS Code extensions don't reach the decider either —
+            // the `.vsix` install logger bypasses the Pinned decision
+            // path (see `parse_vsix_download_path`) since the
+            // Marketplace `lastUpdated` field is on the metadata
+            // endpoint, not the tarball URL.
+            Ecosystem::VscodeExtension => Ok(None),
         }
     }
 }

--- a/crates/sakimori-proxy/src/osv.rs
+++ b/crates/sakimori-proxy/src/osv.rs
@@ -192,6 +192,12 @@ fn eco_to_osv(eco: Ecosystem) -> Option<&'static str> {
         // ecosystems that happen to host their canonical source there
         // — we'd be guessing). Return None and let the caller skip.
         Ecosystem::Git => None,
+        // VS Code extensions: OSV.dev does not currently advertise a
+        // dedicated ecosystem string for Marketplace / OpenVSX
+        // extensions (the closest is `GitHub Actions` for an
+        // unrelated surface). Return None and let the caller skip
+        // until OSV adds editor-extension coverage.
+        Ecosystem::VscodeExtension => None,
     }
 }
 

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -1199,22 +1199,47 @@ impl HttpHandler for SakimoriHandler {
             .and_then(|h| h.to_str().ok())
             .unwrap_or("")
             .to_string();
-        // `.vsix` lifecycle gate — VS Code Marketplace / OpenVSX
-        // tarballs aren't in `ParseResult::Pinned` because
-        // `Ecosystem` doesn't carry an editor-extension variant yet
-        // (roadmap #22). Recognise the URL shape directly on
-        // configured marketplace hosts and tag the response for
-        // inspection. Allow-list keys are canonical `publisher.name`
-        // identifiers, case-insensitive.
-        if self.lifecycle_policy.is_some()
-            && host_in(&self.registries.vscode_marketplace, &host)
+        // `.vsix` install logging + lifecycle gate. VS Code
+        // Marketplace / OpenVSX tarballs don't fit
+        // `ParseResult::Pinned` (publisher segment, no `.tgz`), so
+        // we recognise the URL shape directly on configured
+        // marketplace hosts. The install is logged with
+        // `Ecosystem::VscodeExtension` and name = canonical
+        // `publisher.extension` identifier (same form VS Code uses
+        // internally and that the lifecycle allow-list matches
+        // against). Logging happens regardless of `--lifecycle-policy`
+        // so a no-policy proxy still produces an editor-extension
+        // inventory. Lifecycle tagging is gated on policy + allow-list
+        // and feeds `handle_response`.
+        if host_in(&self.registries.vscode_marketplace, &host)
             && let Some((publisher, ext_name, version)) = parse_vsix_download_path(&path)
         {
             let ext_id = format!("{publisher}.{ext_name}");
-            if !self
-                .lifecycle_allow
-                .iter()
-                .any(|n| n.eq_ignore_ascii_case(&ext_id))
+            if self.install_logger.is_some() || self.otlp_exporter.is_some() {
+                let mode = classify_execution_mode(&user_agent);
+                let mut ev = InstallEvent::new(
+                    sakimori_core::deps::Ecosystem::VscodeExtension,
+                    ext_id.clone(),
+                    version.clone(),
+                )
+                .with_mode(mode);
+                if !user_agent.is_empty() {
+                    ev = ev.with_user_agent(&user_agent);
+                }
+                if let Some(logger) = self.install_logger.as_ref()
+                    && let Err(e) = logger.record(&ev)
+                {
+                    log::warn!("install log write failed (vsix): {e:#}");
+                }
+                if let Some(exporter) = self.otlp_exporter.as_ref() {
+                    exporter.dispatch(&ev);
+                }
+            }
+            if self.lifecycle_policy.is_some()
+                && !self
+                    .lifecycle_allow
+                    .iter()
+                    .any(|n| n.eq_ignore_ascii_case(&ext_id))
             {
                 self.last_vsix = Some((publisher, ext_name, version));
             }

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -346,6 +346,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         last_path: None,
         last_npm_tarball: None,
         last_pypi_sdist: None,
+        last_vsix: None,
         require_provenance: cfg.require_provenance,
         nuget_flat: NugetFlatContainerClient::new(cfg.user_agent.clone()),
         pypi_simple: PypiSimpleClient::new(cfg.user_agent.clone()),
@@ -598,6 +599,13 @@ struct SakimoriHandler {
     /// `.zip` ending). Wheels (`.whl`) are not tagged — they carry
     /// no install-time hook surface to inspect.
     last_pypi_sdist: Option<(String, String)>,
+    /// `Some((publisher, name, version))` when the in-flight request
+    /// was a pinned VS Code Marketplace / OpenVSX `.vsix` download.
+    /// `handle_response` runs the `.vsix` lifecycle gate against the
+    /// extension's `activationEvents` field when this is populated.
+    /// The allow-list key for an extension is the canonical
+    /// `publisher.name` identifier.
+    last_vsix: Option<(String, String, String)>,
     /// Forwarded from [`ProxyConfig::lifecycle_policy`]. `None`
     /// disables the gate entirely (no tarball buffering, no inspect).
     lifecycle_policy: Option<crate::lifecycle::LifecyclePolicy>,
@@ -945,6 +953,153 @@ impl SakimoriHandler {
             }
         }
     }
+
+    /// `.vsix` counterpart to [`Self::lifecycle_inspect_npm_tarball`].
+    ///
+    /// Block decision keys off `activationEvents` containing the
+    /// startup-autorun primitives (`"*"` or `onStartupFinished`) — the
+    /// highest-blast-radius VS Code extension shape and the one recent
+    /// supply-chain droppers favour because it removes the need to
+    /// convince a victim to invoke any specific command. Lazy
+    /// activation (`onCommand:…`, `onLanguage:…`, `workspaceContains:…`,
+    /// no `activationEvents` at all) is passed through.
+    ///
+    /// Strip mode falls back to Block: rewriting `activationEvents`
+    /// would require recomputing the Marketplace integrity hash the
+    /// editor later verifies, and the editor's signed-package flow on
+    /// Microsoft's gallery includes a separate Marketplace signature
+    /// that we can't forge. Documented in CLAUDE.md roadmap #21.
+    async fn lifecycle_inspect_vsix(
+        &self,
+        res: Response<Body>,
+        policy: crate::lifecycle::LifecyclePolicy,
+        publisher: &str,
+        name: &str,
+        version: &str,
+    ) -> Response<Body> {
+        use http_body_util::BodyExt;
+        let extension_id = format!("{publisher}.{name}");
+        let (mut parts, body) = res.into_parts();
+        let collected = match body.collect().await {
+            Ok(c) => c.to_bytes(),
+            Err(e) => {
+                log::warn!(
+                    "lifecycle(vsix): failed to buffer body for {extension_id}@{version}: {e}"
+                );
+                return Response::from_parts(parts, Body::empty());
+            }
+        };
+        let pass_through = || -> Response<Body> {
+            let mut parts2 = parts.clone();
+            parts2.headers.remove(http::header::CONTENT_LENGTH);
+            Response::from_parts(
+                parts2,
+                Body::from(http_body_util::Full::new(collected.clone())),
+            )
+        };
+        let inspection = match crate::vsix_inspect::inspect_vsix(&collected) {
+            Ok(i) => i,
+            Err(e) => {
+                log::warn!(
+                    "lifecycle(vsix): fail-open on {extension_id}@{version} — could not inspect: {e}"
+                );
+                return pass_through();
+            }
+        };
+        if !inspection.has_startup_autorun() {
+            log::debug!(
+                "lifecycle(vsix): {extension_id}@{version} — lazy activation only ({} event(s))",
+                inspection.activation_events.len()
+            );
+            return pass_through();
+        }
+        let events = inspection.activation_events.join(", ");
+        match policy {
+            crate::lifecycle::LifecyclePolicy::Audit => {
+                log::warn!(
+                    "lifecycle(vsix,audit): {extension_id}@{version} fires on editor startup: \
+                     activationEvents=[{events}]; main={main:?}",
+                    main = inspection.main,
+                );
+                pass_through()
+            }
+            crate::lifecycle::LifecyclePolicy::Block | crate::lifecycle::LifecyclePolicy::Strip => {
+                let mode_label = match policy {
+                    crate::lifecycle::LifecyclePolicy::Strip => "strip→block",
+                    _ => "block",
+                };
+                let reason = format!(
+                    "lifecycle(vsix,{mode_label}): blocking {extension_id}@{version} — \
+                     extension declares startup autorun (activationEvents=[{events}]). \
+                     Strip mode does not rewrite .vsix archives (the Marketplace integrity \
+                     hash the editor verifies would not match). Add `{extension_id}` to the \
+                     lifecycle allow-list if this install is expected, or relax to \
+                     `--lifecycle-policy audit` to log without blocking."
+                );
+                log::warn!("{reason}");
+                parts.headers.remove(http::header::CONTENT_LENGTH);
+                Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header("content-type", "text/plain; charset=utf-8")
+                    .header("x-sakimori-deny", "lifecycle-vsix")
+                    .body(Body::from(format!("{reason}\n")))
+                    .expect("static lifecycle deny response")
+            }
+        }
+    }
+}
+
+/// Recognise a pinned `.vsix` download by URL shape.
+///
+/// Returns `Some((publisher, extension_name, version))` for both
+/// canonical Marketplace and OpenVSX URL shapes:
+///
+/// - Microsoft VS Code Marketplace:
+///   `/_apis/public/gallery/publishers/{publisher}/vsextensions/{ext}/{version}/vspackage`
+/// - OpenVSX REST API:
+///   `/api/{namespace}/{ext}/{version}/file/{namespace}.{ext}-{version}.vsix`
+///
+/// Returns `None` for any other path on a marketplace host (the
+/// `extensionquery` JSON, web app HTML, etc.).
+fn parse_vsix_download_path(path: &str) -> Option<(String, String, String)> {
+    let path = path.split('?').next().unwrap_or(path);
+    let path = path.split('#').next().unwrap_or(path);
+    let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    // Microsoft Marketplace shape: 7 segments,
+    // ["_apis", "public", "gallery", "publishers", <pub>,
+    //  "vsextensions", <ext>, <ver>, "vspackage"]
+    if segs.len() == 9
+        && segs[0].eq_ignore_ascii_case("_apis")
+        && segs[1].eq_ignore_ascii_case("public")
+        && segs[2].eq_ignore_ascii_case("gallery")
+        && segs[3].eq_ignore_ascii_case("publishers")
+        && segs[5].eq_ignore_ascii_case("vsextensions")
+        && segs[8].eq_ignore_ascii_case("vspackage")
+    {
+        let publisher = segs[4].to_string();
+        let name = segs[6].to_string();
+        let version = segs[7].to_string();
+        if !publisher.is_empty() && !name.is_empty() && !version.is_empty() {
+            return Some((publisher, name, version));
+        }
+    }
+
+    // OpenVSX REST shape: ["api", <ns>, <ext>, <ver>, "file", <filename.vsix>]
+    if segs.len() == 6
+        && segs[0].eq_ignore_ascii_case("api")
+        && segs[4].eq_ignore_ascii_case("file")
+        && segs[5].to_ascii_lowercase().ends_with(".vsix")
+    {
+        let publisher = segs[1].to_string();
+        let name = segs[2].to_string();
+        let version = segs[3].to_string();
+        if !publisher.is_empty() && !name.is_empty() && !version.is_empty() {
+            return Some((publisher, name, version));
+        }
+    }
+
+    None
 }
 
 /// Recognise PyPI source distribution URLs by file extension. We
@@ -1013,12 +1168,14 @@ impl HttpHandler for SakimoriHandler {
             self.last_path = None;
             self.last_npm_tarball = None;
             self.last_pypi_sdist = None;
+            self.last_vsix = None;
             return RequestOrResponse::Request(req);
         }
         self.last_host = Some(host.clone());
         // Reset per-request; the `Pinned` branch below may set it back.
         self.last_npm_tarball = None;
         self.last_pypi_sdist = None;
+        self.last_vsix = None;
         let path: String = req
             .uri()
             .path_and_query()
@@ -1042,6 +1199,26 @@ impl HttpHandler for SakimoriHandler {
             .and_then(|h| h.to_str().ok())
             .unwrap_or("")
             .to_string();
+        // `.vsix` lifecycle gate — VS Code Marketplace / OpenVSX
+        // tarballs aren't in `ParseResult::Pinned` because
+        // `Ecosystem` doesn't carry an editor-extension variant yet
+        // (roadmap #22). Recognise the URL shape directly on
+        // configured marketplace hosts and tag the response for
+        // inspection. Allow-list keys are canonical `publisher.name`
+        // identifiers, case-insensitive.
+        if self.lifecycle_policy.is_some()
+            && host_in(&self.registries.vscode_marketplace, &host)
+            && let Some((publisher, ext_name, version)) = parse_vsix_download_path(&path)
+        {
+            let ext_id = format!("{publisher}.{ext_name}");
+            if !self
+                .lifecycle_allow
+                .iter()
+                .any(|n| n.eq_ignore_ascii_case(&ext_id))
+            {
+                self.last_vsix = Some((publisher, ext_name, version));
+            }
+        }
         match parse_for_host(&self.parsers, &host, &path) {
             ParseResult::Pinned {
                 ecosystem,
@@ -1123,6 +1300,14 @@ impl HttpHandler for SakimoriHandler {
         {
             return self
                 .lifecycle_inspect_pypi_sdist(res, policy, &name, &version)
+                .await;
+        }
+        if let Some(policy) = self.lifecycle_policy
+            && let Some((publisher, name, version)) = self.last_vsix.take()
+            && res.status().is_success()
+        {
+            return self
+                .lifecycle_inspect_vsix(res, policy, &publisher, &name, &version)
                 .await;
         }
 
@@ -1858,6 +2043,60 @@ fn deny_response(reason: &str) -> Response<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_vsix_marketplace_canonical_path() {
+        let r = parse_vsix_download_path(
+            "/_apis/public/gallery/publishers/ms-python/vsextensions/python/2024.0.0/vspackage",
+        );
+        assert_eq!(
+            r,
+            Some(("ms-python".into(), "python".into(), "2024.0.0".into()))
+        );
+    }
+
+    #[test]
+    fn parse_vsix_marketplace_strips_query() {
+        let r = parse_vsix_download_path(
+            "/_apis/public/gallery/publishers/foo/vsextensions/bar/1.2.3/vspackage?targetPlatform=linux-x64",
+        );
+        assert_eq!(r, Some(("foo".into(), "bar".into(), "1.2.3".into())));
+    }
+
+    #[test]
+    fn parse_vsix_openvsx_rest_path() {
+        let r = parse_vsix_download_path(
+            "/api/rust-lang/rust-analyzer/0.4.0/file/rust-lang.rust-analyzer-0.4.0.vsix",
+        );
+        assert_eq!(
+            r,
+            Some(("rust-lang".into(), "rust-analyzer".into(), "0.4.0".into()))
+        );
+    }
+
+    #[test]
+    fn parse_vsix_rejects_extensionquery_endpoint() {
+        // `extensionquery` is the JSON metadata endpoint, not a
+        // `.vsix` download — the rewriter handles it separately and
+        // the lifecycle gate must not tag it.
+        assert!(parse_vsix_download_path("/_apis/public/gallery/extensionquery").is_none());
+        assert!(parse_vsix_download_path("/vscode/gallery/extensionquery").is_none());
+    }
+
+    #[test]
+    fn parse_vsix_rejects_unrelated_paths() {
+        assert!(parse_vsix_download_path("/").is_none());
+        assert!(parse_vsix_download_path("/items?itemName=ms-python.python").is_none());
+        // Wrong segment count for Marketplace shape
+        assert!(
+            parse_vsix_download_path(
+                "/_apis/public/gallery/publishers/foo/vsextensions/bar/vspackage"
+            )
+            .is_none()
+        );
+        // Missing .vsix suffix on OpenVSX shape
+        assert!(parse_vsix_download_path("/api/foo/bar/1.0.0/file/readme.md").is_none());
+    }
 
     #[test]
     fn classify_execution_mode_recognises_one_shot_runners() {

--- a/crates/sakimori-proxy/src/typosquat.rs
+++ b/crates/sakimori-proxy/src/typosquat.rs
@@ -196,6 +196,12 @@ fn top_list_for(eco: Ecosystem) -> &'static [&'static str] {
         // `github.com/owner/repo` is not part of any package
         // registry's top-N download ranking.
         Ecosystem::Git => &[],
+        // VS Code Marketplace `publisher.name` identifiers have
+        // their own popularity ranking but we don't mirror it yet —
+        // and the typosquat detector targets the install path of
+        // package managers (npm / cargo / pypi / nuget), not the
+        // editor extension surface, so silence is correct here.
+        Ecosystem::VscodeExtension => &[],
     }
 }
 
@@ -240,6 +246,9 @@ impl MirrorLists {
             // Git deps aren't part of the mirrored top-N — see
             // `top_list_for`.
             Ecosystem::Git => &[],
+            // VS Code extensions aren't part of the mirrored top-N
+            // for the same reason — see `top_list_for`.
+            Ecosystem::VscodeExtension => &[],
         }
     }
 

--- a/crates/sakimori-proxy/tests/proxy_vsix_lifecycle_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_vsix_lifecycle_e2e.rs
@@ -1,0 +1,256 @@
+//! End-to-end: `.vsix` lifecycle gate exercised through the proxy.
+//!
+//!   client ── HTTP_PROXY ── sakimori_proxy ── upstream (vsix bytes)
+//!
+//! Builds a synthetic `.vsix` (zip with `extension/package.json`),
+//! serves it from a mock upstream on a path matching the canonical
+//! Marketplace `vspackage` URL shape, and asserts:
+//!
+//! 1. Startup-autorun extension (`activationEvents: ["*"]`) under
+//!    `lifecycle_policy: Block` returns 403 with the
+//!    `x-sakimori-deny: lifecycle-vsix` header.
+//! 2. Lazy-activation extension (`activationEvents: ["onCommand:…"]`)
+//!    flows through untouched.
+//! 3. Startup-autorun extension on the lifecycle allow-list flows
+//!    through untouched (canonical `publisher.name` identifier).
+//!
+//! Unit tests in `vsix_inspect.rs` cover the inspector's algorithmic
+//! branches; this file covers the full hyper / hudsucker request
+//! lifecycle dispatch.
+
+use std::io::{Cursor, Write};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use sakimori_proxy::{ProxyConfig, RegistryHosts, ca::CaFiles};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+use zip::write::SimpleFileOptions;
+
+fn tmp_config_dir(tag: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "sakimori-vsix-e2e-{tag}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+fn build_vsix(manifest_json: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let cursor = Cursor::new(&mut buf);
+        let mut zw = zip::ZipWriter::new(cursor);
+        let opts =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        zw.start_file("[Content_Types].xml", opts).unwrap();
+        zw.write_all(b"<types/>").unwrap();
+        zw.start_file("extension/package.json", opts).unwrap();
+        zw.write_all(manifest_json.as_bytes()).unwrap();
+        zw.finish().unwrap();
+    }
+    buf
+}
+
+async fn spawn_mock_upstream(
+    response_body: Vec<u8>,
+    content_type: &'static str,
+) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let body = Arc::new(response_body);
+    let ct = content_type.to_string();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _peer) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            let body = body.clone();
+            let ct = ct.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::with_capacity(2048);
+                let mut tmp = [0u8; 1024];
+                loop {
+                    match sock.read(&mut tmp).await {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                            if buf.len() > 64 * 1024 {
+                                return;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: {ct}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.write_all(&body).await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    addr
+}
+
+async fn spawn_proxy(cfg_mutator: impl FnOnce(&mut ProxyConfig)) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let config_dir = tmp_config_dir("proxy");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let ca_files = CaFiles::at(config_dir);
+
+    let mut cfg = ProxyConfig::default_dev().unwrap();
+    cfg.listen = addr;
+    cfg.ca_files = ca_files;
+    cfg.install_log_enabled = false;
+    cfg.registries = RegistryHosts {
+        vscode_marketplace: vec!["127.0.0.1".into()],
+        ..RegistryHosts::default()
+    };
+    cfg.lifecycle_policy = Some(sakimori_proxy::lifecycle::LifecyclePolicy::Block);
+    cfg_mutator(&mut cfg);
+
+    tokio::spawn(async move {
+        if let Err(e) = sakimori_proxy::run(cfg).await {
+            eprintln!("proxy exited: {e:#}");
+        }
+    });
+
+    let ready = Arc::new(Notify::new());
+    let ready2 = ready.clone();
+    tokio::spawn(async move {
+        for _ in 0..150 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                ready2.notify_one();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(5), ready.notified())
+        .await
+        .expect("proxy never came up");
+    addr
+}
+
+/// GET through the proxy and return (status, response body, the
+/// `x-sakimori-deny` header if present).
+fn http_get_through_proxy(
+    proxy: std::net::SocketAddr,
+    target_url: &str,
+) -> (u16, Vec<u8>, Option<String>) {
+    let proxy_spec = format!("http://{proxy}");
+    let agent = ureq::AgentBuilder::new()
+        .proxy(ureq::Proxy::new(&proxy_spec).unwrap())
+        .timeout(Duration::from_secs(10))
+        .build();
+    let resp = match agent.get(target_url).call() {
+        Ok(r) => r,
+        Err(ureq::Error::Status(_, r)) => r,
+        Err(e) => panic!("client GET through proxy: {e}"),
+    };
+    let status = resp.status();
+    let deny = resp.header("x-sakimori-deny").map(str::to_string);
+    let mut buf = Vec::new();
+    use std::io::Read;
+    resp.into_reader()
+        .take(4 * 1024 * 1024)
+        .read_to_end(&mut buf)
+        .unwrap();
+    (status, buf, deny)
+}
+
+const VSPACKAGE_PATH: &str =
+    "/_apis/public/gallery/publishers/attacker/vsextensions/evil-ext/1.0.0/vspackage";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vsix_with_wildcard_activation_blocked() {
+    let vsix = build_vsix(
+        r#"{
+            "name": "evil-ext",
+            "publisher": "attacker",
+            "version": "1.0.0",
+            "main": "./out/extension.js",
+            "activationEvents": ["*"]
+        }"#,
+    );
+    let upstream = spawn_mock_upstream(vsix, "application/octet-stream").await;
+    let proxy = spawn_proxy(|_| {}).await;
+
+    let url = format!("http://{upstream}{VSPACKAGE_PATH}");
+    let (status, _body, deny) =
+        tokio::task::spawn_blocking(move || http_get_through_proxy(proxy, &url))
+            .await
+            .unwrap();
+    assert_eq!(status, 403);
+    assert_eq!(deny.as_deref(), Some("lifecycle-vsix"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vsix_with_lazy_activation_passes_through() {
+    let vsix = build_vsix(
+        r#"{
+            "name": "ok-ext",
+            "publisher": "trusted",
+            "version": "1.0.0",
+            "activationEvents": ["onCommand:foo.bar", "onLanguage:rust"]
+        }"#,
+    );
+    let upstream = spawn_mock_upstream(vsix.clone(), "application/octet-stream").await;
+    let proxy = spawn_proxy(|_| {}).await;
+
+    let url = format!(
+        "http://{upstream}/_apis/public/gallery/publishers/trusted/vsextensions/ok-ext/1.0.0/vspackage"
+    );
+    let (status, body, deny) =
+        tokio::task::spawn_blocking(move || http_get_through_proxy(proxy, &url))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+    assert!(
+        deny.is_none(),
+        "lazy-activation extension should not be blocked"
+    );
+    assert_eq!(body, vsix, "body should be the unmodified vsix bytes");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vsix_on_lifecycle_allow_list_bypasses_block() {
+    // Same wildcard manifest as the block test, but the
+    // `publisher.name` is on the allow-list, so the gate must not
+    // fire.
+    let vsix = build_vsix(
+        r#"{
+            "name": "evil-ext",
+            "publisher": "attacker",
+            "version": "1.0.0",
+            "activationEvents": ["*"]
+        }"#,
+    );
+    let upstream = spawn_mock_upstream(vsix.clone(), "application/octet-stream").await;
+    let proxy = spawn_proxy(|cfg| {
+        cfg.lifecycle_allow.push("attacker.evil-ext".into());
+    })
+    .await;
+
+    let url = format!("http://{upstream}{VSPACKAGE_PATH}");
+    let (status, body, deny) =
+        tokio::task::spawn_blocking(move || http_get_through_proxy(proxy, &url))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+    assert!(deny.is_none());
+    assert_eq!(body, vsix);
+}

--- a/crates/sakimori-proxy/tests/proxy_vsix_lifecycle_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_vsix_lifecycle_e2e.rs
@@ -227,6 +227,59 @@ async fn vsix_with_lazy_activation_passes_through() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vsix_install_is_logged_with_publisher_dot_name_identity() {
+    // Roadmap #22: every `.vsix` fetched through the proxy lands in
+    // `installs.jsonl` with `ecosystem: vscode-extension` and name =
+    // canonical `publisher.extension`. This holds regardless of
+    // lifecycle policy — the inventory needs to be complete so a
+    // post-hoc CVE scan covers what was actually installed.
+    let vsix = build_vsix(
+        r#"{
+            "name": "ok-ext",
+            "publisher": "trusted",
+            "version": "2.5.0",
+            "activationEvents": ["onCommand:foo.bar"]
+        }"#,
+    );
+    let upstream = spawn_mock_upstream(vsix, "application/octet-stream").await;
+
+    let log_dir = tmp_config_dir("installog");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let log_path = log_dir.join("installs.jsonl");
+    let log_path_for_cfg = log_path.clone();
+    let proxy = spawn_proxy(move |cfg| {
+        cfg.lifecycle_policy = None;
+        cfg.install_log_enabled = true;
+        cfg.install_log_path = Some(log_path_for_cfg);
+    })
+    .await;
+
+    let url = format!(
+        "http://{upstream}/_apis/public/gallery/publishers/trusted/vsextensions/ok-ext/2.5.0/vspackage"
+    );
+    let (status, _body, _deny) =
+        tokio::task::spawn_blocking(move || http_get_through_proxy(proxy, &url))
+            .await
+            .unwrap();
+    assert_eq!(status, 200);
+
+    // Give the proxy a beat to flush; the logger writes synchronously
+    // but the response runs on another task.
+    for _ in 0..50 {
+        if log_path.exists() && std::fs::metadata(&log_path).unwrap().len() > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let raw = std::fs::read_to_string(&log_path).expect("install log was written");
+    let line = raw.lines().next().expect("at least one log line");
+    let ev: serde_json::Value = serde_json::from_str(line).expect("log line is valid JSON");
+    assert_eq!(ev["ecosystem"], "vscode-extension");
+    assert_eq!(ev["name"], "trusted.ok-ext");
+    assert_eq!(ev["version"], "2.5.0");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn vsix_on_lifecycle_allow_list_bypasses_block() {
     // Same wildcard manifest as the block test, but the
     // `publisher.name` is on the allow-list, so the gate must not


### PR DESCRIPTION
## Summary

Lands two adjacent roadmap items (#21 proxy integration, #22 inventory):

- **`.vsix` lifecycle gate end-to-end.** Wires the existing `vsix_inspect` library into the proxy: pinned `.vsix` URLs on configured `vscode_marketplace` hosts (canonical Marketplace `vspackage` shape + OpenVSX REST) get buffered, manifest-parsed, and either audit-logged or 403'd with `x-sakimori-deny: lifecycle-vsix` when `activationEvents` contains a startup-autorun primitive (`"*"` or `onStartupFinished`). Lazy activation (`onCommand:…`, `onLanguage:…`, no `activationEvents`) passes through. Allow-list keys are canonical `publisher.name` identifiers, case-insensitive. `Strip` falls back to `Block` (the Marketplace integrity hash + signed-package flow both cover the archive bytes, so an in-place rewrite would be rejected).
- **VS Code extensions in the install inventory.** New `Ecosystem::VscodeExtension` (label `"vscode-extension"`); every `.vsix` fetch through a configured Marketplace / OpenVSX host emits an `InstallEvent` with name = `publisher.extension`, regardless of `--lifecycle-policy`. Flows through both `~/.sakimori/installs.jsonl` and the OTLP exporter when configured. `Decider` / OSV / typosquat exhaustive matches all return None — the variant carries no publish-time / OSV ecosystem / top-N typosquat list today, the same way `Git` doesn't, so `sakimori advisories scan` silently skips it until OSV publishes a vscode-marketplace ecosystem.

`ChromeExtension` is still pending and gated on roadmap #20's Chrome Web Store half (no inline publish-time means the update endpoint needs an out-of-band lookup that hasn't been built).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (one unrelated `proxy_https_e2e` flake cleared on rerun)
- [x] Unit: `parse_vsix_download_path` for canonical Marketplace + OpenVSX shapes, rejects `extensionquery` + unrelated paths
- [x] E2E `proxy_vsix_lifecycle_e2e`: wildcard-activation `.vsix` is 403'd; lazy activation passes through; allow-list bypass works; install is logged with `ecosystem: vscode-extension` and `publisher.name`