### PR TITLE
feat(action/proxy): hub-ingest credential pass-through

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,6 +1168,23 @@ jobs:
             ${{ runner.temp }}/scan-empty.json
             ${{ runner.temp }}/scan-missing.json
 
+  proxy-action-contract:
+    # Pure-Node contract tests for `proxy/main.js` — pin the surface
+    # the composite-action presents to its callers (input names,
+    # the `::add-mask::` discipline that keeps the hub-ingest token
+    # out of subsequent step logs, and the env-only credential
+    # propagation). Runs on one OS only; node --test is OS-portable
+    # and the assertions are file-content-based, not behavioural.
+    # The proxy-action-smoke matrix below covers the behavioural
+    # side end-to-end.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node --test proxy/test/main.test.mjs
+
   proxy-action-smoke:
     # Verifies that `bokuweb/sakimori/proxy@v0` (the JS-action wrapper
     # that spawns `sakimori proxy start` and exports HTTPS_PROXY via

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,110 @@
+# `bokuweb/sakimori/proxy`
+
+Run `sakimori proxy` as a GitHub Actions background service so every
+HTTPS request from subsequent steps in the job is filtered through
+it: too-young versions of crates.io / npm / pypi / nuget packages
+are invisible to the resolver — the pnpm-style
+`minimumReleaseAge` auto-fallback for every ecosystem.
+
+Works on Linux, macOS, and Windows GitHub-hosted runners. The
+process keeps running until the post-step (end of job) kills it.
+
+## Quick start (minimumReleaseAge only)
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bokuweb/sakimori/proxy@v0
+        with:
+          min-age: 7d
+      - run: npm ci
+```
+
+Subsequent steps in the same job see `HTTPS_PROXY` / `HTTP_PROXY`
+plus per-tool CA bundle env vars (`CARGO_HTTP_CAINFO`, `PIP_CERT`,
+`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`) set
+by the action — nothing else is required to route traffic through
+the proxy.
+
+## Hub upload (optional)
+
+The proxy can also POST every allowed install to a self-hosted
+[`sakimori-hub`](https://github.com/bokuweb/sakimori-hub) endpoint
+for team-wide visibility into what package versions landed on CI
+runners. The hub side accepts `InstallEventBatch` JSON at
+`POST /v1/{team}/_team|_user|{project}/events` with `Authorization:
+Bearer <token>`.
+
+Mint a token in the hub UI (or via its `POST /api/v1/teams/{slug}/tokens/{user|team}`
+API), store the plaintext as a **repository secret** (e.g.
+`SAKIMORI_TOKEN`), and the URL as a **repository variable**
+(`SAKIMORI_INGEST_URL`):
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bokuweb/sakimori/proxy@v0
+        with:
+          min-age: 7d
+          ingest-url:   ${{ vars.SAKIMORI_INGEST_URL }}
+          ingest-token: ${{ secrets.SAKIMORI_TOKEN }}
+      - run: npm ci
+```
+
+The token is registered with the GitHub Actions log scrubber via
+`::add-mask::` before it ever touches the proxy's environment, so
+any later step that echoes it (`set -x` traces, proxy stdout,
+spawn-error dumps) renders the bytes as `***` in the workflow log.
+Use `${{ secrets.* }}` — never inline the token in the workflow
+YAML.
+
+Setting only one of `ingest-url` / `ingest-token` is a no-op; the
+action surfaces a `::notice::` so the misconfiguration is visible.
+
+### Fork PR caveat
+
+GitHub does not expose repository secrets to workflow runs
+triggered by a fork-based PR. Hub upload is expected to be
+disabled in that case — both the token and (if you stored it
+as a secret rather than a variable) the URL will be empty, and
+the action's notice paths above make that explicit.
+
+## Inputs
+
+| Input             | Default                   | Description |
+|-------------------|---------------------------|-------------|
+| `min-age`         | `7d`                      | Minimum package age. Versions younger than this are invisible to the resolver. |
+| `listen`          | `127.0.0.1:8910`          | Address the proxy listens on. |
+| `fail-on-missing` | `false`                   | Treat unknown publish dates as a deny. Default fails open (allow through) so a flaky registry doesn't brick the build. |
+| `version`         | `v0`                      | sakimori release tag to download. |
+| `token`           | `${{ github.token }}`     | GitHub token for `gh release download`. |
+| `ingest-url`      | `""`                      | Optional sakimori-hub ingest endpoint (see above). |
+| `ingest-token`    | `""`                      | Bearer credential for `ingest-url`. Treat as a secret. |
+
+## Outputs
+
+| Output    | Description |
+|-----------|-------------|
+| `ca-cert` | Absolute path to the proxy's root CA PEM. |
+
+## Limits
+
+`sakimori run` (the eBPF audit/block supervisor) does **not** emit
+install events. Hub upload only fires from the proxy decision path
+— if you want hub coverage, you need to actually route installs
+through this action. A `sakimori install upload` post-hoc batch
+uploader for the local `installs.jsonl` written by the proxy is on
+the roadmap; it would let workflows that already use the proxy
+upload at end-of-job rather than per-install.

