### PR TITLE
feat(proxy): sakimori-hub ingest exporter

### DIFF
--- a/crates/sakimori-proxy/src/hub_ingest.rs
+++ b/crates/sakimori-proxy/src/hub_ingest.rs
@@ -1,0 +1,451 @@
+//! Opt-in `sakimori-hub` ingest exporter.
+//!
+//! Parallel to [`crate::otlp::OtlpExporter`]: every allowed install
+//! also fires a fire-and-forget POST against a self-hosted hub's
+//! `/v1/{team}/_team|_user|{project}/events` endpoint. The hub side
+//! is documented in `bokuweb/sakimori-hub` —
+//! `packages/schemas/src/install-event.ts` is the source of truth
+//! for the wire shape this module produces.
+//!
+//! Wire format:
+//! - Method: `POST`
+//! - Headers: `Authorization: Bearer <token>`, `Content-Type:
+//!   application/json`, `User-Agent: <proxy ua>`
+//! - Body: a JSON array (`InstallEventBatch`) of `InstallEvent`
+//!   objects matching the valibot schema, with `v: 1` injected.
+//!
+//! Best-effort: any failure (no env, hub down, 5xx, schema reject)
+//! is a `log::warn!` and never blocks the install path. The token
+//! is held in [`HubIngestExporter`] with a custom [`Debug`] that
+//! redacts the bytes so a stray `{:?}` in logs cannot leak it.
+//!
+//! Schema mapping is opinionated:
+//! - `crates` ecosystem (the sakimori-core label) is rewritten to
+//!   `cargo` (the hub schema label). Other ecosystems pass
+//!   through.
+//! - `git` / `vscode-extension` are NOT supported by the hub
+//!   schema today; events for those ecosystems are dropped before
+//!   POST rather than producing a 400 the operator has to debug.
+//! - `user_agent` is required by the hub schema but optional on
+//!   the local `InstallEvent`; when absent we substitute the proxy
+//!   user-agent so the wire payload is always valid.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+
+/// Best-effort sakimori-hub ingest exporter. Cheap to clone via `Arc`.
+pub struct HubIngestExporter {
+    endpoint: String,
+    /// Bearer credential. Never logged; see custom `Debug` impl
+    /// below.
+    token: SakimoriToken,
+    user_agent: String,
+}
+
+/// Bearer token wrapper. Sole purpose: keep the plaintext out of
+/// any accidental `{:?}` output. The hub validates this against
+/// an argon2id hash on every request; we never compare it on the
+/// CLI side, so no `Eq` / constant-time-compare surface here.
+#[derive(Clone)]
+pub struct SakimoriToken(String);
+
+impl SakimoriToken {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    fn as_bearer_value(&self) -> String {
+        format!("Bearer {}", self.0)
+    }
+}
+
+impl std::fmt::Debug for SakimoriToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Surface non-emptiness only; never the bytes.
+        write!(f, "SakimoriToken(<redacted, {} bytes>)", self.0.len())
+    }
+}
+
+/// Reject endpoints that aren't safe to POST a bearer token to.
+///
+/// - Scheme must be `http` or `https`.
+/// - Userinfo (`user:pass@host`) is rejected — credentials in
+///   URL would clash with the Authorization header and tend to
+///   show up in logs / shell history.
+/// - Control chars (CR/LF/NUL/…) are rejected — they'd let the
+///   env value forge log lines (codex round-1 low/medium).
+///
+/// Returns the input unchanged on success. Diagnostic strings
+/// are constants (no echo of the bad URL) so this function is
+/// itself safe to use in a startup log.
+pub fn validate_endpoint(endpoint: &str) -> Result<(), &'static str> {
+    if endpoint.is_empty() {
+        return Err("hub ingest URL is empty");
+    }
+    if endpoint.chars().any(|c| c.is_control()) {
+        return Err("hub ingest URL contains control characters");
+    }
+    let (scheme, rest) = endpoint
+        .split_once("://")
+        .ok_or("hub ingest URL must be http:// or https://")?;
+    if !matches!(scheme, "http" | "https") {
+        return Err("hub ingest URL must be http:// or https://");
+    }
+    // The hostport segment ends at the first `/`, `?`, or `#`.
+    let host_segment = rest.split(['/', '?', '#']).next().unwrap_or("");
+    if host_segment.contains('@') {
+        return Err("hub ingest URL must not embed userinfo (user:pass@host)");
+    }
+    if host_segment.is_empty() {
+        return Err("hub ingest URL is missing a host");
+    }
+    Ok(())
+}
+
+impl HubIngestExporter {
+    pub fn new(endpoint: String, token: SakimoriToken, user_agent: String) -> Self {
+        Self {
+            endpoint,
+            token,
+            user_agent,
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Build the `InstallEventBatch` JSON for a single event, or
+    /// `None` if the event's ecosystem is unsupported by the hub
+    /// (`git`, `vscode-extension`).
+    ///
+    /// Public so unit tests can pin the wire shape without
+    /// spinning up the proxy.
+    pub fn build_payload(&self, event: &InstallEvent) -> Option<Value> {
+        let wire = build_wire_event(event, &self.user_agent)?;
+        Some(json!([wire]))
+    }
+
+    /// Fire-and-forget dispatch. Returns immediately; the actual
+    /// HTTP POST runs on a `spawn_blocking` worker. Failure is
+    /// logged at `warn` level. Drops the event silently when the
+    /// ecosystem can't be expressed on the hub schema (so the
+    /// proxy doesn't spam warnings for `git:` deps).
+    pub fn dispatch(self: &Arc<Self>, event: &InstallEvent) {
+        let Some(batch) = self.build_payload(event) else {
+            return;
+        };
+        let endpoint = self.endpoint.clone();
+        let auth = self.token.as_bearer_value();
+        let ua = self.user_agent.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = post_hub(&endpoint, &auth, &ua, &batch) {
+                // The endpoint is non-secret and useful for triage.
+                // `e` carries the HTTP status / ureq error
+                // message — never the bearer value, which is held
+                // only in `auth` (a local), so a `{e:#}` is safe.
+                // Sanitize the URL: an attacker-controlled env
+                // could inject CR/LF to forge log lines.
+                let endpoint_safe = sanitize_for_log(&endpoint);
+                log::warn!("hub ingest POST to {endpoint_safe} failed: {e:#}");
+            }
+        });
+    }
+}
+
+fn post_hub(endpoint: &str, authorization: &str, user_agent: &str, body: &Value) -> Result<()> {
+    let resp = ureq::post(endpoint)
+        .set("authorization", authorization)
+        .set("content-type", "application/json")
+        .set("user-agent", user_agent)
+        .timeout(std::time::Duration::from_millis(3000))
+        .send_json(body.clone())
+        .with_context(|| format!("POST {endpoint}"))?;
+    let status = resp.status();
+    if !(200..300).contains(&status) {
+        anyhow::bail!("hub endpoint returned {status}");
+    }
+    Ok(())
+}
+
+fn build_wire_event(event: &InstallEvent, fallback_user_agent: &str) -> Option<Value> {
+    let ecosystem = map_ecosystem(&event.ecosystem)?;
+    let mode_str = match event.execution_mode {
+        ExecutionMode::Persistent => "persistent",
+        ExecutionMode::Ephemeral => "ephemeral",
+        ExecutionMode::Unknown => "unknown",
+    };
+    // Hub schema requires `user_agent` as a non-empty string (up
+    // to 512 chars). Local event leaves it optional; substitute
+    // the proxy UA when absent so the wire is always valid.
+    let user_agent = event
+        .user_agent
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback_user_agent);
+    // Hub schema caps user_agent at 512 bytes; truncate at the
+    // last UTF-8 char boundary inside that budget. A naive
+    // `&s[..512]` would panic on multi-byte sequences (codex
+    // round-1 medium finding).
+    let user_agent = truncate_on_char_boundary(user_agent, 512);
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("v".into(), Value::from(1u8));
+    obj.insert("ecosystem".into(), Value::from(ecosystem));
+    obj.insert("name".into(), Value::from(event.name.clone()));
+    obj.insert("version".into(), Value::from(event.version.clone()));
+    obj.insert(
+        "resolved_at".into(),
+        Value::from(event.resolved_at.to_rfc3339()),
+    );
+    obj.insert("execution_mode".into(), Value::from(mode_str));
+    obj.insert("user_agent".into(), Value::from(user_agent.to_string()));
+    if let Some(p) = event.project_path.as_deref() {
+        // Hub schema caps project_path at 1024 bytes. Mirror the
+        // user_agent truncation so a long CI workspace path
+        // (e.g. nested runner home dir) doesn't 400 the whole
+        // batch (codex round-1 medium finding).
+        let p = truncate_on_char_boundary(p, 1024);
+        obj.insert("project_path".into(), Value::from(p.to_string()));
+    }
+    Some(Value::Object(obj))
+}
+
+/// Return `s` truncated to at most `max_bytes`, never splitting a
+/// UTF-8 multi-byte sequence. Walks back from the cap to the last
+/// boundary so the result is always valid UTF-8.
+fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Replace control chars that could be used to forge log lines
+/// (newline, carriage return, NUL, …) with `?`. Used wherever an
+/// operator-supplied env value (URL, etc.) is interpolated into a
+/// `log::*!` macro (codex round-1 low/medium finding).
+fn sanitize_for_log(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '?' } else { c })
+        .collect()
+}
+
+fn map_ecosystem(local_label: &str) -> Option<&'static str> {
+    match local_label {
+        "npm" => Some("npm"),
+        // sakimori-core's `Crates.label() == "crates"`; the hub
+        // schema spells it `cargo`. Rewrite here so the operator
+        // doesn't get a confusing 400.
+        "crates" => Some("cargo"),
+        "pypi" => Some("pypi"),
+        "nuget" => Some("nuget"),
+        // git / vscode-extension are deliberately dropped — hub
+        // schema only accepts the four package-registry
+        // ecosystems above.
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use sakimori_core::deps::Ecosystem;
+
+    fn sample_event() -> InstallEvent {
+        let mut ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+            .with_mode(ExecutionMode::Persistent)
+            .with_user_agent("npm/10.0.0 node/20.0.0");
+        ev.resolved_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        ev
+    }
+
+    #[test]
+    fn payload_is_a_one_event_batch_with_v1() {
+        let exp = HubIngestExporter::new(
+            "https://hub.example/v1/acme/_team/events".into(),
+            SakimoriToken::new("skm_team_x"),
+            "sakimori-test/0".into(),
+        );
+        let p = exp.build_payload(&sample_event()).expect("npm event");
+        let arr = p.as_array().expect("batch must be a JSON array");
+        assert_eq!(arr.len(), 1, "one event in, one event out");
+        let ev = &arr[0];
+        assert_eq!(ev["v"], 1);
+        assert_eq!(ev["ecosystem"], "npm");
+        assert_eq!(ev["name"], "left-pad");
+        assert_eq!(ev["version"], "1.3.0");
+        assert_eq!(ev["resolved_at"], "2026-01-02T03:04:05+00:00");
+        assert_eq!(ev["execution_mode"], "persistent");
+        assert_eq!(ev["user_agent"], "npm/10.0.0 node/20.0.0");
+        assert!(ev.get("project_path").is_none(), "absent path is absent");
+    }
+
+    #[test]
+    fn cratesio_ecosystem_is_rewritten_to_cargo() {
+        // Hub schema uses `cargo`; sakimori-core spells it `crates`.
+        // The rewriter is the only place that knows the mapping —
+        // pin it so a future enum rename doesn't silently break the
+        // wire.
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        let mut ev = sample_event();
+        ev.ecosystem = Ecosystem::Crates.label().to_string();
+        ev.name = "serde".into();
+        let p = exp.build_payload(&ev).expect("crates event accepted");
+        assert_eq!(p[0]["ecosystem"], "cargo");
+    }
+
+    #[test]
+    fn unsupported_ecosystems_are_dropped() {
+        // `git` and `vscode-extension` are not in the hub schema.
+        // Returning None here lets dispatch drop them silently
+        // instead of producing a 400 the operator has to debug.
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        for label in ["git", "vscode-extension", "rubygems"] {
+            let mut ev = sample_event();
+            ev.ecosystem = label.to_string();
+            assert!(
+                exp.build_payload(&ev).is_none(),
+                "ecosystem={label} must be dropped from the wire",
+            );
+        }
+    }
+
+    #[test]
+    fn missing_user_agent_falls_back_to_proxy_ua() {
+        // Hub schema requires user_agent. Local InstallEvent
+        // makes it optional. The exporter substitutes the proxy
+        // UA so the wire is always valid.
+        let exp = HubIngestExporter::new(
+            "http://x".into(),
+            SakimoriToken::new("t"),
+            "sakimori-proxy/0.9.9".into(),
+        );
+        let mut ev = sample_event();
+        ev.user_agent = None;
+        let p = exp.build_payload(&ev).unwrap();
+        assert_eq!(p[0]["user_agent"], "sakimori-proxy/0.9.9");
+    }
+
+    #[test]
+    fn long_user_agent_is_truncated_to_512_chars() {
+        // Hub schema caps user_agent at 512; an oversize value
+        // would 400 the whole batch. Truncate defensively so a
+        // pathological UA can't poison the ingest path.
+        let exp = HubIngestExporter::new(
+            "http://x".into(),
+            SakimoriToken::new("t"),
+            "fallback".into(),
+        );
+        let mut ev = sample_event();
+        ev.user_agent = Some("x".repeat(600));
+        let p = exp.build_payload(&ev).unwrap();
+        let ua = p[0]["user_agent"].as_str().unwrap();
+        assert_eq!(ua.len(), 512);
+    }
+
+    #[test]
+    fn project_path_is_serialised_when_present() {
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        let mut ev = sample_event();
+        ev.project_path = Some("/home/octocat/repo".into());
+        let p = exp.build_payload(&ev).unwrap();
+        assert_eq!(p[0]["project_path"], "/home/octocat/repo");
+    }
+
+    #[test]
+    fn token_debug_redacts_plaintext() {
+        // A stray {:?} in logs must never leak the token bytes.
+        // Pin the redaction so a future refactor that derives
+        // Debug on `SakimoriToken` breaks this test loudly.
+        let tok = SakimoriToken::new("skm_team_supersecretvaluewith43chars1234567");
+        let printed = format!("{tok:?}");
+        assert!(!printed.contains("supersecret"), "{printed}");
+        assert!(printed.contains("redacted"), "{printed}");
+    }
+
+    #[test]
+    fn long_non_ascii_user_agent_does_not_panic() {
+        // Codex round-1 medium: a naive `&s[..512]` panics on a
+        // multi-byte char boundary. Pin the safe truncation by
+        // throwing a UA that's all 3-byte UTF-8 codepoints.
+        let exp = HubIngestExporter::new(
+            "http://x".into(),
+            SakimoriToken::new("t"),
+            "fallback".into(),
+        );
+        let mut ev = sample_event();
+        // 300 × 'あ' (3 bytes each) = 900 bytes — well over 512.
+        ev.user_agent = Some("あ".repeat(300));
+        let p = exp.build_payload(&ev).unwrap();
+        let ua = p[0]["user_agent"].as_str().unwrap();
+        assert!(ua.len() <= 512, "ua exceeded cap: {} bytes", ua.len());
+        // Truncation must land on a char boundary — the result
+        // is still valid UTF-8 (the test asserts on a `str` via
+        // `as_str()`, which is itself the proof).
+        assert!(ua.chars().all(|c| c == 'あ'));
+    }
+
+    #[test]
+    fn long_project_path_is_truncated() {
+        // Codex round-1 medium: hub caps project_path at 1024.
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        let mut ev = sample_event();
+        ev.project_path = Some("a".repeat(2000));
+        let p = exp.build_payload(&ev).unwrap();
+        let path = p[0]["project_path"].as_str().unwrap();
+        assert_eq!(path.len(), 1024);
+    }
+
+    #[test]
+    fn endpoint_validation_accepts_http_and_https_hosts() {
+        assert!(validate_endpoint("http://hub.example/v1/acme/_team/events").is_ok());
+        assert!(validate_endpoint("https://hub.example/v1/acme/_team/events").is_ok());
+        assert!(validate_endpoint("https://127.0.0.1:8787/v1/acme/_team/events").is_ok());
+    }
+
+    #[test]
+    fn endpoint_validation_rejects_unsafe_inputs() {
+        // Pin the rejected classes. Each `expect_err` is a
+        // single assertion so a regression points at the exact
+        // bypass.
+        assert!(validate_endpoint("").is_err());
+        assert!(validate_endpoint("ftp://hub.example/").is_err());
+        assert!(validate_endpoint("file:///etc/passwd").is_err());
+        // Embedded userinfo: would clash with Authorization
+        // header and tends to leak via shell history.
+        assert!(validate_endpoint("http://user:pass@hub.example/v1/x").is_err());
+        // Control characters — log-injection vector.
+        assert!(validate_endpoint("http://hub.example/v1\r\nX-Inj: bad").is_err());
+        assert!(validate_endpoint("http://hub.example/\nfoo").is_err());
+        // Missing host.
+        assert!(validate_endpoint("http:///v1/x").is_err());
+    }
+
+    #[test]
+    fn sanitize_for_log_neutralises_control_chars() {
+        assert_eq!(sanitize_for_log("hub.example/foo"), "hub.example/foo");
+        assert_eq!(sanitize_for_log("hub\r\nX-Inj"), "hub??X-Inj");
+        assert_eq!(sanitize_for_log("hub\0foo"), "hub?foo");
+    }
+
+    #[test]
+    fn execution_mode_unknown_serialises_as_unknown() {
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        let mut ev = sample_event();
+        ev.execution_mode = ExecutionMode::Unknown;
+        let p = exp.build_payload(&ev).unwrap();
+        assert_eq!(p[0]["execution_mode"], "unknown");
+    }
+}

