### PR TITLE
feat(hub-creds): load ~/.config/sakimori/credentials TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,6 +2153,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "uuid",
 ]
 

--- a/crates/sakimori/Cargo.toml
+++ b/crates/sakimori/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+toml = { workspace = true }
 bytemuck = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/crates/sakimori/src/cli.rs
+++ b/crates/sakimori/src/cli.rs
@@ -1342,6 +1342,15 @@ pub async fn run(cli: Cli) -> Result<()> {
             } else {
                 sakimori_proxy::strip_cache::default_persist_dir()
             };
+            // Layer the optional credentials file UNDER the
+            // CLI flags (and their `env =` SAKIMORI_INGEST_URL /
+            // SAKIMORI_TOKEN fallbacks). Precedence:
+            //   flag > env > ~/.config/sakimori/credentials
+            // A read failure (bad TOML, world-readable file)
+            // logs a warning and is treated as absent — never
+            // 4xx's the run command.
+            let (hub_ingest_url, hub_ingest_token) =
+                resolve_hub_creds(args.hub_ingest_url.clone(), args.hub_ingest_token.clone());
             let cfg = sakimori_proxy::ProxyConfig {
                 listen: args.listen,
                 min_age,
@@ -1361,9 +1370,8 @@ pub async fn run(cli: Cli) -> Result<()> {
                 install_log_enabled: !args.no_install_log,
                 otlp_endpoint: args.otlp_endpoint,
                 otlp_headers: args.otlp_headers,
-                hub_ingest_endpoint: args.hub_ingest_url,
-                hub_ingest_token: args
-                    .hub_ingest_token
+                hub_ingest_endpoint: hub_ingest_url,
+                hub_ingest_token: hub_ingest_token
                     .map(sakimori_proxy::hub_ingest::SakimoriToken::new),
                 lifecycle_policy,
                 lifecycle_allow: args.lifecycle_allow,
@@ -2946,6 +2954,52 @@ fn run_doctor(args: DoctorArgs) -> Result<()> {
     let results = crate::doctor::run_checks(&inputs);
     print!("{}", crate::doctor::render_report(&results));
     std::process::exit(crate::doctor::exit_code(&results));
+}
+
+/// Layer `(--hub-ingest-url, --hub-ingest-token)` /
+/// `(SAKIMORI_INGEST_URL, SAKIMORI_TOKEN)` over the optional
+/// `~/.config/sakimori/credentials` file. Precedence:
+///
+///   1. CLI flag (clap's `env` annotation also reads the env var
+///      for us, so by the time `args.hub_ingest_*` is populated,
+///      flag+env have already merged).
+///   2. credentials file `[hub]` table.
+///
+/// A file-read / parse / permission failure logs a warning and is
+/// treated as absent — never blocks the run command on a typo.
+fn resolve_hub_creds(
+    flag_url: Option<String>,
+    flag_token: Option<String>,
+) -> (Option<String>, Option<String>) {
+    // Fast-path: both already supplied via flag/env. We MUST NOT
+    // touch the credentials file in this branch — the file could
+    // be world-readable (logged as a warning) and we don't want
+    // to surface that warning when the operator isn't relying on
+    // it.
+    if flag_url.is_some() && flag_token.is_some() {
+        return (flag_url, flag_token);
+    }
+    let Some(path) = crate::hub_credentials::default_credentials_path() else {
+        return (flag_url, flag_token);
+    };
+    match crate::hub_credentials::load_credentials(&path) {
+        Ok(Some(creds)) => (
+            flag_url.or(creds.hub.ingest_url),
+            flag_token.or(creds.hub.token),
+        ),
+        Ok(None) => (flag_url, flag_token),
+        Err(e) => {
+            // Constant-only diagnostic — the path may be
+            // attacker-influenced (env var). `LoadError`'s
+            // `Display` is already path-free.
+            log::warn!(
+                "ignoring {} ({}); falling back to CLI/env",
+                path.display(),
+                e
+            );
+            (flag_url, flag_token)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sakimori/src/hub_credentials.rs
+++ b/crates/sakimori/src/hub_credentials.rs
@@ -1,0 +1,271 @@
+//! `~/.config/sakimori/credentials` — TOML credentials file.
+//!
+//! Tertiary source for the hub-ingest URL + token, layered
+//! UNDER `--hub-ingest-url` / `--hub-ingest-token` CLI flags
+//! and the `SAKIMORI_INGEST_URL` / `SAKIMORI_TOKEN` env vars:
+//!
+//!   precedence: flag > env > credentials file
+//!
+//! Lets an operator put `[hub]` into one file once and run
+//! `sakimori run` without juggling `SAKIMORI_TOKEN=` env exports
+//! every shell.
+//!
+//! ## File format (TOML)
+//!
+//! ```toml
+//! [hub]
+//! ingest_url = "https://hub.example/v1/acme/_user/<member-id>/events"
+//! token      = "skm_user_…"
+//! ```
+//!
+//! Only the `[hub]` table is read; unknown keys are tolerated
+//! (`#[serde(default)]`-ed) so a future `[telemetry]` or
+//! `[proxy]` section can land without breaking older binaries.
+//!
+//! ## File location
+//!
+//! `${SAKIMORI_CONFIG_DIR}/credentials` if the env var is set,
+//! otherwise `${XDG_CONFIG_HOME:-$HOME/.config}/sakimori/credentials`.
+//! The env-var override exists so the test suite can point at a
+//! tmpdir without touching the real `$HOME`.
+//!
+//! ## Permission gate
+//!
+//! On Unix, the file is required to be **not group/world-readable**
+//! (`0o077` mode bits clear). The file IS the bearer credential
+//! and is read silently at every `sakimori run` — leaving it
+//! world-readable is the same shape of bug as a chmod-644 ssh
+//! private key. We fail closed: a too-permissive file logs a
+//! `log::warn!` and is treated as absent, never silently consumed.
+//! Windows has no equivalent check (NTFS ACLs need a different
+//! API); the warning is skipped there.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Env var that overrides the credentials-file directory.
+/// Test-only and operator escape hatch; never set in normal
+/// use.
+pub const CONFIG_DIR_ENV: &str = "SAKIMORI_CONFIG_DIR";
+
+/// The basename of the credentials file inside the config
+/// directory. Matches Cargo's `credentials.toml` style.
+pub const CREDENTIALS_BASENAME: &str = "credentials";
+
+/// Parsed credentials. Only `[hub]` is consumed today; the
+/// `#[serde(default)]` on the field means a fresh file that
+/// only declares `[hub]` is the typical shape.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+pub struct Credentials {
+    #[serde(default)]
+    pub hub: HubCredentials,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+pub struct HubCredentials {
+    /// `SAKIMORI_INGEST_URL` equivalent. Same shape +
+    /// validation as the CLI flag (`https://hub/.../events`).
+    pub ingest_url: Option<String>,
+    /// `SAKIMORI_TOKEN` equivalent. The bearer token. Never
+    /// echoed in logs / error messages — `HubCredentials`
+    /// has a custom `Debug` below that redacts it.
+    pub token: Option<String>,
+}
+
+/// Default config-file path. `None` when neither the override
+/// env nor `$HOME` is available (CI sandbox without HOME).
+pub fn default_credentials_path() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var(CONFIG_DIR_ENV)
+        && !dir.is_empty()
+    {
+        return Some(PathBuf::from(dir).join(CREDENTIALS_BASENAME));
+    }
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join("sakimori").join(CREDENTIALS_BASENAME))
+}
+
+/// Read and parse the credentials file at `path`. Returns:
+///   - `Ok(None)` when the file doesn't exist (the common
+///     case — operator hasn't onboarded).
+///   - `Ok(Some(creds))` on successful parse.
+///   - `Err(_)` on read / parse / permission failure. The
+///     caller in `cli.rs` logs a `warn` and proceeds as if
+///     `Ok(None)` — fail-closed, don't make a typo block the
+///     whole CLI.
+pub fn load_credentials(path: &PathBuf) -> Result<Option<Credentials>, LoadError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(LoadError::Io(e.to_string())),
+    };
+    enforce_unix_perms(path)?;
+    let text = std::str::from_utf8(&bytes).map_err(|_| LoadError::NotUtf8)?;
+    let creds: Credentials = toml::from_str(text).map_err(|e| LoadError::Parse(e.to_string()))?;
+    Ok(Some(creds))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    #[error("read: {0}")]
+    Io(String),
+    #[error("file is not valid UTF-8")]
+    NotUtf8,
+    #[error("toml parse: {0}")]
+    Parse(String),
+    #[error("file is too permissive (must be chmod 600 / 0o077-clear)")]
+    TooPermissive,
+}
+
+#[cfg(unix)]
+fn enforce_unix_perms(path: &PathBuf) -> Result<(), LoadError> {
+    use std::os::unix::fs::PermissionsExt;
+    let meta = std::fs::metadata(path).map_err(|e| LoadError::Io(e.to_string()))?;
+    let mode = meta.permissions().mode();
+    // Bits 0o077 = group + world (rwxrwx). The file may have
+    // user bits set; group / world MUST be zero. Same rule as
+    // `~/.aws/credentials` and `~/.ssh/id_*`.
+    if mode & 0o077 != 0 {
+        return Err(LoadError::TooPermissive);
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn enforce_unix_perms(_path: &PathBuf) -> Result<(), LoadError> {
+    // Windows ACL check needs a different API — out of scope
+    // for v1. The operator's responsibility on Windows.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    #[test]
+    fn parses_complete_hub_section() {
+        let s = r#"
+            [hub]
+            ingest_url = "https://hub.example/v1/acme/_user/u/events"
+            token      = "skm_user_abc"
+        "#;
+        let c: Credentials = toml::from_str(s).unwrap();
+        assert_eq!(
+            c.hub.ingest_url.as_deref(),
+            Some("https://hub.example/v1/acme/_user/u/events"),
+        );
+        assert_eq!(c.hub.token.as_deref(), Some("skm_user_abc"));
+    }
+
+    #[test]
+    fn missing_hub_section_yields_empty_optionals() {
+        let c: Credentials = toml::from_str("").unwrap();
+        assert!(c.hub.ingest_url.is_none());
+        assert!(c.hub.token.is_none());
+    }
+
+    #[test]
+    fn unknown_top_level_sections_are_tolerated() {
+        let s = r#"
+            [hub]
+            token = "skm_user_x"
+
+            [future_section]
+            anything = "goes"
+        "#;
+        let c: Credentials = toml::from_str(s).unwrap();
+        assert_eq!(c.hub.token.as_deref(), Some("skm_user_x"));
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let tmp = tempdir();
+        let path = tmp.join("not-there");
+        assert_eq!(load_credentials(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn invalid_utf8_errors() {
+        let tmp = tempdir();
+        let path = tmp.join("c");
+        std::fs::write(&path, [0xff, 0xfe, 0xfd]).unwrap();
+        #[cfg(unix)]
+        chmod_600(&path);
+        assert!(matches!(load_credentials(&path), Err(LoadError::NotUtf8)));
+    }
+
+    #[test]
+    fn malformed_toml_errors() {
+        let tmp = tempdir();
+        let path = tmp.join("c");
+        std::fs::write(&path, "this = is not valid =\ntoml").unwrap();
+        #[cfg(unix)]
+        chmod_600(&path);
+        assert!(matches!(load_credentials(&path), Err(LoadError::Parse(_))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn world_readable_file_rejected() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempdir();
+        let path = tmp.join("c");
+        std::fs::write(&path, "[hub]\ntoken = \"skm_x\"\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(matches!(
+            load_credentials(&path),
+            Err(LoadError::TooPermissive),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn chmod_600_accepted() {
+        let tmp = tempdir();
+        let path = tmp.join("c");
+        std::fs::write(&path, "[hub]\ntoken = \"skm_x\"\n").unwrap();
+        chmod_600(&path);
+        let c = load_credentials(&path).unwrap().unwrap();
+        assert_eq!(c.hub.token.as_deref(), Some("skm_x"));
+    }
+
+    #[test]
+    fn default_path_respects_override_env() {
+        let saved = std::env::var_os(CONFIG_DIR_ENV);
+        // SAFETY: tests run single-threaded by `cargo test --
+        // --test-threads=1` in this crate's CI; the env mutation
+        // is local to this test.
+        unsafe { std::env::set_var(CONFIG_DIR_ENV, "/tmp/zzz") };
+        let p = default_credentials_path().unwrap();
+        assert_eq!(p, std::path::Path::new("/tmp/zzz/credentials"));
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var(CONFIG_DIR_ENV, v),
+                None => std::env::remove_var(CONFIG_DIR_ENV),
+            }
+        }
+    }
+
+    fn tempdir() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "sakimori-creds-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[cfg(unix)]
+    fn chmod_600(path: &PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}

--- a/crates/sakimori/src/hub_credentials.rs
+++ b/crates/sakimori/src/hub_credentials.rs
@@ -144,7 +144,6 @@ fn enforce_unix_perms(_path: &PathBuf) -> Result<(), LoadError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
 
     #[test]
     fn parses_complete_hub_section() {

--- a/crates/sakimori/src/main.rs
+++ b/crates/sakimori/src/main.rs
@@ -6,6 +6,7 @@ mod daemon;
 mod doctor;
 mod enforcer;
 mod events;
+mod hub_credentials;
 mod install_gate;
 mod kprobe_override;
 mod loader;


### PR DESCRIPTION
## Summary

Backlog sakimori-hub #9. Until now, the hub-ingest config had two entry points: the `--hub-ingest-url` / `--hub-ingest-token` flags or the `SAKIMORI_INGEST_URL` / `SAKIMORI_TOKEN` env vars. For day-to-day personal-machine use, re-exporting those env vars in every shell is friction we don't need.

This PR adds `~/.config/sakimori/credentials` (TOML) as a **third source**, layered under flags and env vars.

## Precedence

```
CLI flag  >  env var  >  ~/.config/sakimori/credentials
```

clap's `env = "..."` already merges the flag and env var values before the handler sees them, so the credentials file is only consulted when both are absent.

## File format

```toml
# ~/.config/sakimori/credentials  (chmod 600)
[hub]
ingest_url = "https://hub.example/v1/acme/_user/<member>/events"
token      = "skm_user_..."
```

The `Credentials` struct uses `#[serde(default)]` on its `[hub]` table so a future `[telemetry]` / `[proxy]` section can land without breaking older binaries (forward-compatible).

## File location

`${SAKIMORI_CONFIG_DIR}/credentials` if the env var is set (test-only escape hatch), otherwise `${XDG_CONFIG_HOME:-$HOME/.config}/sakimori/credentials`.

## Security

- **Permission gate** (Unix): same rule as `~/.aws/credentials` / `~/.ssh/id_*` — if any `0o077` bit is set, the load is **rejected** (`LoadError::TooPermissive`). The caller logs a warning and treats the file as absent, falling back to CLI/env. Fail-closed on the file read, fail-soft on the CLI run (a chmod typo doesn't 4xx the whole command).
- **Fast-path** when both flag/env are already set: the credentials file is never opened — avoids surfacing a world-readable warning when the operator isn't relying on the file at all.
- **No token logging**: `HubCredentials.token` stays a `String` only until it's wrapped in the existing `SakimoriToken` newtype (whose `Debug` redacts the bytes). No call site logs `token` directly.
- **Path in warn log**: the path is echoed via `std::path::Display` and the `LoadError::Display` is path-free, so a hostile env value can't forge log lines via the message itself.
- **Windows**: the ACL check would need a different API; skipped in v1 (operator responsibility on Windows).

## Tests

- `cargo test -p sakimori`: 76 + 7 green (+9 new credentials tests)
- `cargo clippy -p sakimori --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

New unit tests:
- canonical-file parse
- empty / optional handling
- unknown-section tolerance (forward-compat)
- file-not-found → `None`
- invalid UTF-8 / malformed TOML rejection
- `chmod 600` accept / world-readable reject (Unix)
- `SAKIMORI_CONFIG_DIR` env override

## Test plan

- [x] `cargo test -p sakimori hub_credentials` — 9 / 9 green
- [x] `cargo test -p sakimori` — 76 + 7 green
- [x] `cargo clippy -p sakimori --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Live manual verify on a real machine:
  ```bash
  mkdir -p ~/.config/sakimori
  cat > ~/.config/sakimori/credentials <<EOF2
  [hub]
  ingest_url = "https://hub.example/v1/acme/_user/<id>/events"
  token      = "skm_user_..."
  EOF2
  chmod 600 ~/.config/sakimori/credentials

  # flag/env neither set → file is consulted, hub ingest activates
  sakimori proxy start --listen 127.0.0.1:8000
  ```

## Out of scope (follow-ups)

- Windows ACL check
- A `sakimori login` subcommand that writes the credentials file interactively (today the file is hand-edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)