--- a/proxy/action.yml
+++ b/proxy/action.yml
@@ -41,6 +41,36 @@ inputs:
     description: "GitHub token for `gh release download`."
     required: false
     default: ${{ github.token }}
+  ingest-url:
+    description: |
+      Optional `sakimori-hub` ingest endpoint. When set together
+      with `ingest-token`, every allowed install resolved by the
+      proxy is POSTed to this URL as an `InstallEventBatch` —
+      enabling team-wide visibility into what package versions
+      landed on CI runners. The URL must include the full hub
+      route, e.g.
+      `https://hub.example/v1/{team}/_team/events` (team token),
+      `https://hub.example/v1/{team}/_user/{member_id}/events`
+      (user token), or
+      `https://hub.example/v1/{team}/{project}/events` (project
+      token). Leave empty (default) to disable hub upload — the
+      proxy still filters minimumReleaseAge as usual.
+    required: false
+    default: ""
+  ingest-token:
+    description: |
+      Bearer credential for `ingest-url`. Issued by the hub's
+      `POST /api/v1/teams/{slug}/tokens/{user|team}` endpoint.
+      Always paired with `ingest-url`; setting one without the
+      other is a no-op and logs a warning.
+
+      Treat as a secret. Pass via `${{ secrets.SAKIMORI_TOKEN }}`
+      — never inline the token in a workflow file. The action
+      registers it with `::add-mask::` before exporting so the
+      bytes never appear in subsequent logs, but a token typed
+      into the workflow YAML stays in git history regardless.
+    required: false
+    default: ""
 
 outputs:
   ca-cert:

--- a/proxy/action.yml
+++ b/proxy/action.yml
@@ -64,8 +64,10 @@ inputs:
       Always paired with `ingest-url`; setting one without the
       other is a no-op and logs a warning.
 
-      Treat as a secret. Pass via `${{ secrets.SAKIMORI_TOKEN }}`
-      — never inline the token in a workflow file. The action
+      Treat as a secret. Pass via a workflow expression that
+      reads `secrets.SAKIMORI_TOKEN` (see README for the exact
+      YAML) — never inline the token in a workflow file. The
+      action
       registers it with `::add-mask::` before exporting so the
       bytes never appear in subsequent logs, but a token typed
       into the workflow YAML stays in git history regardless.

--- a/proxy/main.js
+++ b/proxy/main.js
@@ -34,6 +34,26 @@ function notice(msg) {
   process.stdout.write(`::notice::${msg}\n`);
 }
 
