### PR TITLE
feat(hub-ingest): forward vscode-extension events as ecosystem=vscode

### DIFF
--- a/crates/sakimori-proxy/src/hub_ingest.rs
+++ b/crates/sakimori-proxy/src/hub_ingest.rs
@@ -21,11 +21,13 @@
 //!
 //! Schema mapping is opinionated:
 //! - `crates` ecosystem (the sakimori-core label) is rewritten to
-//!   `cargo` (the hub schema label). Other ecosystems pass
-//!   through.
-//! - `git` / `vscode-extension` are NOT supported by the hub
-//!   schema today; events for those ecosystems are dropped before
-//!   POST rather than producing a 400 the operator has to debug.
+//!   `cargo` (the hub schema label).
+//! - `vscode-extension` (sakimori-core label) is rewritten to
+//!   `vscode` (the hub schema label, as of sakimori-hub PR #87).
+//!   Other ecosystems pass through unchanged.
+//! - `git` is NOT supported by the hub schema today; events for
+//!   that ecosystem are dropped before POST rather than producing
+//!   a 400 the operator has to debug.
 //! - `user_agent` is required by the hub schema but optional on
 //!   the local `InstallEvent`; when absent we substitute the proxy
 //!   user-agent so the wire payload is always valid.
@@ -121,7 +123,8 @@ impl HubIngestExporter {
 
     /// Build the `InstallEventBatch` JSON for a single event, or
     /// `None` if the event's ecosystem is unsupported by the hub
-    /// (`git`, `vscode-extension`).
+    /// (`git`). `crates` and `vscode-extension` are rewritten to
+    /// the hub-spelled `cargo` / `vscode` labels.
     ///
     /// Public so unit tests can pin the wire shape without
     /// spinning up the proxy.
@@ -287,9 +290,14 @@ fn map_ecosystem(local_label: &str) -> Option<&'static str> {
         "crates" => Some("cargo"),
         "pypi" => Some("pypi"),
         "nuget" => Some("nuget"),
-        // git / vscode-extension are deliberately dropped — hub
-        // schema only accepts the four package-registry
-        // ecosystems above.
+        // Same shape as the `crates`→`cargo` rewrite: sakimori-core
+        // emits the longer `vscode-extension`, hub PR #87 accepts
+        // the shorter `vscode`. Keep the rename pinned here so a
+        // future enum label change can't silently desync.
+        "vscode-extension" => Some("vscode"),
+        // `git` has no hub-schema equivalent and is deliberately
+        // dropped. Returning None lets dispatch skip the event
+        // silently instead of producing a 400.
         _ => None,
     }
 }
@@ -346,12 +354,33 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_ecosystems_are_dropped() {
-        // `git` and `vscode-extension` are not in the hub schema.
-        // Returning None here lets dispatch drop them silently
-        // instead of producing a 400 the operator has to debug.
+    fn vscode_extension_ecosystem_is_rewritten_to_vscode() {
+        // Hub schema (sakimori-hub PR #87) accepts the shorter
+        // `vscode` label; sakimori-core's
+        // `Ecosystem::VscodeExtension.label()` is the longer
+        // `vscode-extension`. The rewriter is the only place
+        // that knows the mapping — pin it so the wire stays
+        // round-trippable with the hub's valibot picklist.
         let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
-        for label in ["git", "vscode-extension", "rubygems"] {
+        let mut ev = sample_event();
+        ev.ecosystem = Ecosystem::VscodeExtension.label().to_string();
+        ev.name = "ms-python.python".into();
+        ev.version = "2026.4.0".into();
+        let p = exp
+            .build_payload(&ev)
+            .expect("vscode-extension event accepted");
+        assert_eq!(p[0]["ecosystem"], "vscode");
+        assert_eq!(p[0]["name"], "ms-python.python");
+    }
+
+    #[test]
+    fn unsupported_ecosystems_are_dropped() {
+        // `git` has no hub-schema equivalent and is deliberately
+        // dropped. Returning None here lets dispatch drop the
+        // event silently instead of producing a 400 the operator
+        // has to debug.
+        let exp = HubIngestExporter::new("http://x".into(), SakimoriToken::new("t"), "ua".into());
+        for label in ["git", "rubygems"] {
             let mut ev = sample_event();
             ev.ecosystem = label.to_string();
             assert!(


### PR DESCRIPTION
## Summary
- Teach `hub_ingest::map_ecosystem` to rewrite `vscode-extension` (the sakimori-core local label) into `vscode` (the hub schema's wire label, accepted as of sakimori-hub#87).
- Same shape as the existing `crates` → `cargo` rewrite: the proxy is the single place that knows the local↔wire mismatch, so a future enum rename cannot silently desync the wire.
- Updates module-level docs and `build_payload` doc to reflect that `git` is now the only deliberately-dropped ecosystem.

## Why
The proxy already records VSCode extension installs in `installs.jsonl` with `ecosystem: vscode-extension` (see `proxy_vsix_lifecycle_e2e::vsix_install_is_logged_with_publisher_dot_name_identity`). Until #87 the hub's wire schema admitted only `npm|cargo|pypi|nuget`, so `map_ecosystem` returned `None` for vscode-extension and the dispatch path silently dropped the event. With the hub side merged, this PR completes the round-trip end-to-end: a vsix fetched through the proxy now lands in `install_events` with `ecosystem='vscode'` and shows up in the hub's Inventory view filter.

## Test plan
- [x] Red-first: `vscode_extension_ecosystem_is_rewritten_to_vscode` was added and confirmed Red (panic on `.expect("vscode-extension event accepted")`) before adding the match arm.
- [x] `unsupported_ecosystems_are_dropped` updated — drops `vscode-extension` from the list (no longer dropped), keeps `git` and `rubygems` to pin the drop path.
- [x] `cargo test -p sakimori-proxy --lib hub_ingest::` — 14/14 pass.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — all binaries green.
- [ ] End-to-end against a real hub: deferred. Existing `proxy_vsix_lifecycle_e2e` already covers the `installs.jsonl` path; the new wire arm is pinned by the unit test that asserts `p[0]["ecosystem"] == "vscode"`. An e2e adding a `mock_hub` ingest assertion for the rewritten label would be a nice follow-up but is not required for correctness here.

## Security considerations
n/a — pure wire-label rewrite on an already-authenticated, schema-validated outbound path. No new external inputs, no auth changes, no logging additions. The rewrite destination is a hardcoded `&'static str`; nothing attacker-controlled selects the wire label.

## codex consultation
n/a — single match-arm addition mirroring the existing `crates` → `cargo` rewrite shape, with a Red-first unit test pinning the wire and the workspace gate green.

## Related
- sakimori-hub#87 — the hub-side counterpart (merged) that taught the wire schema, D1 CHECK, server mappers, and Inventory filter to accept `ecosystem=vscode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)