### PR TITLE
test(proxy): validate OTLP payload shape via opentelemetry-proto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,33 @@ the canonical public hosts, list the internal hosts under
    advisory push notifications, OTLP for general observability,
    both for either.
 
+   **Semantic-convention honesty.** The OTLP **envelope** (the
+   `resourceLogs[].scopeLogs[].logRecords[]` shape, `timeUnixNano`
+   as a decimal string, `severityNumber` in the 1..24 enum range,
+   `AnyValue` variants, `service.name` / `service.version` on the
+   resource) follows OTLP/HTTP JSON exactly — any spec-compliant
+   collector parses it. The **`package.*` attribute keys are
+   sakimori-specific**, not OpenTelemetry semantic conventions:
+   OTel has no registered "package install event" attribute set
+   yet, so we use our own namespace. If/when semconv ships an
+   official equivalent (`software.package.*`?) the exporter will
+   add it alongside (not replace `package.*`, to keep existing
+   dashboards working). Don't claim "semconv compliant" — claim
+   "OTLP-wire compliant, custom attribute namespace".
+
+   The envelope claim is enforced by
+   [crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs](crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs):
+   it round-trips the exporter's output through
+   `opentelemetry-proto`'s generated `ExportLogsServiceRequest`
+   type, which carries the canonical OTLP field set + proto3→JSON
+   name mapping. Any future regression that emits a non-OTLP
+   shape (int64 as JSON number, wrong AnyValue variant key,
+   unknown severity, …) trips that test before reaching CI's
+   slower mock-HTTP `proxy_otlp_e2e.rs`. Running a real
+   `otel/opentelemetry-collector-contrib` in CI is roadmap
+   (Docker cost + signal-to-noise) — the proto round-trip is
+   the lightweight stand-in.
+
    **npx** works for free here (same `registry.npmjs.org` path
    the npm rewriter already handles); **Homebrew** does *not* fit
    minimumReleaseAge (formula updates are PRs to a git repo, not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "core-error"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +589,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "enum-as-inner"
@@ -1275,6 +1293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,6 +1662,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1830,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2113,6 +2200,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "log",
+ "opentelemetry-proto",
  "proptest",
  "rcgen",
  "rustls 0.23.40",

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ sakimori proxy start [OPTIONS]
 | **Lifecycle-script gate** (Shai-Hulud-class defence) | `--lifecycle-policy {audit,block,strip}`, `--lifecycle-allow <PKG>` (repeatable), `--lifecycle-strip-on-failure {block,passthrough}`, `--lifecycle-strip-cache-dir <DIR>`, `--lifecycle-no-strip-cache` | `audit` logs install-time scripts; `block` 403s tarballs that ship them; `strip` rewrites the tarball in place to drop the script keys + recompute the SRI hash + amend the packument so npm's integrity verifier agrees. See CLAUDE.md Roadmap #15 for the threat model. |
 | **Egress allow-list** | `--network-allow <HOST>` (repeatable), `--network-allow-file <PATH>` | Default-deny hostname filter. Patterns: `host.example.com` (exact) or `*.example.com` (any subdomain, excludes apex). Off by default. |
 | **Install log + advisories** | `--no-install-log`, `--install-log <PATH>` | The local-first append-only audit log feeding `sakimori advisories scan`. On by default at `~/.sakimori/installs.jsonl`. |
-| **OTLP fan-out** | `--otlp-endpoint <URL>`, `--otlp-header <K=V>` (repeatable) | Mirror every allowed install as an OTLP/HTTP `LogRecord` to Datadog / Honeycomb / Loki / a self-run otel-collector. |
+| **OTLP fan-out** | `--otlp-endpoint <URL>`, `--otlp-header <K=V>` (repeatable) | Mirror every allowed install as an OTLP/HTTP `LogRecord` to Datadog / Honeycomb / Loki / a self-run otel-collector. The **wire envelope** is spec-compliant OTLP/HTTP JSON (any collector parses it); the **`package.*` attribute keys** are sakimori-specific, not OpenTelemetry semantic conventions — OTel has no "package install" semconv yet. See [OTLP semantic conventions](#otlp-semantic-conventions) below. |
 | **Custom registries** | `--npm-registry`, `--pypi-registry`, `--pypi-files-host`, `--cargo-registry-host`, `--cargo-sparse-host`, `--nuget-registry` (all repeatable), `--registries-config <FILE>`, `--upstream-ca-file <PATH>` (repeatable) | Teach the proxy about internal mirrors / replacement registries so the rewriters + lifecycle gate fire on their traffic too. `--upstream-ca-file` adds a PEM CA to the upstream rustls trust store for mirrors behind a private CA. See the [Custom registries](#custom--internal-registries) subsection below. |
 
 **First-run side effect**: generates a self-signed root CA at the
@@ -500,6 +500,43 @@ sakimori proxy start \
 - **`dist.tarball` URL rewriting.** The npm rewriter preserves the
   upstream's own tarball URL byte-for-byte — mirrors that serve
   their own tarball URLs keep doing so transparently.
+
+#### OTLP semantic conventions
+
+`--otlp-endpoint` emits one OTLP/HTTP **JSON** `LogRecord` per
+allowed install. Two layers, with different compliance stories:
+
+- **Envelope — OTLP-wire compliant.** The
+  `resourceLogs[].scopeLogs[].logRecords[]` shape, the proto3→JSON
+  name mapping (camelCase wire names; `timeUnixNano` as a decimal
+  string for 64-bit ints), the `AnyValue` variant keys
+  (`stringValue`, `intValue`, …), and the resource attributes
+  `service.name` / `service.version` all follow the OTLP spec.
+  Any spec-compliant collector (otel-collector-contrib, Datadog
+  Agent's OTLP receiver, Honeycomb's OTel endpoint, Loki, …)
+  parses the payload. This is enforced by
+  [`crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs`][otlp-rt],
+  which deserializes every emitted payload through
+  `opentelemetry-proto`'s generated `ExportLogsServiceRequest`
+  type — same strict shape gate a real collector applies.
+
+- **Attribute keys — sakimori-specific, NOT semconv.** The
+  per-install fields use a `package.*` namespace
+  (`package.ecosystem`, `package.name`, `package.version`,
+  `package.resolved_at`, `package.execution_mode`,
+  `package.project_path`, `package.user_agent`, `package.git.*`).
+  OpenTelemetry has no registered "package install event"
+  attribute set yet, so we use our own namespace rather than
+  shoehorn the data into `code.*` or `vcs.*`. If/when semconv
+  ships an official equivalent (e.g. `software.package.*`),
+  sakimori will add it alongside the existing keys rather than
+  rename — existing dashboards keep working.
+
+If you grep your collector config for "semconv-compliant
+attributes": **no, these aren't.** If you grep for "OTLP-wire
+compatible": **yes, they are.**
+
+[otlp-rt]: crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs
 
 ### `proxy install-ca` / `uninstall-ca`
 

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -71,3 +71,11 @@ proptest = { workspace = true }
 # matches hudsucker's internal rustls 0.22 pin (same TLS types
 # both ends of the proxy must speak).
 tokio-rustls = { version = "0.25", default-features = false, features = ["logging", "tls12", "ring"] }
+# Strict OTLP/HTTP JSON shape validation. The proto-generated types
+# carry the canonical OTLP field set + JSON name mapping (camelCase
+# wire names → snake_case Rust fields, int64 → decimal string, etc.).
+# Deserializing our hand-rolled payload through them is the same gate
+# a real otel-collector applies, just without a Go binary in CI.
+# default-features = false drops the heavy `tonic` transport — we
+# only need the message types + serde derives.
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "logs", "with-serde"] }

--- a/crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs
+++ b/crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs
@@ -1,0 +1,165 @@
+//! Strict OTLP/HTTP JSON shape validation.
+//!
+//! `proxy_otlp_e2e.rs` proves the exporter is wired into the install
+//! decision path, but its assertions are field-by-field on a
+//! `serde_json::Value` — they can't catch a payload that is *shaped*
+//! correctly but uses a field name or value type a real
+//! otel-collector would reject (e.g. emitting `timeUnixNano` as a
+//! JSON number instead of a string, which violates the proto3→JSON
+//! mapping for 64-bit ints).
+//!
+//! This file feeds the payload our exporter produces through
+//! `opentelemetry-proto`'s generated message types. The proto-derived
+//! `serde::Deserialize` impls enforce:
+//!
+//!  - canonical OTLP field names (camelCase on the wire),
+//!  - int64 / fixed64 fields encoded as decimal strings,
+//!  - `AnyValue` carrying exactly one of the documented variant keys
+//!    (`stringValue`, `intValue`, `boolValue`, …),
+//!  - `severityNumber` falling inside the OTLP enum range.
+//!
+//! If a future change starts emitting a non-OTLP shape, this test
+//! breaks before the change can ship — without spending a CI minute
+//! on a Docker-hosted collector.
+//!
+//! NOTE: the `package.*` attribute namespace itself is **not**
+//! OpenTelemetry semantic-convention compliant — those keys are
+//! sakimori-specific (see README "Semantic conventions" subsection).
+//! This test validates the *envelope*, which is the bit a collector
+//! parses; the attribute keys ride through as opaque strings.
+
+use chrono::{DateTime, Utc};
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as AnyValueVariant;
+use sakimori_core::deps::Ecosystem;
+use sakimori_core::installs::{ExecutionMode, InstallEvent};
+use sakimori_proxy::otlp::OtlpExporter;
+
+fn fixed_event() -> InstallEvent {
+    let mut ev = InstallEvent::new(Ecosystem::Npm, "left-pad", "1.3.0")
+        .with_mode(ExecutionMode::Persistent)
+        .with_user_agent("npm/10.0.0 node/20.0.0")
+        .with_project_path("/work/repo");
+    ev.resolved_at = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    ev
+}
+
+fn exporter() -> OtlpExporter {
+    OtlpExporter::new(
+        "https://otel.example.invalid/v1/logs".into(),
+        vec![],
+        "sakimori-test/0".into(),
+    )
+}
+
+#[test]
+fn payload_round_trips_through_opentelemetry_proto() {
+    let payload = exporter().build_payload(&fixed_event());
+
+    // The strict gate: the proto-derived `Deserialize` impl will
+    // reject unknown variant tags inside AnyValue, the wrong JSON
+    // type for int64 fields, missing oneof discriminators, etc.
+    let parsed: ExportLogsServiceRequest =
+        serde_json::from_value(payload).expect("OTLP payload must deserialize via proto types");
+
+    // Envelope: 1 resource → 1 scope → 1 record.
+    assert_eq!(parsed.resource_logs.len(), 1);
+    let rl = &parsed.resource_logs[0];
+    let resource = rl.resource.as_ref().expect("resource present");
+    let service_name = resource
+        .attributes
+        .iter()
+        .find(|kv| kv.key == "service.name")
+        .and_then(|kv| kv.value.as_ref())
+        .and_then(|v| v.value.as_ref())
+        .expect("service.name attribute present");
+    match service_name {
+        AnyValueVariant::StringValue(s) => assert_eq!(s, "sakimori-proxy"),
+        other => panic!("service.name must be stringValue, got {other:?}"),
+    }
+
+    assert_eq!(rl.scope_logs.len(), 1);
+    let sl = &rl.scope_logs[0];
+    let scope = sl.scope.as_ref().expect("instrumentation scope present");
+    assert_eq!(scope.name, "sakimori-proxy");
+
+    assert_eq!(sl.log_records.len(), 1);
+    let lr = &sl.log_records[0];
+
+    // 64-bit timestamp must have decoded — if the exporter ever
+    // regresses to emitting a JSON number, the proto's Deserialize
+    // bails before reaching this assertion.
+    let expected_nanos = DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+        .unwrap()
+        .timestamp_nanos_opt()
+        .unwrap() as u64;
+    assert_eq!(lr.time_unix_nano, expected_nanos);
+    assert_eq!(lr.observed_time_unix_nano, expected_nanos);
+
+    // severityNumber must fall inside the OTLP enum (1..=24). The
+    // proto-derived parser accepts any int32, so we re-check here.
+    assert!(
+        (1..=24).contains(&lr.severity_number),
+        "severityNumber {} outside OTLP range",
+        lr.severity_number
+    );
+    assert_eq!(lr.severity_text, "INFO");
+
+    let body = lr
+        .body
+        .as_ref()
+        .and_then(|v| v.value.as_ref())
+        .expect("log body present");
+    match body {
+        AnyValueVariant::StringValue(s) => assert_eq!(s, "package install"),
+        other => panic!("log body must be stringValue, got {other:?}"),
+    }
+
+    // Attribute namespace check — these keys are sakimori-specific
+    // (not OTel semconv) but must at least all be present + carry
+    // stringValue. Pinning the shape here means a future variant
+    // change (e.g. switching `package.version` to intValue) trips
+    // this test, which is the user-facing contract.
+    let attr_keys: Vec<&str> = lr.attributes.iter().map(|kv| kv.key.as_str()).collect();
+    for required in [
+        "package.ecosystem",
+        "package.name",
+        "package.version",
+        "package.resolved_at",
+        "package.execution_mode",
+        "package.project_path",
+        "package.user_agent",
+    ] {
+        assert!(
+            attr_keys.contains(&required),
+            "required attribute `{required}` missing; got {attr_keys:?}"
+        );
+    }
+    for kv in &lr.attributes {
+        let v = kv
+            .value
+            .as_ref()
+            .and_then(|v| v.value.as_ref())
+            .unwrap_or_else(|| panic!("attribute {} has no value", kv.key));
+        assert!(
+            matches!(v, AnyValueVariant::StringValue(_)),
+            "attribute {} must be stringValue (current contract), got {:?}",
+            kv.key,
+            v
+        );
+    }
+}
+
+#[test]
+fn unknown_execution_mode_still_passes_proto_validation() {
+    // Regression guard: the `unknown` enum-as-string mustn't
+    // accidentally collide with anything the proto deserializer
+    // treats specially.
+    let mut ev = fixed_event();
+    ev.execution_mode = ExecutionMode::Unknown;
+    let payload = exporter().build_payload(&ev);
+    let _: ExportLogsServiceRequest =
+        serde_json::from_value(payload).expect("unknown-mode payload must still deserialize");
+}


### PR DESCRIPTION
## Summary

- New strict-shape test [`crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs`](crates/sakimori-proxy/tests/otlp_proto_roundtrip.rs) round-trips the OTLP exporter output through `opentelemetry-proto`'s generated `ExportLogsServiceRequest` type. That's the same JSON gate a spec-compliant otel-collector applies (canonical OTLP field names, proto3→JSON int64-as-decimal-string, `AnyValue` variant keys, severity enum range) — without the CI cost of running an actual `otel-collector-contrib` Docker image.
- `opentelemetry-proto = "0.32"` added as a **dev-dep only**, with `default-features = false` + `["gen-tonic-messages", "logs", "with-serde"]` so the tonic gRPC transport is excluded from the build graph; only message types + serde derives compile into the test binary.
- README + CLAUDE.md clarified: the OTLP **envelope** is spec-compliant, but the `package.*` attribute keys are **sakimori-specific, not OpenTelemetry semantic conventions** — OTel has no "package install event" semconv yet. Avoids misleading "semconv compliant" claims. If/when an official equivalent ships, we'll add it *alongside* `package.*` rather than rename, to keep existing dashboards working.

## Why

`proxy_otlp_e2e.rs` only proved the dispatch path fires; its mock HTTP server returns 200 to anything, so a payload regression (e.g. `timeUnixNano` emitted as a JSON number, wrong `AnyValue` variant) would silently pass and only fail in production where a real collector rejects it. The proto round-trip catches those classes of regression in 0.00s of test wall-time.

A real-collector Docker e2e remains roadmap; this is the lightweight stand-in.

## Test plan

- [x] `cargo test -p sakimori-proxy --test otlp_proto_roundtrip` — both tests pass
- [x] `cargo test -p sakimori-proxy --test proxy_otlp_e2e` — both existing tests still pass (regression check)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p sakimori-proxy --all-targets -- -D warnings` (no warnings)