### PR TITLE
feat(supervisor): `--snapshot-extensions` on `run` + `daemon`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1227,8 +1227,29 @@ and lights up the most existing detection for free.
     drift exits 1 unless `--allow-drift`. `--home <DIR>` is the
     test/CI escape hatch.
 
-    Still pending: integration into `sakimori run` / `daemon` so
-    the snapshot is taken automatically around supervised steps.
+    ✅ Wired into `sakimori run --snapshot-extensions` and
+    `sakimori daemon start --snapshot-extensions`. Both surfaces
+    take a baseline + a full pre-run IOC sweep (the "host was
+    already poisoned before sakimori attached" signal) before the
+    supervised step starts, then re-discover roots at shutdown
+    (catches roots created mid-run) and diff against the baseline.
+    Three sibling top-level JSON keys land in the report:
+    `extension_drift` (structural diff, same shape as
+    `workspace_drift`), `extension_iocs` (catalog hits on
+    added/modified paths during the run), and
+    `extension_iocs_baseline` (catalog hits on the pre-run
+    snapshot). The step summary and HTML report grow three matching
+    sections. High-severity IOC hits in **either** bucket fail the
+    run unconditionally in any mode — these are known supply-chain
+    worm fingerprints, not policy calls. Structural drift alone
+    fails the run only in block mode, mirroring `workspace_drift`.
+    `$HOME` is canonicalised + sanity-checked (refuses `/`, empty
+    string) before any walk, so a misconfigured runner can't
+    accidentally scan the entire filesystem under the flag. Test
+    matrix lives in [crates/sakimori-core/tests/extension_report_matrix.rs](crates/sakimori-core/tests/extension_report_matrix.rs)
+    covering the four meaningful corners (clean, pre-existing
+    High, drift-time High, benign drift only).
+
     Pairs naturally with `file.deny` on the same paths once
     exposed via policy presets — the eBPF tripwire fires on the
     write itself while the post-run diff catches sideloads that

--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ Flags:
 | `--html` | — | — | self-contained HTML report (dark-mode aware, filterable) |
 | `--snapshot-workspace` | — | — | dir to hash before/after the run; drift goes into the JSON log + step summary, and (in block mode) makes the run fail |
 | `--snapshot-skip` | — | — | extra dir basenames to skip during the snapshot (repeatable) |
+| `--snapshot-extensions` | — | — | snapshot every editor-extension dir under `$HOME` before + after the run; drift + pre-existing IOC + drift-time IOC sections land in the JSON log under `extension_drift` / `extension_iocs` / `extension_iocs_baseline`. High-severity IOC fails the run unconditionally; structural drift fails the run only in block mode |
 
 Exit code: child's exit code, unless `mode=block` and **either**:
 - at least one event was denied, **or**

--- a/crates/sakimori-core/src/editor_extensions.rs
+++ b/crates/sakimori-core/src/editor_extensions.rs
@@ -24,7 +24,10 @@ use std::{
 
 use anyhow::Result;
 
-use crate::tamper::{Options, Snapshot};
+use crate::{
+    iocs,
+    tamper::{Diff, Options, Snapshot, diff},
+};
 
 /// One known editor-extension root we walk. The `label` is what gets
 /// prefixed onto each file's relative path in the merged snapshot so
@@ -163,6 +166,123 @@ pub fn snapshot_roots(roots: &[EditorRoot], opts: &Options) -> Result<Snapshot> 
     Ok(merged)
 }
 
+/// Supervisor-facing baseline: discover every editor-extension root
+/// under `home`, snapshot them, and report which roots were actually
+/// present at discovery time. Empty when no editor is installed —
+/// the supervisor MUST still run [`drift_extensions`] post-run, since
+/// an attacker can create `~/.vscode/extensions/` during the
+/// supervised step (sideload pattern).
+pub fn baseline_extensions(home: &Path) -> Result<(Snapshot, Vec<EditorRoot>)> {
+    let roots = default_roots(home);
+    let snap = snapshot_roots(&roots, &Options::default())?;
+    Ok((snap, roots))
+}
+
+/// Supervisor-facing post-run: re-discover roots (catches roots that
+/// appeared during the supervised step), snapshot, diff against
+/// `baseline`, and IOC-scan only the added/modified paths against
+/// the bundled catalog. Pre-existing-compromise detection lives in
+/// [`scan_existing_extensions`] and runs separately — see plan slice.
+pub fn drift_extensions(home: &Path, baseline: &Snapshot) -> Result<ExtensionDrift> {
+    let roots = default_roots(home);
+    let current = snapshot_roots(&roots, &Options::default())?;
+    let d = diff(baseline, &current);
+    let scan_paths: Vec<&Path> = d
+        .added
+        .iter()
+        .map(|p| p.as_path())
+        .chain(d.modified.iter().map(|m| m.path.as_path()))
+        .collect();
+    // Snapshot paths are root-label-prefixed (e.g.
+    // `vscode-extensions/foo.bar-1.0.0/extension/tasks.json`); pass
+    // each root's *parent* — `$HOME` — as the content-read root and
+    // re-materialise the absolute path per scan. Simpler: scan each
+    // root individually with its own prefix.
+    let iocs = scan_drift_in_roots(&roots, &scan_paths);
+    Ok(ExtensionDrift {
+        added: d.added.clone(),
+        modified_paths: d.modified.iter().map(|m| m.path.clone()).collect(),
+        removed: d.removed.clone(),
+        diff: d,
+        iocs,
+    })
+}
+
+/// Pre-run sweep: snapshot every discovered root and IOC-scan every
+/// file in it (path rules + content rules). The result tells the
+/// caller "the host was already poisoned before sakimori attached"
+/// — a separate signal from drift, with the same High-severity
+/// unconditional-fail contract.
+pub fn scan_existing_extensions(home: &Path) -> Result<iocs::Report> {
+    let roots = default_roots(home);
+    let mut findings: Vec<iocs::Finding> = Vec::new();
+    for root in &roots {
+        if !root.path.is_dir() {
+            continue;
+        }
+        let snap = Snapshot::take(&root.path, &Options::default())?;
+        // Scan the relative paths but use root.path as the content-
+        // read root, then rewrite each finding's path to be
+        // label-prefixed so the report distinguishes "this hit was
+        // under cursor-extensions" from "this hit was under
+        // vscode-extensions".
+        let rel: Vec<&Path> = snap.files.keys().map(|p| p.as_path()).collect();
+        let prefix = PathBuf::from(&root.label);
+        for mut f in iocs::scan_paths_in_root(&root.path, rel.iter().copied()) {
+            f.path = prefix.join(&f.path);
+            findings.push(f);
+        }
+    }
+    Ok(iocs::Report::new(findings))
+}
+
+/// Drift IOC scan helper: paths are already root-label-prefixed (per
+/// [`snapshot_roots`]). Match each path back to its owning root so
+/// the content-rule reader opens the right absolute file.
+fn scan_drift_in_roots(roots: &[EditorRoot], paths: &[&Path]) -> iocs::Report {
+    let mut findings: Vec<iocs::Finding> = Vec::new();
+    for root in roots {
+        let prefix = PathBuf::from(&root.label);
+        // Filter paths owned by this root, strip the prefix so the
+        // scanner can resolve the absolute path against root.path.
+        let mine: Vec<PathBuf> = paths
+            .iter()
+            .filter_map(|p| p.strip_prefix(&prefix).ok().map(PathBuf::from))
+            .collect();
+        if mine.is_empty() {
+            continue;
+        }
+        let mine_refs: Vec<&Path> = mine.iter().map(|p| p.as_path()).collect();
+        for mut f in iocs::scan_paths_in_root(&root.path, mine_refs.iter().copied()) {
+            f.path = prefix.join(&f.path);
+            findings.push(f);
+        }
+    }
+    iocs::Report::new(findings)
+}
+
+/// What the supervisor embeds in the report for the drift half.
+#[derive(Debug, Clone)]
+pub struct ExtensionDrift {
+    /// Full structural diff. Same shape `workspace_drift` already
+    /// serialises so reviewers can re-use existing tooling.
+    pub diff: Diff,
+    /// Convenience accessor — paths added vs. baseline.
+    pub added: Vec<PathBuf>,
+    /// Convenience accessor — paths whose content/metadata changed.
+    pub modified_paths: Vec<PathBuf>,
+    /// Convenience accessor — paths present in baseline, gone now.
+    pub removed: Vec<PathBuf>,
+    /// IOC findings on `added + modified_paths` only.
+    pub iocs: iocs::Report,
+}
+
+impl ExtensionDrift {
+    pub fn is_clean(&self) -> bool {
+        self.diff.is_clean() && self.iocs.is_clean()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -243,6 +363,140 @@ mod tests {
                 .any(|k| k == "cursor-extensions/a.b-1.0.0/package.json"),
             "got: {keys:?}"
         );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn baseline_extensions_empty_home_returns_empty_snapshot() {
+        let home = tmp_home("baseline-empty");
+        let (snap, roots) = baseline_extensions(&home).unwrap();
+        assert!(snap.files.is_empty());
+        assert!(roots.is_empty());
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn drift_extensions_picks_up_root_created_after_baseline() {
+        // The whole point of post-run re-discovery: an attacker who
+        // creates `~/.vscode/extensions/` during the supervised step
+        // must show up in drift even though baseline saw nothing.
+        let home = tmp_home("drift-new-root");
+        let (baseline, _) = baseline_extensions(&home).unwrap();
+        // Now create the root + a file under it.
+        let vscode_ext = home.join(".vscode").join("extensions").join("a.b-1.0.0");
+        fs::create_dir_all(&vscode_ext).unwrap();
+        fs::write(vscode_ext.join("package.json"), b"{}").unwrap();
+        let drift = drift_extensions(&home, &baseline).unwrap();
+        assert!(
+            drift
+                .added
+                .iter()
+                .any(|p| p.to_string_lossy().contains("a.b-1.0.0/package.json")),
+            "expected the post-baseline-created file to appear in drift.added; got: {:?}",
+            drift.added,
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn drift_extensions_only_scans_added_or_modified_for_iocs() {
+        // A `tasks.json` already present in baseline must NOT
+        // re-trip the IOC scanner during drift — the pre-existing
+        // sweep is the right surface for that. Avoids double-counting
+        // the same finding across both buckets.
+        let home = tmp_home("drift-iocs-add-only");
+        let vscode_ext = home
+            .join(".vscode")
+            .join("extensions")
+            .join("evil.ext-1.0.0")
+            .join(".vscode");
+        fs::create_dir_all(&vscode_ext).unwrap();
+        let tasks_path = vscode_ext.join("tasks.json");
+        fs::write(
+            &tasks_path,
+            br#"{"version":"2.0.0","tasks":[{"label":"x","type":"shell","command":"echo","runOn": "folderOpen"}]}"#,
+        )
+        .unwrap();
+
+        let (baseline, _) = baseline_extensions(&home).unwrap();
+        // No further changes → drift is empty, iocs is empty.
+        let drift = drift_extensions(&home, &baseline).unwrap();
+        assert!(
+            drift.diff.is_clean(),
+            "diff should be clean: {:?}",
+            drift.diff
+        );
+        assert!(
+            drift.iocs.is_clean(),
+            "iocs should be clean: {:?}",
+            drift.iocs
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn drift_extensions_iocs_fires_on_newly_added_tasks_json() {
+        let home = tmp_home("drift-iocs-fires");
+        // Baseline is taken with an empty extensions dir; the
+        // attacker drops a poisoned tasks.json under a new extension
+        // folder during the run.
+        fs::create_dir_all(home.join(".vscode").join("extensions")).unwrap();
+        let (baseline, _) = baseline_extensions(&home).unwrap();
+        let vscode_ext = home
+            .join(".vscode")
+            .join("extensions")
+            .join("evil.ext-1.0.0")
+            .join(".vscode");
+        fs::create_dir_all(&vscode_ext).unwrap();
+        fs::write(
+            vscode_ext.join("tasks.json"),
+            br#"{"version":"2.0.0","tasks":[{"label":"x","type":"shell","command":"echo","runOn": "folderOpen"}]}"#,
+        )
+        .unwrap();
+        let drift = drift_extensions(&home, &baseline).unwrap();
+        assert!(
+            drift.iocs.has_high(),
+            "expected High-severity IOC hit on tasks.json folderOpen; got: {:?}",
+            drift.iocs,
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn scan_existing_extensions_flags_pre_existing_tasks_json() {
+        // The "you were already poisoned before sakimori attached"
+        // signal. Catalog hit must be High-severity and path must be
+        // label-prefixed so the report can tell which editor's
+        // tree the hit came from.
+        let home = tmp_home("scan-existing");
+        let vscode_ext = home
+            .join(".vscode")
+            .join("extensions")
+            .join("evil.ext-1.0.0")
+            .join(".vscode");
+        fs::create_dir_all(&vscode_ext).unwrap();
+        fs::write(
+            vscode_ext.join("tasks.json"),
+            br#"{"version":"2.0.0","tasks":[{"label":"x","type":"shell","command":"echo","runOn": "folderOpen"}]}"#,
+        )
+        .unwrap();
+        let rep = scan_existing_extensions(&home).unwrap();
+        assert!(rep.has_high(), "expected High IOC at baseline: {:?}", rep);
+        assert!(
+            rep.findings
+                .iter()
+                .any(|f| f.path.to_string_lossy().starts_with("vscode-extensions/")),
+            "finding must be prefixed by its root label: {:?}",
+            rep.findings,
+        );
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn scan_existing_extensions_empty_home_is_clean() {
+        let home = tmp_home("scan-existing-empty");
+        let rep = scan_existing_extensions(&home).unwrap();
+        assert!(rep.is_clean());
         fs::remove_dir_all(home).ok();
     }
 

--- a/crates/sakimori-core/src/html.rs
+++ b/crates/sakimori-core/src/html.rs
@@ -6,7 +6,9 @@
 
 use std::fmt::Write;
 
-use crate::{events::Event, iocs, policy::Policy, stats::Stats, tamper::Diff};
+use crate::{
+    events::Event, iocs, policy::Policy, report::ExtensionSection, stats::Stats, tamper::Diff,
+};
 
 /// Render the full report. The result is a complete `<!DOCTYPE html>`
 /// document.
@@ -16,6 +18,7 @@ pub fn render(
     meta: ReportMeta<'_>,
     drift: Option<&Diff>,
     iocs: Option<&iocs::Report>,
+    extension: Option<&ExtensionSection<'_>>,
 ) -> String {
     let mut html = String::with_capacity(16 * 1024);
 
@@ -130,6 +133,41 @@ pub fn render(
         && !r.is_clean()
     {
         render_iocs_section(&mut html, r);
+    }
+
+    if let Some(ext) = extension {
+        if let Some(r) = ext.iocs_baseline
+            && !r.is_clean()
+        {
+            render_extension_iocs_section(
+                &mut html,
+                r,
+                "Editor extensions — pre-existing IOC hits",
+                "Catalog hits in editor-extension directories that existed \
+                 before the supervised step started. High-severity entries \
+                 indicate the host was already poisoned before sakimori \
+                 attached.",
+                "extension_iocs_baseline",
+            );
+        }
+        if let Some(d) = ext.drift
+            && !d.is_clean()
+        {
+            render_extension_drift_section(&mut html, d);
+        }
+        if let Some(r) = ext.iocs_drift
+            && !r.is_clean()
+        {
+            render_extension_iocs_section(
+                &mut html,
+                r,
+                "Editor extensions — IOC hits during drift",
+                "Catalog hits on extension paths added or modified during \
+                 the supervised step. Sideload signal: a poisoned extension \
+                 just dropped onto the host.",
+                "extension_iocs",
+            );
+        }
     }
 
     html.push_str(
@@ -384,10 +422,133 @@ fn render_drift_section(out: &mut String, drift: &Diff) {
     out.push_str("  </section>\n\n");
 }
 
+/// Mirror of [`render_drift_section`] for the editor-extension half.
+/// Separate function so the section title and JSON key in the
+/// truncation footer point at the right place (`extension_drift`
+/// vs `workspace_drift`).
+fn render_extension_drift_section(out: &mut String, drift: &Diff) {
+    let total = drift.total();
+    let _ = write!(
+        out,
+        r#"  <section class="drift">
+    <h2>Editor extensions — drift <span class="badge badge-warn">{total} change{plural}</span></h2>
+    <p class="hint">Files added / modified / removed in
+       <code>~/.vscode/extensions</code> and friends during the supervised
+       step. Compare against the baseline taken at
+       <code>--snapshot-extensions</code>.</p>
+    <table class="events-table">
+      <thead><tr><th>change</th><th>path</th><th>note</th></tr></thead>
+      <tbody>
+"#,
+        total = total,
+        plural = if total == 1 { "" } else { "s" },
+    );
+    for p in drift.added.iter().take(HTML_DRIFT_TOP_N) {
+        let _ = writeln!(
+            out,
+            r#"        <tr><td><span class="chip chip-add">added</span></td><td><code>{}</code></td><td></td></tr>"#,
+            html_escape(&p.display().to_string())
+        );
+    }
+    for m in drift.modified.iter().take(HTML_DRIFT_TOP_N) {
+        let note = drift_modification_note(m);
+        let _ = writeln!(
+            out,
+            r#"        <tr><td><span class="chip chip-mod">modified</span></td><td><code>{}</code></td><td><span class="muted">{}</span></td></tr>"#,
+            html_escape(&m.path.display().to_string()),
+            html_escape(&note),
+        );
+    }
+    for p in drift.removed.iter().take(HTML_DRIFT_TOP_N) {
+        let _ = writeln!(
+            out,
+            r#"        <tr><td><span class="chip chip-del">removed</span></td><td><code>{}</code></td><td></td></tr>"#,
+            html_escape(&p.display().to_string())
+        );
+    }
+    let shown = drift.added.len().min(HTML_DRIFT_TOP_N)
+        + drift.modified.len().min(HTML_DRIFT_TOP_N)
+        + drift.removed.len().min(HTML_DRIFT_TOP_N);
+    out.push_str("      </tbody>\n    </table>\n");
+    if total > shown {
+        let _ = writeln!(
+            out,
+            r#"    <p class="hint">… {} more rows omitted; full diff is in <code>extension_drift</code> of the JSON log.</p>"#,
+            total - shown,
+        );
+    }
+    out.push_str("  </section>\n\n");
+}
+
 /// Cap on IOC rows surfaced before truncation. Same shape as the
 /// drift cap — the full list lives in `workspace_iocs` of the JSON
 /// log regardless.
 const HTML_IOCS_TOP_N: usize = 50;
+
+/// Mirror of [`render_iocs_section`] with caller-provided title /
+/// hint text / JSON-key, so the same renderer covers both extension
+/// IOC buckets (pre-existing vs drift-time).
+fn render_extension_iocs_section(
+    out: &mut String,
+    report: &iocs::Report,
+    title: &str,
+    hint: &str,
+    json_key: &str,
+) {
+    let total = report.findings.len();
+    let high = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == iocs::Severity::High)
+        .count();
+    let badge_class = if high > 0 {
+        "badge-danger"
+    } else {
+        "badge-warn"
+    };
+    let _ = write!(
+        out,
+        r#"  <section class="iocs">
+    <h2>{title} <span class="badge {badge_class}">{total} hit{plural}</span></h2>
+    <p class="hint">{hint} (<code>catalog {ver}</code>)</p>
+    <table class="events-table">
+      <thead><tr><th>severity</th><th>path</th><th>rule</th><th>family</th><th>description</th></tr></thead>
+      <tbody>
+"#,
+        title = html_escape(title),
+        badge_class = badge_class,
+        total = total,
+        plural = if total == 1 { "" } else { "s" },
+        hint = html_escape(hint),
+        ver = html_escape(report.catalog_version),
+    );
+    for f in report.findings.iter().take(HTML_IOCS_TOP_N) {
+        let (chip_class, label) = match f.severity {
+            iocs::Severity::High => ("chip-del", "🛑 HIGH"),
+            iocs::Severity::Medium => ("chip-mod", "⚠️ MED"),
+        };
+        let _ = writeln!(
+            out,
+            r#"        <tr><td><span class="chip {chip_class}">{label}</span></td><td><code>{path}</code></td><td><code>{rule}</code></td><td>{family}</td><td>{desc}</td></tr>"#,
+            chip_class = chip_class,
+            label = label,
+            path = html_escape(&f.path.display().to_string()),
+            rule = html_escape(f.rule_id),
+            family = html_escape(f.family),
+            desc = html_escape(f.description),
+        );
+    }
+    out.push_str("      </tbody>\n    </table>\n");
+    if total > HTML_IOCS_TOP_N {
+        let _ = writeln!(
+            out,
+            r#"    <p class="hint">… {} more rows omitted; full list is in <code>{}</code> of the JSON log.</p>"#,
+            total - HTML_IOCS_TOP_N,
+            html_escape(json_key),
+        );
+    }
+    out.push_str("  </section>\n\n");
+}
 
 fn render_iocs_section(out: &mut String, report: &iocs::Report) {
     let total = report.findings.len();
@@ -776,7 +937,7 @@ mod tests {
     fn html_includes_host_column_header() {
         let p = Policy::permissive_audit();
         let s = stats_with_one_connect("1.2.3.4", None);
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         assert!(out.contains("<th>host</th>"), "host column header missing");
     }
 
@@ -784,7 +945,7 @@ mod tests {
     fn connect_row_shows_hostname_when_present() {
         let p = Policy::permissive_audit();
         let s = stats_with_one_connect("1.2.3.4", Some("example.com"));
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         assert!(out.contains("example.com"), "hostname should render");
         // The IP still appears in the detail column.
         assert!(out.contains("1.2.3.4:443"));
@@ -794,7 +955,7 @@ mod tests {
     fn connect_row_shows_dash_when_hostname_missing() {
         let p = Policy::permissive_audit();
         let s = stats_with_one_connect("1.2.3.4", None);
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         // Em-dash placeholder in the host cell.
         assert!(out.contains("—"), "dash placeholder expected when no PTR");
     }
@@ -821,7 +982,7 @@ mod tests {
             denied: false,
             source: None,
         });
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         // Both rows should render; the host cell is simply empty for
         // non-connect events.
         assert!(out.contains("/bin/sh"));
@@ -832,7 +993,7 @@ mod tests {
     fn source_column_header_present() {
         let p = Policy::permissive_audit();
         let s = stats_with_one_connect("1.2.3.4", None);
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         assert!(out.contains("<th>source</th>"), "source column missing");
     }
 
@@ -860,7 +1021,7 @@ mod tests {
                 root_argv: Some("npm install left-pad@1.0.0".into()),
             }),
         });
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         // Chip with the pm label rendered.
         assert!(
             out.contains(">npm<"),
@@ -878,7 +1039,7 @@ mod tests {
         // Event without source → em-dash placeholder.
         let p = Policy::permissive_audit();
         let s = stats_with_one_connect("1.2.3.4", None);
-        let out = render(&p, &s, meta(), None, None);
+        let out = render(&p, &s, meta(), None, None, None);
         // Both the host and source cells use the em-dash placeholder
         // — count >=2 to confirm the source cell got one too.
         assert!(
@@ -896,7 +1057,7 @@ mod tests {
         let s = Stats::default();
 
         // Clean diff → no section.
-        let out = render(&p, &s, meta(), Some(&Diff::default()), None);
+        let out = render(&p, &s, meta(), Some(&Diff::default()), None, None);
         assert!(!out.contains("Workspace drift"));
 
         // Real diff → section appears with chip rows.
@@ -915,7 +1076,7 @@ mod tests {
             }],
             removed: vec![PathBuf::from("src/old.rs")],
         };
-        let out = render(&p, &s, meta(), Some(&drift), None);
+        let out = render(&p, &s, meta(), Some(&drift), None, None);
         assert!(out.contains("Workspace drift"));
         assert!(out.contains("chip-add"));
         assert!(out.contains("chip-mod"));
@@ -933,7 +1094,7 @@ mod tests {
 
         // Clean report → no section header.
         let clean = iocs::Report::new(Vec::new());
-        let out = render(&p, &s, meta(), None, Some(&clean));
+        let out = render(&p, &s, meta(), None, Some(&clean), None);
         assert!(!out.contains("Known-IOC hits"));
 
         // High + Medium findings → section appears with the danger
@@ -955,7 +1116,7 @@ mod tests {
                 description: "auth token risk",
             },
         ]);
-        let out = render(&p, &s, meta(), None, Some(&report));
+        let out = render(&p, &s, meta(), None, Some(&report), None);
         assert!(
             out.contains("Known-IOC hits"),
             "expected IOC section heading"
@@ -990,7 +1151,7 @@ mod tests {
             severity: iocs::Severity::Medium,
             description: "generic typosquat name",
         }]);
-        let out = render(&p, &s, meta(), None, Some(&report));
+        let out = render(&p, &s, meta(), None, Some(&report), None);
         assert!(out.contains("Known-IOC hits"));
         // The block starts with `Known-IOC hits` and the badge that
         // follows should be `badge-warn`, not `badge-danger`.

--- a/crates/sakimori-core/src/report.rs
+++ b/crates/sakimori-core/src/report.rs
@@ -48,6 +48,34 @@ pub struct ReportArgs<'a> {
     /// because a High-severity IOC must fail the supervised step
     /// even when the user passed `--allow-drift` for generic noise.
     pub workspace_iocs: Option<&'a iocs::Report>,
+    /// Editor-extension snapshot results — drift + drift-time IOC
+    /// hits + pre-existing IOC hits, parallel to the workspace
+    /// triple. Surfaces in the JSON log under three sibling top-
+    /// level keys (`extension_drift`, `extension_iocs`,
+    /// `extension_iocs_baseline`) and as three additional sections
+    /// in the step summary / HTML report. Set only when the user
+    /// passed `--snapshot-extensions` on `sakimori run` or
+    /// `sakimori daemon start`.
+    pub extension: Option<ExtensionSection<'a>>,
+}
+
+/// Bundle of the three editor-extension report surfaces. Kept in one
+/// struct so the renderer / supervisor signature change is one
+/// optional field instead of three.
+#[derive(Default, Clone, Copy)]
+pub struct ExtensionSection<'a> {
+    /// Structural diff of the discovered roots between baseline and
+    /// post-run. Same shape as `workspace_drift` so JSON consumers
+    /// reuse the existing tamper::Diff parser.
+    pub drift: Option<&'a Diff>,
+    /// IOC findings on the drift's added + modified paths only —
+    /// "something just dropped here during the run".
+    pub iocs_drift: Option<&'a iocs::Report>,
+    /// IOC findings against the full pre-run snapshot — "the host
+    /// was already poisoned before sakimori attached". High-severity
+    /// hits in this bucket fail the run unconditionally, same as
+    /// drift-time hits.
+    pub iocs_baseline: Option<&'a iocs::Report>,
 }
 
 pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
@@ -70,6 +98,23 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
         && !iocs.is_clean()
     {
         payload["workspace_iocs"] = serde_json::to_value(iocs)?;
+    }
+    if let Some(ext) = args.extension.as_ref() {
+        if let Some(d) = ext.drift
+            && !d.is_clean()
+        {
+            payload["extension_drift"] = serde_json::to_value(d)?;
+        }
+        if let Some(r) = ext.iocs_drift
+            && !r.is_clean()
+        {
+            payload["extension_iocs"] = serde_json::to_value(r)?;
+        }
+        if let Some(r) = ext.iocs_baseline
+            && !r.is_clean()
+        {
+            payload["extension_iocs_baseline"] = serde_json::to_value(r)?;
+        }
     }
     // Cloud-secret egress tripwire: derived purely from the sampled
     // events, no extra config required. Emits only when at least one
@@ -110,6 +155,7 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
             args.workspace_drift,
             args.workspace_iocs,
             &cloud_secret_hits,
+            args.extension.as_ref(),
         );
         writeln!(f, "{body}")?;
     }
@@ -127,6 +173,7 @@ pub fn write(args: &ReportArgs<'_>, stats: &Stats) -> Result<()> {
             meta,
             args.workspace_drift,
             args.workspace_iocs,
+            args.extension.as_ref(),
         );
         std::fs::write(path, rendered)?;
     }
@@ -149,6 +196,7 @@ pub fn render_step_summary(
     drift: Option<&Diff>,
     ioc_report: Option<&iocs::Report>,
     cloud_secret_hits: &[cloud_secrets::Hit],
+    extension: Option<&ExtensionSection<'_>>,
 ) -> String {
     let mut out = String::new();
     let _ = writeln!(out, "## sakimori\n");
@@ -206,7 +254,103 @@ pub fn render_step_summary(
     if !cloud_secret_hits.is_empty() {
         push_cloud_secret_section(&mut out, cloud_secret_hits);
     }
+    if let Some(ext) = extension {
+        push_extension_sections(&mut out, ext);
+    }
     out
+}
+
+fn push_extension_sections(out: &mut String, ext: &ExtensionSection<'_>) {
+    if let Some(r) = ext.iocs_baseline
+        && !r.is_clean()
+    {
+        let _ = writeln!(
+            out,
+            "\n### ❌ Editor extensions — pre-existing IOC hits (host already poisoned)\n",
+        );
+        let _ = writeln!(out, "_Catalog version: `{}`._\n", r.catalog_version);
+        let _ = writeln!(out, "| severity | path | rule | description |");
+        let _ = writeln!(out, "|:-:|---|---|---|");
+        for f in &r.findings {
+            let sev = match f.severity {
+                iocs::Severity::High => "🛑 HIGH",
+                iocs::Severity::Medium => "⚠️ MED",
+            };
+            let _ = writeln!(
+                out,
+                "| {sev} | `{}` | `{}` | {} |",
+                escape_pipe(&f.path.display().to_string()),
+                f.rule_id,
+                escape_pipe(f.description),
+            );
+        }
+    }
+    if let Some(d) = ext.drift
+        && !d.is_clean()
+    {
+        let _ = writeln!(
+            out,
+            "\n### Editor extensions — drift during the supervised step\n",
+        );
+        let _ = writeln!(out, "| | | path | note |\n|:-:|---|---|---|");
+        for p in d.added.iter().take(DRIFT_TOP_N) {
+            let _ = writeln!(
+                out,
+                "| ➕ | added    | `{}` |  |",
+                escape_pipe(&p.display().to_string())
+            );
+        }
+        for m in d.modified.iter().take(DRIFT_TOP_N) {
+            let _ = writeln!(
+                out,
+                "| 🔧 | modified | `{}` | {} |",
+                escape_pipe(&m.path.display().to_string()),
+                modification_note(m),
+            );
+        }
+        for p in d.removed.iter().take(DRIFT_TOP_N) {
+            let _ = writeln!(
+                out,
+                "| ➖ | removed  | `{}` |  |",
+                escape_pipe(&p.display().to_string())
+            );
+        }
+        let total = d.total();
+        let shown = d.added.len().min(DRIFT_TOP_N)
+            + d.modified.len().min(DRIFT_TOP_N)
+            + d.removed.len().min(DRIFT_TOP_N);
+        if total > shown {
+            let _ = writeln!(
+                out,
+                "\n_… {} more rows omitted; full diff is in `extension_drift` of the JSON log._",
+                total - shown,
+            );
+        }
+    }
+    if let Some(r) = ext.iocs_drift
+        && !r.is_clean()
+    {
+        let _ = writeln!(
+            out,
+            "\n### ❌ Editor extensions — IOC hits during drift (sideload signal)\n",
+        );
+        let _ = writeln!(out, "_Catalog version: `{}`._\n", r.catalog_version);
+        let _ = writeln!(out, "| severity | path | rule | description |");
+        let _ = writeln!(out, "|:-:|---|---|---|");
+        for f in &r.findings {
+            let sev = match f.severity {
+                iocs::Severity::High => "🛑 HIGH",
+                iocs::Severity::Medium => "⚠️ MED",
+            };
+            let _ = writeln!(
+                out,
+                "| {sev} | `{}` | `{}` | {} |",
+                escape_pipe(&f.path.display().to_string()),
+                f.rule_id,
+                escape_pipe(f.description),
+            );
+        }
+    }
 }
 
 fn push_cloud_secret_section(out: &mut String, hits: &[cloud_secrets::Hit]) {
@@ -539,7 +683,7 @@ mod tests {
         stats.ingest(ev_open("/etc/hosts", false));
         stats.ingest(ev_exec("/bin/sh", false));
 
-        let s = render_step_summary("npm install", &stats, None, None, &[]);
+        let s = render_step_summary("npm install", &stats, None, None, &[], None);
         // Header + command line.
         assert!(s.contains("## sakimori"));
         assert!(s.contains("`npm install`"));
@@ -565,7 +709,7 @@ mod tests {
         }
         stats.ingest(ev_connect(Some("evil.example"), "9.9.9.9", 443, true));
 
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         let evil_pos = s.find("evil.example").expect("evil row present");
         let good_pos = s.find("good.example").expect("good row present");
         assert!(
@@ -582,7 +726,7 @@ mod tests {
         // headers in the summary).
         let mut stats = Stats::default();
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(s.contains("### Files"));
         assert!(!s.contains("### Network"));
         assert!(!s.contains("### Processes"));
@@ -591,7 +735,7 @@ mod tests {
     #[test]
     fn pipe_in_command_is_escaped_so_table_doesnt_break() {
         let stats = Stats::default();
-        let s = render_step_summary("bash -c 'foo | bar'", &stats, None, None, &[]);
+        let s = render_step_summary("bash -c 'foo | bar'", &stats, None, None, &[], None);
         assert!(s.contains(r"bash -c 'foo \| bar'"));
     }
 
@@ -601,7 +745,7 @@ mod tests {
         for i in 0..(SUMMARY_TOP_N + 5) {
             stats.ingest(ev_open(&format!("/tmp/file-{i}"), false));
         }
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(s.contains("more rows omitted"));
     }
 
@@ -612,7 +756,7 @@ mod tests {
             ..Stats::default()
         };
         stats.ingest(ev_open("/x", false));
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(s.contains("⚠️"));
         assert!(s.contains("7 events were dropped"));
     }
@@ -624,7 +768,7 @@ mod tests {
         // No source attribution anywhere → table suppressed.
         let mut stats = Stats::default();
         stats.ingest(ev_connect(Some("a.example"), "1.1.1.1", 443, false));
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(
             !s.contains("### Sources"),
             "with zero attribution the section must be hidden, got:\n{s}"
@@ -658,7 +802,7 @@ mod tests {
         stats.ingest(e2);
         stats.ingest(e3);
 
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(s.contains("### Sources"), "section header missing");
         assert!(s.contains("`npm`"));
         assert!(s.contains("`pip`"));
@@ -686,7 +830,7 @@ mod tests {
             removed: vec![PathBuf::from("src/old.rs")],
         };
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[]);
+        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[], None);
 
         assert!(s.contains("| drift    | **3** |"), "drift count missing");
         assert!(s.contains("### Workspace drift"), "drift section missing");
@@ -701,7 +845,7 @@ mod tests {
     fn drift_section_suppressed_when_clean() {
         use crate::tamper::Diff;
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&Diff::default()), None, &[]);
+        let s = render_step_summary("cmd", &stats, Some(&Diff::default()), None, &[], None);
         assert!(!s.contains("### Workspace drift"));
         // Clean diff still gets a "drift | 0" row so the user knows
         // the snapshot ran.
@@ -721,7 +865,7 @@ mod tests {
             removed: vec![],
         };
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[]);
+        let s = render_step_summary("cmd", &stats, Some(&drift), None, &[], None);
         assert!(s.contains("more rows omitted"), "{s}");
     }
 
@@ -737,7 +881,7 @@ mod tests {
             description: "Shai-Hulud dropper",
         }]);
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, Some(&report), &[]);
+        let s = render_step_summary("cmd", &stats, None, Some(&report), &[], None);
         assert!(s.contains("Known-IOC hits"), "{s}");
         assert!(s.contains("🛑 HIGH"), "{s}");
         assert!(s.contains(".claude/setup.mjs"), "{s}");
@@ -749,7 +893,7 @@ mod tests {
         use crate::iocs::Report;
         let report = Report::new(vec![]);
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, Some(&report), &[]);
+        let s = render_step_summary("cmd", &stats, None, Some(&report), &[], None);
         assert!(!s.contains("Known-IOC hits"), "{s}");
     }
 
@@ -764,7 +908,7 @@ mod tests {
             package_manager: "npm".into(),
         }];
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, None, &hits);
+        let s = render_step_summary("cmd", &stats, None, None, &hits, None);
         assert!(s.contains("Cloud-secret egress"), "{s}");
         assert!(s.contains("cloud-metadata-imds"), "{s}");
         assert!(s.contains("169.254.169.254"), "{s}");
@@ -774,7 +918,7 @@ mod tests {
     #[test]
     fn cloud_secret_section_omitted_when_no_hits() {
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, None, &[]);
+        let s = render_step_summary("cmd", &stats, None, None, &[], None);
         assert!(!s.contains("Cloud-secret egress"), "{s}");
     }
 
@@ -793,7 +937,7 @@ mod tests {
             package_manager: "npm".into(),
         }];
         let stats = Stats::default();
-        let s = render_step_summary("cmd", &stats, None, None, &hits);
+        let s = render_step_summary("cmd", &stats, None, None, &hits, None);
         assert!(s.contains("⚠️ ALLOW"), "{s}");
         assert!(!s.contains("❌ DENY"), "{s}");
     }

--- a/crates/sakimori-core/tests/extension_report_matrix.rs
+++ b/crates/sakimori-core/tests/extension_report_matrix.rs
@@ -1,0 +1,198 @@
+//! Matrix integration test for the editor-extension report surface.
+//!
+//! Mirrors the per-scenario / per-mode contract Codex required in the
+//! plan review: each row drives a synthetic `$HOME` through
+//! `editor_extensions::{baseline_extensions, scan_existing_extensions,
+//! drift_extensions}` and then `report::write` to assert that the JSON
+//! log carries the expected sibling top-level keys
+//! (`extension_drift`, `extension_iocs`, `extension_iocs_baseline`)
+//! and that high-severity catalog hits show up where they should.
+//!
+//! Full run/daemon integration is gated on eBPF + Linux, so this
+//! covers the wiring at the report layer — the supervisor unwraps
+//! these into the same `ReportArgs::extension` shape we're testing
+//! directly.
+
+use std::{fs, path::PathBuf};
+
+use sakimori_core::{
+    editor_extensions::{baseline_extensions, drift_extensions, scan_existing_extensions},
+    policy::Policy,
+    report::{ExtensionSection, ReportArgs, write},
+    stats::Stats,
+};
+
+fn tmp_home(tag: &str) -> PathBuf {
+    let id = format!(
+        "{}-{}-{}",
+        std::process::id(),
+        tag,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let p = std::env::temp_dir().join(format!("sakimori-ext-matrix-{id}"));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn write_poisoned_tasks_json(home: &std::path::Path, ext_name: &str) {
+    let dir = home
+        .join(".vscode")
+        .join("extensions")
+        .join(ext_name)
+        .join(".vscode");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("tasks.json"),
+        br#"{"version":"2.0.0","tasks":[{"label":"x","type":"shell","command":"echo","runOn": "folderOpen"}]}"#,
+    )
+    .unwrap();
+}
+
+fn write_report_and_parse(
+    home: &std::path::Path,
+    section: ExtensionSection<'_>,
+) -> serde_json::Value {
+    let log_path = home.join("report.jsonl");
+    let policy = Policy::permissive_audit();
+    let stats = Stats::default();
+    let args = ReportArgs {
+        log: log_path.to_str().unwrap(),
+        summary: None,
+        html: None,
+        command: "test",
+        mode: sakimori_core::policy::Mode::Audit,
+        policy: &policy,
+        workspace_drift: None,
+        workspace_iocs: None,
+        extension: Some(section),
+    };
+    write(&args, &stats).expect("report::write");
+    let raw = fs::read_to_string(&log_path).expect("read log");
+    serde_json::from_str(&raw).expect("parse jsonl")
+}
+
+#[test]
+fn matrix_clean_baseline_clean_run_no_extension_keys_in_json() {
+    // No editors installed, no drift → none of the three sibling
+    // keys should appear; they're suppressed when empty/clean per
+    // the same convention as workspace_drift.
+    let home = tmp_home("matrix-clean");
+    let (baseline, _) = baseline_extensions(&home).unwrap();
+    let iocs_baseline = scan_existing_extensions(&home).unwrap();
+    let drift = drift_extensions(&home, &baseline).unwrap();
+
+    let section = ExtensionSection {
+        drift: Some(&drift.diff),
+        iocs_drift: Some(&drift.iocs),
+        iocs_baseline: Some(&iocs_baseline),
+    };
+    let json = write_report_and_parse(&home, section);
+    assert!(json.get("extension_drift").is_none(), "{json}");
+    assert!(json.get("extension_iocs").is_none(), "{json}");
+    assert!(json.get("extension_iocs_baseline").is_none(), "{json}");
+    fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn matrix_pre_existing_high_ioc_surfaces_in_baseline_key() {
+    let home = tmp_home("matrix-pre-existing-high");
+    // Plant a poisoned tasks.json BEFORE the baseline runs.
+    write_poisoned_tasks_json(&home, "evil.ext-1.0.0");
+    let (baseline, _) = baseline_extensions(&home).unwrap();
+    let iocs_baseline = scan_existing_extensions(&home).unwrap();
+    let drift = drift_extensions(&home, &baseline).unwrap();
+
+    assert!(
+        iocs_baseline.has_high(),
+        "test setup: baseline IOC should be High"
+    );
+    assert!(
+        drift.diff.is_clean() && drift.iocs.is_clean(),
+        "no drift between identical snapshots"
+    );
+
+    let section = ExtensionSection {
+        drift: Some(&drift.diff),
+        iocs_drift: Some(&drift.iocs),
+        iocs_baseline: Some(&iocs_baseline),
+    };
+    let json = write_report_and_parse(&home, section);
+    assert!(
+        json.get("extension_iocs_baseline").is_some(),
+        "pre-existing High IOC must surface in extension_iocs_baseline: {json}"
+    );
+    assert!(json.get("extension_drift").is_none(), "{json}");
+    assert!(
+        json.get("extension_iocs").is_none(),
+        "drift-time bucket stays empty when nothing dropped during the run: {json}"
+    );
+    fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn matrix_drift_high_ioc_surfaces_in_drift_key_not_baseline() {
+    // Clean baseline; an attacker drops a poisoned tasks.json mid-run.
+    let home = tmp_home("matrix-drift-high");
+    fs::create_dir_all(home.join(".vscode").join("extensions")).unwrap();
+    let (baseline, _) = baseline_extensions(&home).unwrap();
+    let iocs_baseline = scan_existing_extensions(&home).unwrap();
+    assert!(iocs_baseline.is_clean(), "clean baseline expected");
+    write_poisoned_tasks_json(&home, "evil.ext-1.0.0");
+    let drift = drift_extensions(&home, &baseline).unwrap();
+
+    assert!(drift.iocs.has_high(), "drift-time High IOC expected");
+
+    let section = ExtensionSection {
+        drift: Some(&drift.diff),
+        iocs_drift: Some(&drift.iocs),
+        iocs_baseline: Some(&iocs_baseline),
+    };
+    let json = write_report_and_parse(&home, section);
+    assert!(
+        json.get("extension_iocs").is_some(),
+        "drift-time IOC must surface in extension_iocs: {json}"
+    );
+    assert!(
+        json.get("extension_drift").is_some(),
+        "structural drift accompanies the IOC hit: {json}"
+    );
+    assert!(
+        json.get("extension_iocs_baseline").is_none(),
+        "baseline bucket stays empty when host wasn't pre-poisoned: {json}"
+    );
+    fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn matrix_structural_drift_without_ioc_only_emits_drift_key() {
+    // Add a benign file to a freshly-created extension dir — drift
+    // fires but no catalog rule matches.
+    let home = tmp_home("matrix-drift-benign");
+    fs::create_dir_all(home.join(".vscode").join("extensions")).unwrap();
+    let (baseline, _) = baseline_extensions(&home).unwrap();
+    let iocs_baseline = scan_existing_extensions(&home).unwrap();
+    let new_dir = home
+        .join(".vscode")
+        .join("extensions")
+        .join("benign.ext-1.0.0");
+    fs::create_dir_all(&new_dir).unwrap();
+    fs::write(new_dir.join("README.md"), b"hi").unwrap();
+    let drift = drift_extensions(&home, &baseline).unwrap();
+
+    assert!(!drift.diff.is_clean(), "drift expected");
+    assert!(drift.iocs.is_clean(), "no IOC: {:?}", drift.iocs);
+
+    let section = ExtensionSection {
+        drift: Some(&drift.diff),
+        iocs_drift: Some(&drift.iocs),
+        iocs_baseline: Some(&iocs_baseline),
+    };
+    let json = write_report_and_parse(&home, section);
+    assert!(json.get("extension_drift").is_some(), "{json}");
+    assert!(json.get("extension_iocs").is_none(), "{json}");
+    assert!(json.get("extension_iocs_baseline").is_none(), "{json}");
+    fs::remove_dir_all(home).ok();
+}

--- a/crates/sakimori-win/src/win.rs
+++ b/crates/sakimori-win/src/win.rs
@@ -288,6 +288,10 @@ pub fn run() -> Result<()> {
         // `--snapshot-workspace`. Adding it here is a follow-up.
         workspace_drift: None,
         workspace_iocs: None,
+        // Editor-extension snapshot isn't wired into the Windows
+        // ETW supervisor yet — Linux supervisor opted in via
+        // `--snapshot-extensions`. Adding it here is a follow-up.
+        extension: None,
     };
     sakimori_core::report::write(&report_args, &final_stats)?;
 

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -315,6 +315,15 @@ pub struct DaemonStartArgs {
     /// otherwise added/removed entries will fire spuriously.
     #[arg(long = "workspace-skip", value_name = "NAME")]
     pub workspace_skip: Vec<String>,
+
+    /// Snapshot every editor-extension directory under `$HOME` at
+    /// start AND at shutdown. Surfaces three new sections in the
+    /// JSON log: `extension_drift`, `extension_iocs`, and
+    /// `extension_iocs_baseline` — see `sakimori run --snapshot-
+    /// extensions` for details. A High-severity IOC in either bucket
+    /// fails the job in any mode. Off by default.
+    #[arg(long)]
+    pub snapshot_extensions: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -1199,6 +1208,21 @@ pub struct RunArgs {
     #[arg(long = "snapshot-skip", value_name = "NAME")]
     pub snapshot_skip: Vec<String>,
 
+    /// Snapshot every editor-extension directory under `$HOME` before
+    /// and after the supervised command. Surfaces three new sections
+    /// in the JSON log: `extension_drift` (structural diff),
+    /// `extension_iocs` (catalog hits on added/modified paths during
+    /// the run), and `extension_iocs_baseline` (catalog hits on the
+    /// pre-run snapshot — "the host was already poisoned"). A High-
+    /// severity IOC in either bucket fails the run unconditionally,
+    /// even in audit mode — these are known supply-chain worm
+    /// fingerprints, not policy calls. Structural drift only fails
+    /// the run in block mode, matching `--snapshot-workspace`. Off
+    /// by default — opt-in because the pre-run scan walks every
+    /// installed extension on disk.
+    #[arg(long)]
+    pub snapshot_extensions: bool,
+
     /// Command + args to execute under supervision.
     #[arg(trailing_var_arg = true, required = true)]
     pub command: Vec<String>,
@@ -1666,6 +1690,7 @@ async fn run_daemon_start(args: DaemonStartArgs) -> Result<()> {
         workspace_baseline: args.workspace_baseline,
         workspace_dir: args.workspace_dir,
         workspace_skip: args.workspace_skip,
+        snapshot_extensions: args.snapshot_extensions,
     })
     .await
 }
@@ -2565,6 +2590,48 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         None => None,
     };
 
+    // Editor-extension snapshot: baseline + pre-existing IOC sweep
+    // happen BEFORE we start the supervisor, same shape as the
+    // workspace baseline. Hard-error on safety-guard violations
+    // (HOME unresolvable, refusing `/`), soft-fail on walk errors
+    // (warn + drop the section) so a transient permission issue
+    // doesn't take down the run.
+    let (ext_baseline_snap, ext_iocs_baseline) = if args.snapshot_extensions {
+        match resolve_safe_home() {
+            Ok(home) => {
+                let baseline = match sakimori_core::editor_extensions::baseline_extensions(&home) {
+                    Ok((s, roots)) => {
+                        log::info!(
+                            "editor-extension baseline: {} files across {} root(s) under {}",
+                            s.files.len(),
+                            roots.len(),
+                            home.display(),
+                        );
+                        Some(s)
+                    }
+                    Err(e) => {
+                        log::warn!("editor-extension baseline snapshot failed: {e:#}");
+                        None
+                    }
+                };
+                let iocs_baseline =
+                    match sakimori_core::editor_extensions::scan_existing_extensions(&home) {
+                        Ok(r) => Some(r),
+                        Err(e) => {
+                            log::warn!("editor-extension baseline IOC scan failed: {e:#}");
+                            None
+                        }
+                    };
+                (baseline, iocs_baseline)
+            }
+            Err(e) => {
+                return Err(e.context("--snapshot-extensions requires a safe $HOME"));
+            }
+        }
+    } else {
+        (None, None)
+    };
+
     let supervised = loader::Supervisor::start(
         policy.clone(),
         mode,
@@ -2602,6 +2669,26 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
     // CI step on flaky DNS.
     crate::resolve_hostnames::resolve(&mut stats).await;
 
+    // Editor-extension drift + drift-time IOCs. Same fail-soft
+    // policy as workspace drift — log + summary still go out
+    // without `extension_drift` if anything errors mid-way.
+    let ext_drift = if args.snapshot_extensions {
+        match (resolve_safe_home(), ext_baseline_snap.as_ref()) {
+            (Ok(home), Some(b)) => {
+                match sakimori_core::editor_extensions::drift_extensions(&home, b) {
+                    Ok(d) => Some(d),
+                    Err(e) => {
+                        log::warn!("editor-extension drift snapshot failed: {e:#}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     let ioc_report = drift.as_ref().map(|d| {
         let paths: Vec<&std::path::Path> = d
             .added
@@ -2622,6 +2709,25 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
     });
 
     let command_str = args.command.join(" ");
+    let ext_section = ext_drift
+        .as_ref()
+        .map(|d| &d.diff)
+        .filter(|d| !d.is_clean());
+    let ext_iocs_drift = ext_drift
+        .as_ref()
+        .map(|d| &d.iocs)
+        .filter(|r| !r.is_clean());
+    let ext_iocs_baseline_ref = ext_iocs_baseline.as_ref().filter(|r| !r.is_clean());
+    let extension = if args.snapshot_extensions {
+        Some(sakimori_core::report::ExtensionSection {
+            drift: ext_section,
+            iocs_drift: ext_iocs_drift,
+            iocs_baseline: ext_iocs_baseline_ref,
+        })
+    } else {
+        None
+    };
+
     let report_args = ReportArgs {
         log: &args.log,
         summary: args.summary.as_deref(),
@@ -2631,11 +2737,27 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         policy: &policy,
         workspace_drift: drift.as_ref().filter(|d| !d.is_clean()),
         workspace_iocs: ioc_report.as_ref().filter(|r| !r.is_clean()),
+        extension,
     };
     sakimori_core::report::write(&report_args, &stats)?;
 
     let drift_violation = drift.as_ref().map(|d| !d.is_clean()).unwrap_or(false);
     let ioc_high = ioc_report.as_ref().map(|r| r.has_high()).unwrap_or(false);
+    // High-severity in either editor-extension bucket fails the
+    // run unconditionally — same contract as workspace IOC. Drift
+    // alone follows the workspace pattern (block-mode only).
+    let ext_drift_violation = ext_drift
+        .as_ref()
+        .map(|d| !d.diff.is_clean())
+        .unwrap_or(false);
+    let ext_ioc_high = ext_drift
+        .as_ref()
+        .map(|d| d.iocs.has_high())
+        .unwrap_or(false)
+        || ext_iocs_baseline
+            .as_ref()
+            .map(|r| r.has_high())
+            .unwrap_or(false);
 
     if stats.denied > 0 && matches!(mode, policy::Mode::Block) {
         // GitHub Actions error annotation — renders as a red banner on the
@@ -2662,7 +2784,56 @@ async fn run_supervised(args: RunArgs) -> Result<()> {
         );
         std::process::exit(1);
     }
+    if ext_drift_violation && matches!(mode, policy::Mode::Block) {
+        let n = ext_drift.as_ref().map(|d| d.diff.total()).unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::editor-extension drift detected: {n} extension files added/modified/removed during the supervised step"
+        );
+        std::process::exit(1);
+    }
+    if ext_ioc_high {
+        let drift_hits = ext_drift
+            .as_ref()
+            .map(|d| d.iocs.findings.len())
+            .unwrap_or(0);
+        let baseline_hits = ext_iocs_baseline
+            .as_ref()
+            .map(|r| r.findings.len())
+            .unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::editor-extension IOC hit: {} pre-existing + {} drift-time path(s) match a known supply-chain campaign fingerprint",
+            baseline_hits, drift_hits,
+        );
+        std::process::exit(1);
+    }
     std::process::exit(exit);
+}
+
+/// Resolve `$HOME` (or `%USERPROFILE%` on Windows) and refuse degenerate
+/// values that would cause `--snapshot-extensions` to walk the entire
+/// filesystem. Canonicalises so symlinked HOMEs resolve to their real
+/// path. Hard-fails the run if the env var is missing or points at
+/// `/` — a defence feature shouldn't silently scan everything.
+fn resolve_safe_home() -> Result<PathBuf> {
+    let raw = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or_else(|| anyhow::anyhow!("$HOME / %USERPROFILE% is unset"))?;
+    let raw_path = PathBuf::from(&raw);
+    if raw_path.as_os_str().is_empty() {
+        anyhow::bail!("$HOME resolved to empty string");
+    }
+    // Canonicalise when possible; if the path doesn't exist on disk
+    // yet (rare but legitimate for tests against ephemeral tmp dirs)
+    // fall back to the raw value rather than failing — the snapshot
+    // walk handles non-existent roots gracefully.
+    let canon = raw_path.canonicalize().unwrap_or_else(|_| raw_path.clone());
+    if canon == Path::new("/") || canon.as_os_str().is_empty() {
+        anyhow::bail!(
+            "$HOME canonicalised to '/' — refusing to walk the entire \
+             filesystem under --snapshot-extensions"
+        );
+    }
+    Ok(canon)
 }
 
 fn run_install_daemon(args: ProxyDaemonArgs) -> Result<()> {

--- a/crates/sakimori/src/daemon.rs
+++ b/crates/sakimori/src/daemon.rs
@@ -73,6 +73,11 @@ pub struct DaemonStartArgs {
     /// match what was passed to `sakimori workspace snapshot`
     /// when the baseline was taken.
     pub workspace_skip: Vec<String>,
+    /// Take a baseline + post-run snapshot of every editor-extension
+    /// directory under `$HOME`. See `sakimori run --snapshot-
+    /// extensions` for semantics. Off by default; opt-in because
+    /// the pre-run sweep walks every installed extension on disk.
+    pub snapshot_extensions: bool,
 }
 
 /// Parameters for `sakimori daemon stop`.
@@ -117,6 +122,39 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         );
     }
 
+    // Editor-extension baseline + pre-existing IOC sweep run BEFORE
+    // we attach the eBPF programs. Hard-fail on $HOME safety guard,
+    // soft-fail on snapshot errors.
+    let (ext_baseline_snap, ext_iocs_baseline) = if args.snapshot_extensions {
+        let home = resolve_safe_home().context("--snapshot-extensions requires a safe $HOME")?;
+        let baseline = match sakimori_core::editor_extensions::baseline_extensions(&home) {
+            Ok((s, roots)) => {
+                log::info!(
+                    "daemon editor-extension baseline: {} files across {} root(s) under {}",
+                    s.files.len(),
+                    roots.len(),
+                    home.display(),
+                );
+                Some(s)
+            }
+            Err(e) => {
+                log::warn!("daemon editor-extension baseline snapshot failed: {e:#}");
+                None
+            }
+        };
+        let iocs_baseline = match sakimori_core::editor_extensions::scan_existing_extensions(&home)
+        {
+            Ok(r) => Some(r),
+            Err(e) => {
+                log::warn!("daemon editor-extension baseline IOC scan failed: {e:#}");
+                None
+            }
+        };
+        (baseline, iocs_baseline)
+    } else {
+        (None, None)
+    };
+
     let cgroup = Cgroup::observe_existing(args.observe_cgroup_of, args.allow_root_cgroup)
         .context("attaching to existing cgroup")?;
     log::info!(
@@ -156,6 +194,42 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         .as_ref()
         .map(|d| scan_drift_for_iocs(d, args.workspace_dir.as_deref()));
 
+    // Editor-extension drift at shutdown — mirrors `sakimori run`.
+    let ext_drift = if args.snapshot_extensions {
+        match (resolve_safe_home(), ext_baseline_snap.as_ref()) {
+            (Ok(home), Some(b)) => {
+                match sakimori_core::editor_extensions::drift_extensions(&home, b) {
+                    Ok(d) => Some(d),
+                    Err(e) => {
+                        log::warn!("daemon editor-extension drift snapshot failed: {e:#}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let ext_section = ext_drift
+        .as_ref()
+        .map(|d| &d.diff)
+        .filter(|d| !d.is_clean());
+    let ext_iocs_drift = ext_drift
+        .as_ref()
+        .map(|d| &d.iocs)
+        .filter(|r| !r.is_clean());
+    let ext_iocs_baseline_ref = ext_iocs_baseline.as_ref().filter(|r| !r.is_clean());
+    let extension = if args.snapshot_extensions {
+        Some(sakimori_core::report::ExtensionSection {
+            drift: ext_section,
+            iocs_drift: ext_iocs_drift,
+            iocs_baseline: ext_iocs_baseline_ref,
+        })
+    } else {
+        None
+    };
+
     let report = ReportArgs {
         log: &args.log,
         summary: args.summary.as_deref(),
@@ -165,11 +239,24 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         policy: &policy,
         workspace_drift: drift.as_ref().filter(|d| !d.is_clean()),
         workspace_iocs: ioc_report.as_ref().filter(|r| !r.is_clean()),
+        extension,
     };
     sakimori_core::report::write(&report, &stats)?;
 
     let drift_violation = drift.as_ref().map(|d| !d.is_clean()).unwrap_or(false);
     let ioc_high = ioc_report.as_ref().map(|r| r.has_high()).unwrap_or(false);
+    let ext_drift_violation = ext_drift
+        .as_ref()
+        .map(|d| !d.diff.is_clean())
+        .unwrap_or(false);
+    let ext_ioc_high = ext_drift
+        .as_ref()
+        .map(|d| d.iocs.has_high())
+        .unwrap_or(false)
+        || ext_iocs_baseline
+            .as_ref()
+            .map(|r| r.has_high())
+            .unwrap_or(false);
 
     // Block-mode parity with `sakimori run`: any denied event flips the
     // exit code so the surrounding job fails.
@@ -197,7 +284,51 @@ pub async fn start(args: DaemonStartArgs) -> Result<()> {
         );
         std::process::exit(1);
     }
+    if ext_drift_violation && matches!(mode, Mode::Block) {
+        let n = ext_drift.as_ref().map(|d| d.diff.total()).unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::editor-extension drift detected: {n} extension files added/modified/removed during the supervised job"
+        );
+        std::process::exit(1);
+    }
+    if ext_ioc_high {
+        let drift_hits = ext_drift
+            .as_ref()
+            .map(|d| d.iocs.findings.len())
+            .unwrap_or(0);
+        let baseline_hits = ext_iocs_baseline
+            .as_ref()
+            .map(|r| r.findings.len())
+            .unwrap_or(0);
+        eprintln!(
+            "::error title=sakimori::editor-extension IOC hit: {} pre-existing + {} drift-time path(s) match a known supply-chain campaign fingerprint",
+            baseline_hits, drift_hits,
+        );
+        std::process::exit(1);
+    }
     Ok(())
+}
+
+/// Resolve `$HOME` (or `%USERPROFILE%`), refusing degenerate values
+/// that would cause `--snapshot-extensions` to walk the entire
+/// filesystem. Mirrors [`crate::cli::resolve_safe_home`] — kept
+/// private here to avoid leaking a CLI helper across modules.
+fn resolve_safe_home() -> Result<PathBuf> {
+    let raw = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or_else(|| anyhow::anyhow!("$HOME / %USERPROFILE% is unset"))?;
+    let raw_path = PathBuf::from(&raw);
+    if raw_path.as_os_str().is_empty() {
+        anyhow::bail!("$HOME resolved to empty string");
+    }
+    let canon = raw_path.canonicalize().unwrap_or_else(|_| raw_path.clone());
+    if canon == Path::new("/") || canon.as_os_str().is_empty() {
+        anyhow::bail!(
+            "$HOME canonicalised to '/' — refusing to walk the entire \
+             filesystem under --snapshot-extensions"
+        );
+    }
+    Ok(canon)
 }
 
 /// Run the IOC catalog against `drift.added` + `drift.modified`. Files


### PR DESCRIPTION
## Summary

Completes roadmap #24 — wires the v2026.05.21 editor-extension snapshot library into the supervised run path. `sakimori run --snapshot-extensions` and `sakimori daemon start --snapshot-extensions` now take a baseline + a full pre-run IOC sweep across every discovered editor-extension root under `\$HOME`, and at shutdown re-discover roots (catches roots created mid-run — the sideload pattern) and diff against the baseline.

Three sibling top-level JSON keys land in the report:
- `extension_drift` — structural diff, same shape as `workspace_drift`
- `extension_iocs` — catalog hits on added/modified paths during the run
- `extension_iocs_baseline` — catalog hits on the pre-run snapshot (\"host was already poisoned before sakimori attached\")

The step summary and HTML report grow three matching sections, reusing the workspace renderer's chip/table styles.

## Why

The 2026-05 GitHub-internal-repo compromise (poisoned VS Code extension on an employee device) made it explicit: editor extensions are a parallel distribution channel CI runners are exposed to. The library + IOC catalog landed in v2026.05.21; this PR is the supervisor-side plumbing so the protection fires automatically around supervised steps instead of needing a separate \`sakimori extensions diff\` step.

## Exit-code policy

Mirrors \`workspace_*\`:
- **High-severity IOC** in either bucket (baseline or drift) → exit 1 in **any mode** (Audit too). The fingerprint is \"this is a known supply-chain worm artefact\", not a policy call.
- **Structural drift alone** → exit 1 only in block mode.
- **\$HOME safety**: canonicalised + sanity-checked (refuses \`/\`, empty string) before any walk, so a misconfigured runner can't accidentally scan the entire filesystem under the flag.

## Test plan

- [x] 6 new core unit tests in [editor_extensions.rs](crates/sakimori-core/src/editor_extensions.rs) covering \`baseline_extensions\`, \`drift_extensions\`, \`scan_existing_extensions\` — including the \"root appears mid-run\" edge case Codex flagged
- [x] 4 integration tests in [extension_report_matrix.rs](crates/sakimori-core/tests/extension_report_matrix.rs) covering the four meaningful corners of the scenario × emit-key matrix (clean, pre-existing High, drift-time High, benign drift only)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` — 742+ tests pass

## Plan review

Sent to Codex (\`gpt-5.3-codex\`) over 2 rounds; round 1 raised 7 substantive findings (post-run re-discovery when baseline is empty, core/sakimori test split, drop \`home_override\` from \`SupervisorArgs\`, schema alignment with existing workspace pattern, table-driven matrix tests, pre-existing-compromise scan, docs/CI updates) — all addressed in round 2 with verdict **APPROVED**.

## Out of scope (tracked as follow-ups)

- Action-input forwarding via \`bokuweb/sakimori/job@v0\` (separate PR once the run-side behaviour is stable in CI for a release cycle)
- \`--allow-extension-drift\` / \`--no-iocs\` flags (defer per Codex's simplification suggestion)
- Devcontainer-aware extension discovery
- \`policy preset extensions\` adding eBPF \`file.deny\` for extension dirs (gated on roadmap #4b lifting the 8-entry cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)