+// Register `value` with the GitHub Actions log scrubber so any
+// subsequent step that echoes the bytes (including stdout from
+// the proxy itself, the supervised command, or a `set -x` trace)
+// renders them as `***` in the workflow log. Only emit when the
+// value is non-empty — `::add-mask::` with an empty payload is
+// a no-op that still produces noise in the log.
+function addMask(value) {
+  if (!value) return;
+  // GH workflow-command payload escaping (mirror @actions/core's
+  // `toCommandValue` + `escapeData`). A bearer with `\r` or `\n`
+  // in it would otherwise terminate the `::add-mask::` line early
+  // and leak the trailing bytes into the workflow log. Tokens
+  // SHOULD be single-line, but treat untrusted input as untrusted.
+  const escaped = String(value)
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+  process.stdout.write(`::add-mask::${escaped}\n`);
+}
+
 function setEnv(name, value) {
   const f = process.env.GITHUB_ENV;
   if (!f) return;
@@ -179,6 +199,31 @@ async function waitForListen(host, port, deadlineMs) {
   const minAge = input("min-age", "7d");
   const failOnMissing = input("fail-on-missing") === "true";
 
+  // Optional sakimori-hub ingest wiring. The proxy reads these
+  // from the environment (see SakimoriToken / SAKIMORI_INGEST_URL
+  // in sakimori-proxy). Mask the token IMMEDIATELY — before any
+  // later code can echo it via `set -x`-style traces or a
+  // spawn-error path that includes the env block.
+  const ingestUrl = input("ingest-url");
+  const ingestToken = input("ingest-token");
+  if (ingestToken) {
+    addMask(ingestToken);
+  }
+  // Endpoint/token presence are dependent: either both or neither.
+  // The proxy logs a warn at startup if only one is set; surface
+  // the same signal at action level so the CI log gives the
+  // operator one clear place to fix it.
+  if (ingestUrl && !ingestToken) {
+    notice(
+      "sakimori-proxy: `ingest-url` is set but `ingest-token` is empty; hub upload disabled",
+    );
+  }
+  if (ingestToken && !ingestUrl) {
+    notice(
+      "sakimori-proxy: `ingest-token` is set but `ingest-url` is empty; hub upload disabled",
+    );
+  }
+
   const runnerTemp = process.env.RUNNER_TEMP || os.tmpdir();
   const tmpDir = path.join(runnerTemp, "sakimori-proxy-action");
   fs.mkdirSync(tmpDir, { recursive: true });
@@ -241,9 +286,33 @@ async function waitForListen(host, port, deadlineMs) {
   console.log(`sakimori-proxy: spawning ${binPath} ${proxyArgs.join(" ")}`);
   // detached + unref + stdio→files lets the process survive Node's
   // exit at end-of-step and keep serving subsequent steps.
+  //
+  // Build the child env explicitly: inherit ours by default, then
+  // overlay the hub-ingest credentials so the child reads them via
+  // clap's `env =` binding (see SAKIMORI_INGEST_URL / SAKIMORI_TOKEN
+  // in crates/sakimori/src/cli.rs). Passing through the env (not
+  // argv) keeps the secret off `ps` output and any spawn-failure
+  // log paths that dump argv.
+  const childEnv = { ...process.env };
+  // Strip the action's own INPUT_* env so the spawned proxy
+  // never sees the token under its INPUT_INGEST_TOKEN alias
+  // (codex round-1: the inherited copy would otherwise live
+  // alongside SAKIMORI_TOKEN and double the leak surface). The
+  // proxy only reads SAKIMORI_* names; nothing downstream needs
+  // INPUT_* at all.
+  for (const key of Object.keys(childEnv)) {
+    if (key.startsWith("INPUT_")) {
+      delete childEnv[key];
+    }
+  }
+  if (ingestUrl && ingestToken) {
+    childEnv.SAKIMORI_INGEST_URL = ingestUrl;
+    childEnv.SAKIMORI_TOKEN = ingestToken;
+  }
   const child = spawn(binPath, proxyArgs, {
     detached: true,
     stdio: ["ignore", stdoutFd, stderrFd],
+    env: childEnv,
     // Windows: don't open a console window for the proxy.
     windowsHide: true,
   });

--- a/proxy/test/main.test.mjs
+++ b/proxy/test/main.test.mjs
@@ -1,0 +1,158 @@
+// Contract tests for `bokuweb/sakimori/proxy`'s composite-action
+// wiring. Runs under plain Node — `node --test proxy/test/main.test.mjs`
+// — so the CI's existing lint job can add a single line without
+// pulling vitest / jest in for a JS-action this small.
+//
+// These tests stop short of spawning the real `sakimori proxy`
+// binary (the proxy-action-smoke matrix in ci.yml does that
+// end-to-end). They pin the SURFACE: input names, env-variable
+// propagation, and the `::add-mask::` discipline that keeps the
+// hub-ingest token out of subsequent step logs.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const proxyDir = path.resolve(here, "..");
+const actionYml = fs.readFileSync(path.join(proxyDir, "action.yml"), "utf8");
+const mainJs = fs.readFileSync(path.join(proxyDir, "main.js"), "utf8");
+
+// ---------------------------------------------------------------
+// action.yml input declarations
+// ---------------------------------------------------------------
+//
+// We grep rather than parse YAML because the file is tiny and a
+// regex-level pin gives a sharper failure message ("ingest-url
+// input missing") than a structural assertion would. If the
+// grammar ever gets more complex, swap in a real YAML parser.
+
+test("action.yml declares the ingest-url input", () => {
+  assert.match(
+    actionYml,
+    /^\s{2}ingest-url:\s*$/m,
+    "ingest-url input must be declared under `inputs:`",
+  );
+});
+
+test("action.yml declares the ingest-token input", () => {
+  assert.match(
+    actionYml,
+    /^\s{2}ingest-token:\s*$/m,
+    "ingest-token input must be declared under `inputs:`",
+  );
+});
+
+test("ingest inputs default to empty (opt-in, not required)", () => {
+  // Both inputs must default to "" so callers who don't want hub
+  // upload see no behavioural change. A non-empty default would
+  // surprise an existing user.
+  const urlBlock = actionYml.match(/ingest-url:[\s\S]*?(?=\n\s{2}\S|\noutputs:)/);
+  assert.ok(urlBlock, "could not locate ingest-url block");
+  assert.match(urlBlock[0], /required:\s*false/);
+  assert.match(urlBlock[0], /default:\s*""/);
+
+  const tokBlock = actionYml.match(/ingest-token:[\s\S]*?(?=\n\s{2}\S|\noutputs:)/);
+  assert.ok(tokBlock, "could not locate ingest-token block");
+  assert.match(tokBlock[0], /required:\s*false/);
+  assert.match(tokBlock[0], /default:\s*""/);
+});
+
+// ---------------------------------------------------------------
+// main.js wiring
+// ---------------------------------------------------------------
+
+test("main.js reads both inputs", () => {
+  // Pin the exact `input("ingest-url")` / `input("ingest-token")`
+  // call shape because that's how composite-action inputs become
+  // `INPUT_*` env vars (see helper at top of main.js).
+  assert.match(mainJs, /input\(\s*["']ingest-url["']\s*\)/);
+  assert.match(mainJs, /input\(\s*["']ingest-token["']\s*\)/);
+});
+
+test("main.js masks the ingest token via ::add-mask::", () => {
+  // The token MUST be registered with the GH Actions log scrubber
+  // before any subsequent log line could echo it (proxy logs,
+  // supervised `set -x` traces, spawn-error paths). This pin
+  // catches a regression where the mask call moves below the
+  // spawn or gets dropped.
+  assert.match(mainJs, /add-mask/);
+  assert.match(mainJs, /addMask\s*\(\s*ingestToken\s*\)/);
+});
+
+test("addMask is called before childEnv assembly and spawn (ordering)", () => {
+  // Codex round-1: the bare presence of addMask is insufficient —
+  // a regression that moves it below the spawn would still pass
+  // the substring test above. Pin file-order so the mask is
+  // registered with the runner BEFORE any later code path could
+  // echo the bytes (childEnv assembly, spawn-stderr dump, …).
+  const idxMask = mainJs.indexOf("addMask(ingestToken)");
+  const idxChildEnv = mainJs.indexOf("const childEnv");
+  const idxSpawn = mainJs.search(/\bspawn\(binPath/);
+  assert.ok(idxMask >= 0, "addMask(ingestToken) call must exist");
+  assert.ok(idxChildEnv >= 0, "childEnv assembly must exist");
+  assert.ok(idxSpawn >= 0, "spawn(binPath, …) must exist");
+  assert.ok(
+    idxMask < idxChildEnv && idxChildEnv < idxSpawn,
+    `expected addMask < childEnv < spawn (got ${idxMask}, ${idxChildEnv}, ${idxSpawn})`,
+  );
+});
+
+test("addMask escapes CR/LF/% so a multiline token can't break the workflow-command line", () => {
+  // Codex round-1: a token containing `\r` or `\n` would terminate
+  // `::add-mask::<token>\n` early and leak the trailing bytes.
+  // Mirror @actions/core's command escaping: `%` → %25, `\r` → %0D,
+  // `\n` → %0A. The function is internal so pin the regex shape
+  // here.
+  assert.match(mainJs, /replace\(\s*\/%\/g\s*,\s*["']%25["']\s*\)/);
+  assert.match(mainJs, /replace\(\s*\/\\r\/g\s*,\s*["']%0D["']\s*\)/);
+  assert.match(mainJs, /replace\(\s*\/\\n\/g\s*,\s*["']%0A["']\s*\)/);
+});
+
+test("INPUT_* env vars are stripped from the spawned proxy env", () => {
+  // Codex round-1: childEnv = {...process.env} would otherwise
+  // forward INPUT_INGEST_TOKEN to the proxy alongside the
+  // explicit SAKIMORI_TOKEN, doubling the leak surface. Pin the
+  // explicit strip.
+  assert.match(mainJs, /key\.startsWith\(["']INPUT_["']\)/);
+  assert.match(mainJs, /delete\s+childEnv\[\s*key\s*\]/);
+});
+
+test("main.js propagates the credentials to the spawned proxy env", () => {
+  // The proxy binary reads SAKIMORI_INGEST_URL / SAKIMORI_TOKEN
+  // via clap's `env =` binding. The wire from action input →
+  // proxy is: `process.env` of the spawned child carries
+  // SAKIMORI_INGEST_URL + SAKIMORI_TOKEN. Pin both keys
+  // verbatim so a typo (e.g. SAKIMORI_HUB_URL) doesn't silently
+  // disable ingest.
+  assert.match(mainJs, /SAKIMORI_INGEST_URL\s*=\s*ingestUrl/);
+  assert.match(mainJs, /SAKIMORI_TOKEN\s*=\s*ingestToken/);
+  // And the spawn site receives an explicit `env:` field — the
+  // default of "inherit current process env" would also work for
+  // the simple case, but only the explicit form lets us set
+  // SAKIMORI_TOKEN without also leaking it into Node's own env
+  // for accidental child spawns from later code.
+  assert.match(mainJs, /\bspawn\([^)]*?\benv:\s*childEnv/s);
+});
+
+test("main.js only sets ingest env when BOTH url and token are present", () => {
+  // Half-configured ingest is a likely operator mistake (e.g.
+  // forgot to wire the secret). The proxy itself logs a warn for
+  // the half-set case; the action should not silently set just
+  // one half on the child env (that would be a no-op anyway, but
+  // a bare URL with no Authorization would also let the child
+  // attempt and fail every install).
+  assert.match(mainJs, /if\s*\(\s*ingestUrl\s*&&\s*ingestToken\s*\)\s*{/);
+});
+
+test("main.js does not pass the token via argv (env-only)", () => {
+  // Tokens on argv leak through `ps`, error messages that dump
+  // argv, etc. Pin that the proxy spawn line builds `proxyArgs`
+  // from public flags only — no `--hub-ingest-token` or
+  // `ingestToken` reference inside the args array literal.
+  const argsBlock = mainJs.match(/const\s+proxyArgs\s*=\s*\[[\s\S]*?\];/);
+  assert.ok(argsBlock, "could not locate proxyArgs block");
+  assert.doesNotMatch(argsBlock[0], /ingestToken|hub-ingest-token/i);
+});


### PR DESCRIPTION
## Summary

- Adds optional `ingest-url` / `ingest-token` inputs to `bokuweb/sakimori/proxy@v0`. When both are set, the spawned `sakimori proxy` reads them as `SAKIMORI_INGEST_URL` / `SAKIMORI_TOKEN` and POSTs allowed installs to a [sakimori-hub](https://github.com/bokuweb/sakimori-hub) endpoint (the actual POST was shipped in [#105](https://github.com/bokuweb/sakimori/pull/105)).
- Half-configured (one of two) is a no-op with a `::notice::`.

## How it looks for a caller

```yaml
- uses: bokuweb/sakimori/proxy@v0
  with:
    min-age: 7d
    ingest-url:   ${{ vars.SAKIMORI_INGEST_URL }}
    ingest-token: ${{ secrets.SAKIMORI_TOKEN }}
- run: npm ci
```

Full docs in [proxy/README.md](proxy/README.md) including the fork-PR caveat and the (current) limit that `sakimori run` does NOT emit install events — only the proxy decision path does, which is exactly what this action wraps.

## Codex round-1 (consulted before implementation + on the diff)

- Picked the minimum-plumbing approach (D in codex's framing): action.yml inputs + env propagation to the spawned proxy. Avoided rewriting the root `bokuweb/sakimori@v0` action or adding a new `sakimori install upload` subcommand for now — both are good follow-ups but out of scope for "fastest path to working CI ingest."
- Caught + fixed on the diff:
  - `INPUT_INGEST_TOKEN` leaking through `{...process.env}` into the spawned proxy — now stripped by an explicit `INPUT_*` purge before spawn.
  - `::add-mask::<token>` payload was unescaped — a token containing `\r` / `\n` would have terminated the workflow command early and leaked trailing bytes. Now escaped (`%` → `%25`, `\r` → `%0D`, `\n` → `%0A`), matching `@actions/core`'s `escapeData`.
  - Weak mask-ordering test — replaced "matches `addMask(...)` anywhere" with an explicit `idxMask < idxChildEnv < idxSpawn` assertion.

## Security considerations

- **Token never crosses argv.** `proxyArgs` carries only the public flags; the credential rides on `env:` of the spawn (and the action's own `INPUT_*` aliases are stripped first).
- **`::add-mask::` is emitted immediately after read**, before any download / notice / spawn / stderr-dump line can echo the bytes. Ordering is asserted by a contract test.
- **Mask payload is escaped** so a multi-line / `%`-containing token can't terminate the workflow command.
- **CSRF / SSRF / etc.** — same envelope as S1 (#105). The proxy already rejects schemes other than `http`/`https`, embedded userinfo, and control chars in the URL.
- **Fork PR runs** don't see `secrets.*`, so the action correctly degrades to "hub upload disabled" with a `::notice::`. Documented in the README.

## Test plan

- [x] `node --test proxy/test/main.test.mjs` — 11 contract assertions green (input declarations, default-empty, mask presence + ordering + escape, env-only propagation, `INPUT_*` strip, no-token-on-argv)
- [x] New `proxy-action-contract` CI job runs those tests on ubuntu-latest
- [x] Existing `proxy-action-smoke` matrix (Linux / macOS / Windows) continues to cover the binary-level behaviour
- [x] `actionlint` clean on `.github/workflows/ci.yml`
- [x] `node --check proxy/main.js && node --check proxy/post.js`
- [ ] Manual: end-to-end against a real hub-staging URL (next session — also gates the S3 UI work for ergonomic token minting)

## Refs

- [#105](https://github.com/bokuweb/sakimori/pull/105) — S1: `sakimori-proxy` hub_ingest exporter (merged)
- [bokuweb/sakimori-hub#56](https://github.com/bokuweb/sakimori-hub/pull/56) — multi-slice plan doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)