--- a/crates/sakimori-proxy/src/lib.rs
+++ b/crates/sakimori-proxy/src/lib.rs
@@ -6,6 +6,7 @@ pub mod daemon;
 pub mod decision;
 pub mod git_fetch;
 pub mod host_allow;
+pub mod hub_ingest;
 pub mod install;
 pub mod lifecycle;
 pub mod nuget_flatcontainer_client;

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -101,6 +101,24 @@ pub struct ProxyConfig {
     /// `Authorization: Bearer …` for vendor backends. Ignored when
     /// `otlp_endpoint` is `None`.
     pub otlp_headers: Vec<(String, String)>,
+    /// Optional `sakimori-hub` ingest endpoint. When `Some` AND
+    /// `hub_ingest_token` is also set, every allowed install
+    /// fires a fire-and-forget POST to this URL — in addition to
+    /// any OTLP fan-out or local install log. The URL must
+    /// include the full hub route, e.g.
+    /// `https://hub.example/v1/{team_slug}/_team/events` (team
+    /// token),
+    /// `https://hub.example/v1/{team_slug}/_user/{member_id}/events`
+    /// (user token), or
+    /// `https://hub.example/v1/{team_slug}/{project_slug}/events`
+    /// (project token). Disabling either endpoint or token
+    /// disables the exporter.
+    pub hub_ingest_endpoint: Option<String>,
+    /// Bearer credential for the hub ingest endpoint. Held in a
+    /// dedicated newtype so a stray `{:?}` cannot leak it; see
+    /// [`crate::hub_ingest::SakimoriToken`]. `None` disables the
+    /// exporter.
+    pub hub_ingest_token: Option<crate::hub_ingest::SakimoriToken>,
     /// Lifecycle-script policy for npm tarballs. `None` disables the
     /// gate (current default). `Some(Audit)` logs script bodies for
     /// every fetched tarball that ships an `install` / `preinstall` /
@@ -176,6 +194,8 @@ impl ProxyConfig {
             install_log_enabled: true,
             otlp_endpoint: None,
             otlp_headers: Vec::new(),
+            hub_ingest_endpoint: None,
+            hub_ingest_token: None,
             lifecycle_policy: None,
             lifecycle_allow: Vec::new(),
             lifecycle_strip_on_failure: crate::lifecycle::StripFailurePolicy::Block,
@@ -337,6 +357,66 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
             cfg.user_agent.clone(),
         ))
     });
+    // The hub ingest exporter requires BOTH an endpoint and a
+    // token. Setting just one is almost certainly a config
+    // mistake (e.g. SAKIMORI_INGEST_URL exported but
+    // SAKIMORI_TOKEN missing on a CI runner); surface that loudly
+    // at startup instead of silently dropping every event.
+    let hub_ingest_exporter = match (
+        cfg.hub_ingest_endpoint.as_ref(),
+        cfg.hub_ingest_token.as_ref(),
+    ) {
+        (Some(endpoint), Some(token)) => {
+            // Validate the URL before constructing the exporter
+            // so a garbage env value fails loudly at startup
+            // instead of spraying one log::warn per install.
+            // Rejects schemes other than http/https, embedded
+            // userinfo, and control chars (log-injection guard,
+            // codex round-1 low/medium).
+            match crate::hub_ingest::validate_endpoint(endpoint) {
+                Ok(()) => {
+                    // After validation the URL is known to be
+                    // control-char-free, so logging it verbatim
+                    // is safe.
+                    log::info!("hub ingest → {endpoint}");
+                    Some(Arc::new(crate::hub_ingest::HubIngestExporter::new(
+                        endpoint.clone(),
+                        token.clone(),
+                        cfg.user_agent.clone(),
+                    )))
+                }
+                Err(why) => {
+                    // Diagnostic is a constant `&'static str`;
+                    // never echoes the unvalidated endpoint.
+                    log::warn!("hub ingest disabled: {why}");
+                    None
+                }
+            }
+        }
+        (Some(_endpoint), None) => {
+            // Don't echo the endpoint — control chars in an
+            // unconfigured URL would still let the env value
+            // forge log lines. The actionable message is the
+            // same with or without the URL.
+            log::warn!(
+                "hub ingest endpoint set but token is missing; \
+                 set SAKIMORI_TOKEN to enable the exporter"
+            );
+            None
+        }
+        (None, Some(_)) => {
+            // Token without endpoint: don't log the token (custom
+            // Debug redacts but log::warn! with `{:?}` would still
+            // surface `SakimoriToken(<redacted, N bytes>)`). The
+            // useful signal is "set the URL too".
+            log::warn!(
+                "SAKIMORI_TOKEN is set but hub ingest endpoint is missing; \
+                 set SAKIMORI_INGEST_URL to enable the exporter"
+            );
+            None
+        }
+        (None, None) => None,
+    };
     let registries = Arc::new(cfg.registries.clone());
     let handler = SakimoriHandler {
         parsers: Arc::new(parsers_from_hosts(&cfg.registries)),
@@ -353,6 +433,7 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         network_allow: cfg.network_allow.map(Arc::new),
         install_logger,
         otlp_exporter,
+        hub_ingest_exporter,
         lifecycle_policy: cfg.lifecycle_policy,
         lifecycle_allow: Arc::new(cfg.lifecycle_allow.into_iter().collect()),
         lifecycle_strip_on_failure: cfg.lifecycle_strip_on_failure,
@@ -585,6 +666,11 @@ struct SakimoriHandler {
     /// sakimori-hub push notifications, OTLP is for generic
     /// observability backends).
     otlp_exporter: Option<Arc<crate::otlp::OtlpExporter>>,
+    /// Optional sakimori-hub ingest exporter. `None` disables hub
+    /// fan-out. Coexists with `otlp_exporter` and `install_logger`
+    /// — the proxy fans out to whichever transports the operator
+    /// configured.
+    hub_ingest_exporter: Option<Arc<crate::hub_ingest::HubIngestExporter>>,
     /// Hostname allow-list. `None` (or empty) → unrestricted egress.
     /// `Some(non-empty)` → default-deny: any CONNECT or plain-HTTP
     /// request whose target host doesn't match returns 403 before
@@ -1274,7 +1360,10 @@ impl HttpHandler for SakimoriHandler {
                 let now = Utc::now();
                 match self.decider.decide(ecosystem, &name, &version, now) {
                     Decision::Allow => {
-                        if self.install_logger.is_some() || self.otlp_exporter.is_some() {
+                        if self.install_logger.is_some()
+                            || self.otlp_exporter.is_some()
+                            || self.hub_ingest_exporter.is_some()
+                        {
                             let mode = classify_execution_mode(&user_agent);
                             let mut ev =
                                 InstallEvent::new(ecosystem, &name, &version).with_mode(mode);
@@ -1289,6 +1378,9 @@ impl HttpHandler for SakimoriHandler {
                                 log::warn!("install log write failed: {e:#}");
                             }
                             if let Some(exporter) = self.otlp_exporter.as_ref() {
+                                exporter.dispatch(&ev);
+                            }
+                            if let Some(exporter) = self.hub_ingest_exporter.as_ref() {
                                 exporter.dispatch(&ev);
                             }
                         }

--- a/crates/sakimori-proxy/tests/hub_ingest_e2e.rs
+++ b/crates/sakimori-proxy/tests/hub_ingest_e2e.rs
@@ -1,0 +1,230 @@
+//! End-to-end check for the sakimori-hub ingest exporter.
+//!
+//! Unit tests in `src/hub_ingest.rs::tests` pin the payload
+//! shape; this file pins the *wire surface*: HTTP method, path,
+//! Authorization header, Content-Type, and body parse against
+//! the hub schema. A regression where the dispatcher silently
+//! stopped posting (e.g. spawn_blocking task panicked, ureq
+//! timeout misconfigured) would pass the unit tests and silently
+//! drop every install — exactly the failure mode this file
+//! catches.
+//!
+//! We bypass the full proxy harness here on purpose: spinning up
+//! hudsucker + a mock npm tarball is the OTLP e2e's job. What we
+//! want at this layer is "the exporter dispatch dispatches".
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
+use sakimori_core::deps::Ecosystem;
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+use sakimori_proxy::hub_ingest::{HubIngestExporter, SakimoriToken};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Minimal HTTP/1.1 capturing server. Returns 200 on every
+/// request and stores the raw bytes (request line + headers +
+/// body) in a shared Vec for assertions.
+async fn spawn_capturing_http_server() -> (std::net::SocketAddr, Arc<Mutex<Vec<Vec<u8>>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let records: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+    let r2 = records.clone();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _peer) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            let records = r2.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::with_capacity(8 * 1024);
+                let mut tmp = [0u8; 4096];
+                let hdr_end = loop {
+                    match sock.read(&mut tmp).await {
+                        Ok(0) => return,
+                        Ok(n) => {
+                            buf.extend_from_slice(&tmp[..n]);
+                            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                                break pos + 4;
+                            }
+                            if buf.len() > 256 * 1024 {
+                                return;
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                };
+                let header_str = std::str::from_utf8(&buf[..hdr_end]).unwrap_or("");
+                let content_len = header_str
+                    .lines()
+                    .find_map(|line| {
+                        let mut parts = line.splitn(2, ':');
+                        let k = parts.next()?.trim();
+                        let v = parts.next()?.trim();
+                        if k.eq_ignore_ascii_case("content-length") {
+                            v.parse::<usize>().ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(0);
+                while buf.len() - hdr_end < content_len {
+                    match sock.read(&mut tmp).await {
+                        Ok(0) => break,
+                        Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        Err(_) => break,
+                    }
+                }
+                {
+                    let mut g = records.lock().unwrap();
+                    g.push(buf.clone());
+                }
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+                    .await;
+                let _ = sock.shutdown().await;
+            });
+        }
+    });
+    (addr, records)
+}
+
+/// Redact the bearer token before printing headers in an
+/// assertion failure — CI logs can become artifacts and we don't
+/// want the token bytes copied around even from a test.
+/// (Codex round-1 nit.)
+fn redact_auth(headers: &str) -> String {
+    headers
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.to_ascii_lowercase().starts_with("authorization:") {
+                "Authorization: <redacted>".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn split_request(captured: &[u8]) -> (String, Vec<u8>) {
+    let pos = captured
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("captured request must have end-of-headers");
+    let headers = String::from_utf8_lossy(&captured[..pos]).to_string();
+    let body = captured[pos + 4..].to_vec();
+    (headers, body)
+}
+
+fn sample_event() -> InstallEvent {
+    let mut ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+        .with_mode(ExecutionMode::Persistent)
+        .with_user_agent("npm/10.0.0 node/20.0.0")
+        .with_project_path("/work/repo");
+    ev.resolved_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ev
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispatch_posts_to_configured_endpoint_with_bearer() {
+    // Mark `_now` unused — we don't currently inspect timestamps
+    // beyond what the payload carries.
+    let _ = SystemTime::now().duration_since(UNIX_EPOCH);
+    let (addr, captured) = spawn_capturing_http_server().await;
+    let endpoint = format!("http://{addr}/v1/acme/_team/events");
+    let exporter = Arc::new(HubIngestExporter::new(
+        endpoint.clone(),
+        SakimoriToken::new("skm_team_supersecretvaluewith43chars1234567"),
+        "sakimori-proxy/test".into(),
+    ));
+
+    exporter.dispatch(&sample_event());
+
+    // dispatch is spawn_blocking; poll up to ~3s for the request
+    // to land. Lock is taken in a tight scope to satisfy
+    // clippy::await_holding_lock.
+    let cap = {
+        let mut last = None;
+        for _ in 0..60 {
+            let snap = {
+                let g = captured.lock().unwrap();
+                if g.is_empty() { None } else { Some(g.clone()) }
+            };
+            if let Some(s) = snap {
+                last = Some(s);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        last.expect("exporter must POST within 3s of dispatch")
+    };
+    assert_eq!(cap.len(), 1, "exactly one POST per dispatch");
+    let (headers, body) = split_request(&cap[0]);
+
+    assert!(
+        headers.starts_with("POST /v1/acme/_team/events HTTP/1.1\r\n"),
+        "hub ingest must POST to the configured path; got:\n{redacted_headers}",
+        redacted_headers = redact_auth(&headers)
+    );
+    let lc_headers = headers.to_ascii_lowercase();
+    assert!(
+        lc_headers.contains("authorization: bearer skm_team_supersecretvaluewith43chars1234567"),
+        "Authorization header must carry the Bearer token; got:\n{redacted_headers}",
+        redacted_headers = redact_auth(&headers)
+    );
+    assert!(
+        lc_headers.contains("content-type: application/json"),
+        "hub ingest body must be JSON; got:\n{redacted_headers}",
+        redacted_headers = redact_auth(&headers)
+    );
+    assert!(
+        lc_headers.contains("user-agent: sakimori-proxy/test"),
+        "User-Agent must match the configured proxy UA; got:\n{redacted_headers}",
+        redacted_headers = redact_auth(&headers)
+    );
+
+    let payload: serde_json::Value =
+        serde_json::from_slice(&body).expect("body must parse as JSON");
+    let arr = payload.as_array().expect("body must be a JSON array");
+    assert_eq!(arr.len(), 1, "one event per single-event dispatch");
+    let ev = &arr[0];
+    assert_eq!(ev["v"], 1);
+    assert_eq!(ev["ecosystem"], "npm");
+    assert_eq!(ev["name"], "left-pad");
+    assert_eq!(ev["version"], "1.3.0");
+    assert_eq!(ev["execution_mode"], "persistent");
+    assert_eq!(ev["user_agent"], "npm/10.0.0 node/20.0.0");
+    assert_eq!(ev["project_path"], "/work/repo");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispatch_drops_unsupported_ecosystem_silently() {
+    // `git` deps never reach the hub — the exporter drops them
+    // before posting so the operator doesn't see 400s. Pin that
+    // contract: zero requests must arrive at the mock server.
+    let (addr, captured) = spawn_capturing_http_server().await;
+    let exporter = Arc::new(HubIngestExporter::new(
+        format!("http://{addr}/v1/acme/_team/events"),
+        SakimoriToken::new("skm_team_x"),
+        "ua".into(),
+    ));
+    let mut ev = sample_event();
+    ev.ecosystem = Ecosystem::Git.label().to_string();
+    exporter.dispatch(&ev);
+
+    // Wait briefly to make sure no request lands.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let g = captured.lock().unwrap();
+    assert!(
+        g.is_empty(),
+        "git ecosystem must not produce a POST; got {} request(s)",
+        g.len()
+    );
+}

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -826,6 +826,39 @@ pub struct ProxyStartArgs {
     /// `--otlp-endpoint` is not set.
     #[arg(long = "otlp-header", value_name = "K=V", value_parser = parse_kv)]
     pub otlp_headers: Vec<(String, String)>,
+    /// Opt-in `sakimori-hub` ingest endpoint. When set together
+    /// with `--hub-ingest-token` (or `SAKIMORI_TOKEN`), every
+    /// allowed install is POSTed to this URL as an
+    /// `InstallEventBatch`. The URL must include the full hub
+    /// route, e.g.
+    /// `https://hub.example/v1/{team}/_team/events` (team token),
+    /// `https://hub.example/v1/{team}/_user/{member_id}/events`
+    /// (user token), or
+    /// `https://hub.example/v1/{team}/{project}/events` (project
+    /// token). Read from the env var `SAKIMORI_INGEST_URL`
+    /// when the flag is absent — that's how the GitHub Action
+    /// wires it through.
+    #[arg(
+        long = "hub-ingest-url",
+        value_name = "URL",
+        env = "SAKIMORI_INGEST_URL"
+    )]
+    pub hub_ingest_url: Option<String>,
+    /// Bearer token for the `sakimori-hub` ingest endpoint. Issued
+    /// by the hub's `POST /api/v1/teams/{slug}/tokens/{user|team}`
+    /// endpoint (or a future project-token issuer). Always paired
+    /// with `--hub-ingest-url`; setting one without the other is
+    /// a no-op and logs a warning at proxy startup. Read from
+    /// `SAKIMORI_TOKEN` when the flag is absent. **Never logged**
+    /// — wrapped in `SakimoriToken` whose `Debug` redacts the
+    /// bytes.
+    #[arg(
+        long = "hub-ingest-token",
+        value_name = "TOKEN",
+        env = "SAKIMORI_TOKEN",
+        hide_env_values = true
+    )]
+    pub hub_ingest_token: Option<String>,
     /// Lifecycle-script gate for npm tarballs (Shai-Hulud-class
     /// defence). `audit` logs every fetched tarball that ships
     /// `install` / `preinstall` / `postinstall` / `prepare` scripts
@@ -1283,6 +1316,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 install_log_enabled: !args.no_install_log,
                 otlp_endpoint: args.otlp_endpoint,
                 otlp_headers: args.otlp_headers,
+                hub_ingest_endpoint: args.hub_ingest_url,
+                hub_ingest_token: args
+                    .hub_ingest_token
+                    .map(sakimori_proxy::hub_ingest::SakimoriToken::new),
                 lifecycle_policy,
                 lifecycle_allow: args.lifecycle_allow,
                 lifecycle_strip_on_failure,


### PR DESCRIPTION
## Summary

- Adds an opt-in `sakimori-hub` ingest exporter to the proxy, parallel to the existing OTLP fan-out. Every allowed install fires a fire-and-forget POST to `/v1/{team}/_team|_user|{project}/events` with `Authorization: Bearer <token>` and an `InstallEventBatch` JSON body matching the hub's valibot schema.
- Config: `--hub-ingest-url` / `--hub-ingest-token` flags or `SAKIMORI_INGEST_URL` / `SAKIMORI_TOKEN` env vars. Either-without-the-other logs a warning at startup and disables the exporter.
- This is the **CLI-side** of "make end-to-end ingest from sakimori CLI / GitHub Action work against staging." Hub-side API for issuing tokens is already merged in `sakimori-hub` (see PR #38 there); a follow-up PR resurrects the UI for that.

## Why this slice

`../sakimori-hub` already exposes:
- `POST /api/v1/teams/{slug}/tokens/{user|team}` — mint
- `POST /v1/{team}/_team|_user|{project}/events` — accept ingest

…but the CLI had no code at all for the second one (no env-var reading, no HTTP POST). That was the actual blocker for ingest. This PR unblocks it.

## Wire mapping

The local `sakimori_core::installs::InstallEvent` is shaped into the hub's `InstallEvent` schema:
- `v: 1` injected
- `ecosystem` is rewritten `"crates" → "cargo"` (the hub schema spells it `cargo`); unsupported ecosystems (`git`, `vscode-extension`) are silently dropped before POST so the operator doesn't get a 400 on unrelated deps.
- `user_agent` is required by the hub schema but optional locally — falls back to the proxy UA.
- `user_agent` / `project_path` are truncated to the hub's documented byte caps (512 / 1024) on UTF-8 char boundaries.

## Security considerations

- **Token leakage**: bearer is wrapped in a `SakimoriToken` newtype whose `Debug` returns `<redacted, N bytes>`; the bearer value lives only on the local `auth` variable inside `dispatch`, never in error / context strings. Clap's `--hub-ingest-token` flag has `hide_env_values = true` so the env value can't surface via help / error paths. Docs nudge operators to the env-var form (argv is outside clap's hiding scope).
- **URL validation**: `validate_endpoint` rejects schemes other than `http`/`https`, embedded userinfo (`user:pass@host`), and control chars (CR/LF/NUL/…). Codex round-1 flagged the control-char path as a log-injection vector; the failure-path also routes the URL through `sanitize_for_log` defensively.
- **Panic safety**: codex round-1 medium — naive `&s[..512]` would panic on a multi-byte char boundary, synchronously, before `spawn_blocking`. Now `truncate_on_char_boundary` walks back to the last valid boundary.
- **SSRF**: this is inherent to a self-hostable hub model — the env var IS the egress target. We bound the egress to http(s) only and reject credentials in the URL. Operators are expected to scope `SAKIMORI_INGEST_URL` to their hub deployment.
- **Best-effort**: failure (no env, hub down, 5xx, schema reject) is a `log::warn!` and never blocks the install path. The proxy keeps working when the hub is down.

## Test plan

- [x] `cargo test --workspace` — 13 hub_ingest unit tests + 2 hub_ingest_e2e integration tests, all green; full workspace green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Manual: run the proxy with `SAKIMORI_INGEST_URL=http://127.0.0.1:8787/v1/acme/_team/events SAKIMORI_TOKEN=skm_team_…`, drive `npm install left-pad` through it, verify the event arrives on the hub's queue
- [ ] action.yml wiring (next slice, separate PR)

## Codex round-1 findings (all addressed in this commit)

- UA char-boundary panic risk → `truncate_on_char_boundary`
- `project_path` cap missing → mirror UA cap (1024)
- URL log-injection via control chars → `validate_endpoint` + `sanitize_for_log`
- Test failure prints bearer → `redact_auth` helper in the e2e

Plan + cross-repo tracking in [sakimori-hub/docs/cli-actions-ingest-plan.md](https://github.com/bokuweb/sakimori-hub/blob/main/docs/cli-actions-ingest-plan.md) (lands with the matching hub PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)