### PR TITLE
fix(actions): harden workflow input handling

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,20 +1,8 @@
 # cargo-audit configuration. See .github/workflows/security.yml.
 #
-# This file mirrors the `ignore` list in `deny.toml` so cargo-audit
-# and cargo-deny agree on which advisories are in-flight follow-ups
-# vs new findings. Bump both files in lockstep.
-#
 # The CI workflow runs `cargo audit --deny warnings`; that flag
 # escalates `unmaintained` to a failure too. Tighten further only
 # after writing down the rationale in the same commit.
 
 [advisories]
-# See deny.toml `[advisories.ignore]` for per-id rationale.
-# `audit.toml` accepts a flat list of RUSTSEC IDs.
-ignore = [
-  "RUSTSEC-2026-0049",  # rustls-webpki 0.102 via hudsucker 0.22 — bump 0.24 (until 2026-06-30)
-  "RUSTSEC-2026-0098",  # rustls-webpki 0.102 via hudsucker 0.22 — bump 0.24 (until 2026-06-30)
-  "RUSTSEC-2026-0099",  # rustls-webpki 0.102 via hudsucker 0.22 — bump 0.24 (until 2026-06-30)
-  "RUSTSEC-2026-0104",  # rustls-webpki 0.102 via hudsucker 0.22 — bump 0.24 (until 2026-06-30)
-  "RUSTSEC-2026-0119",  # hickory-proto 0.24.4 via hickory-resolver 0.24 — bump 0.26 (until 2026-06-30)
-]
+ignore = []

--- a/.github/workflows/consumer-smoke.yml
+++ b/.github/workflows/consumer-smoke.yml
@@ -1,6 +1,6 @@
 name: consumer-smoke
 
-# Proves the published release is consumable as `bokuweb/sakimori@v0`.
+# Proves the published v0 release is consumable through the action.
 # Runs after a release is published, on manual dispatch, and on PRs
 # (so we exercise the PR-comment sub-action end-to-end).
 
@@ -18,12 +18,14 @@ jobs:
   use-as-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # The exact pattern third-party consumers will write.
-      - uses: bokuweb/sakimori@v0
+      # Keep action code immutable while `version: v0` exercises the same
+      # floating release resolution that consumers get from `@v0`.
+      - uses: bokuweb/sakimori@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
         with:
           mode: audit
+          version: v0
 
       - name: Run supervised command
         run: |
@@ -89,7 +91,7 @@ jobs:
           test -f sakimori-report.html
 
       # Upload both so the comment's one-liner can pull the HTML.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sakimori-report
           path: |
@@ -98,7 +100,7 @@ jobs:
 
       # Only meaningful on pull_request events — on release/dispatch this
       # step no-ops (the sub-action bails early).
-      - uses: bokuweb/sakimori/comment@v0
+      - uses: bokuweb/sakimori/comment@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
         if: github.event_name == 'pull_request'
         with:
           log: sakimori.log.json
@@ -123,10 +125,11 @@ jobs:
     # happens. Runs alongside use-as-action (doesn't need its results).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bokuweb/sakimori@v0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: bokuweb/sakimori@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
         with:
           mode: block
+          version: v0
       - name: Block-mode run should fail with a denied connect
         run: |
           cat > /tmp/block.yml <<'EOF'
@@ -159,10 +162,11 @@ jobs:
     # the same inputs / env contract as the Linux job above.
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bokuweb/sakimori@v0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: bokuweb/sakimori@8491d10e50cf65e438bedb87cd6f4e496140ac29 # v0
         with:
           mode: audit
+          version: v0
       - name: Run supervised command (Windows)
         shell: pwsh
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,10 +21,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
             tags="${tags},ghcr.io/${GITHUB_REPOSITORY_OWNER}/sakimori-proxy:latest"
           fi
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,6 +62,17 @@ jobs:
   # Rust supply chain
   # -------------------------------------------------------------
 
+  action-metadata-contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+      - run: node --test tests/action-security.test.mjs
+
   cargo-audit:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,68 +62,6 @@ jobs:
   # Rust supply chain
   # -------------------------------------------------------------
 
-  # -------------------------------------------------------------
-  # Hard-deadline enforcement on time-boxed advisory ignores.
-  # -------------------------------------------------------------
-  #
-  # `osv-scanner.toml` carries `ignoreUntil` natively — osv-scanner
-  # silently drops the ignore after the date. cargo-audit and
-  # cargo-deny do NOT support per-entry expiry, so the ignore
-  # lists in `.cargo/audit.toml` + `deny.toml` would otherwise
-  # remain in effect forever (codex round-1 finding: the deadline
-  # isn't enforced symmetrically across scanners).
-  #
-  # This job is the symmetry: hard-fail after `IGNORE_DEADLINE`
-  # if any of the time-boxed RUSTSEC IDs are still listed in
-  # either file. Forces the maintainer to actually do the
-  # hudsucker / hickory bump (or, in a worst case, write down
-  # why the deadline needs to slide and update the date in all
-  # three files together).
-
-  ignore-expiry:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    env:
-      IGNORE_DEADLINE: "2026-06-30"
-      # IDs to sweep for. Update this list in lockstep with the
-      # entries in `.cargo/audit.toml` + `deny.toml` +
-      # `osv-scanner.toml`.
-      WATCHED_IDS: "RUSTSEC-2026-0049|RUSTSEC-2026-0098|RUSTSEC-2026-0099|RUSTSEC-2026-0104|RUSTSEC-2026-0119"
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Enforce ignore expiry
-        shell: bash
-        run: |
-          set -euo pipefail
-          today=$(date -u +%Y-%m-%d)
-          if [[ "$today" > "$IGNORE_DEADLINE" ]]; then
-            offenders=()
-            for f in .cargo/audit.toml deny.toml osv-scanner.toml; do
-              if [ -f "$f" ] && grep -qE "$WATCHED_IDS" "$f"; then
-                offenders+=("$f")
-              fi
-            done
-            if [ "${#offenders[@]}" -gt 0 ]; then
-              echo "::error::Time-boxed advisory ignores past their deadline $IGNORE_DEADLINE"
-              echo ""
-              echo "Files still listing the time-boxed RUSTSEC IDs:"
-              printf '  - %s\n' "${offenders[@]}"
-              echo ""
-              echo "By the deadline the workspace should have bumped:"
-              echo "  - hudsucker        0.22 -> 0.24 (closes RUSTSEC-2026-{0049,0098,0099,0104})"
-              echo "  - hickory-resolver 0.24 -> 0.26 (closes RUSTSEC-2026-0119)"
-              echo ""
-              echo "Remove the IDs from the listed files, or — if the bump is"
-              echo "genuinely blocked — open a PR sliding the deadline in ALL"
-              echo "THREE config files AND the IGNORE_DEADLINE env above."
-              exit 1
-            fi
-            echo "deadline passed but no offending IDs remain — ok"
-          else
-            echo "today=$today  deadline=$IGNORE_DEADLINE  ignores still in effect"
-          fi
-
   cargo-audit:
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -109,15 +109,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -183,6 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -265,7 +266,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -273,6 +274,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -333,12 +343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +371,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -436,6 +451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -463,6 +488,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -481,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +532,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -500,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -531,9 +581,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -597,18 +647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -881,6 +919,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -909,23 +948,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.6",
- "thiserror 1.0.69",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -933,22 +972,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1000,9 +1064,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hudsucker"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb9d62508d54891fe529dc3a3e169aa7938b89898ba5ab0431ac5bafe66a249"
+checksum = "8e2dca99d166caa6658eb3842ab0c6672241e47027dcf6f407aa0cf61755b480"
 dependencies = [
  "bstr",
  "futures",
@@ -1013,9 +1077,9 @@ dependencies = [
  "hyper-tungstenite",
  "hyper-util",
  "moka",
- "rand 0.8.6",
+ "rand 0.10.2",
  "rcgen",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-graceful",
@@ -1047,28 +1111,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
  "log",
- "rustls 0.22.4",
- "rustls-pki-types",
+ "rustls",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "hyper-tungstenite"
-version = "0.13.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a343d17fe7885302ed7252767dc7bb83609a874b6ff581142241ec4b73957ad"
+checksum = "bc778da281a749ed28d2be73a9f2cd13030680a1574bc729debd1195e44f00e9"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -1332,6 +1394,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,12 +1503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,15 +1543,6 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -1522,6 +1618,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -1642,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -1654,6 +1756,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1686,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -1795,6 +1901,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,11 +1937,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1884,33 +2001,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1925,21 +2032,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -1952,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -2019,8 +2123,17 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2042,21 +2155,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2065,11 +2164,12 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2085,24 +2185,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2204,7 +2294,7 @@ dependencies = [
  "opentelemetry-proto",
  "proptest",
  "rcgen",
- "rustls 0.23.40",
+ "rustls",
  "sakimori-core",
  "semver",
  "serde",
@@ -2321,7 +2411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2332,7 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2366,6 +2456,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2430,6 +2536,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,9 +2564,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2456,7 +2583,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2582,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-graceful"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627ba4daa4cbce14740603401c895e72d47ecd86690a18e3f0841266e9340de7"
+checksum = "45740b38b48641855471cd402922e89156bdfbd97b69b45eeff170369cc18c7d"
 dependencies = [
  "loom",
  "pin-project-lite",
@@ -2606,24 +2733,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
+ "rustls",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2748,22 +2874,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
- "rustls 0.22.4",
+ "rand 0.9.4",
+ "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
- "url",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2799,6 +2923,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -2812,7 +2942,7 @@ dependencies = [
  "base64",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3034,7 +3164,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3366,11 +3496,12 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -3378,7 +3509,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3394,10 +3525,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ureq = { version = "2", default-features = false, features = ["tls", "json"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
 toml = "0.8"
 notify = "6"
-hickory-resolver = "0.24"
+hickory-resolver = "0.26.1"
 uuid = { version = "1", features = ["v4"] }
 nix = { version = "0.29", features = ["sched", "process", "user", "fs"] }
 bytes = "1"

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,9 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_POLICY: ${{ inputs.policy }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_LOG: ${{ inputs.log }}
       run: |
         set -euo pipefail
 
@@ -116,9 +119,9 @@ runs:
         echo "bpf=${dest}/sakimori.bpf.o" >> "${GITHUB_OUTPUT}"
         echo "SAKIMORI_BPF_OBJ=${dest}/sakimori.bpf.o" >> "${GITHUB_ENV}"
         echo "SAKIMORI_BIN=${dest}/sakimori" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_POLICY=${{ inputs.policy }}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_MODE=${{ inputs.mode }}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_LOG=${{ inputs.log }}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_POLICY=${INPUT_POLICY}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_MODE=${INPUT_MODE}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_LOG=${INPUT_LOG}" >> "${GITHUB_ENV}"
         echo "SAKIMORI_OS=linux" >> "${GITHUB_ENV}"
 
     # --------------- Windows ---------------
@@ -128,6 +131,9 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_POLICY: ${{ inputs.policy }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_LOG: ${{ inputs.log }}
       run: |
         $ErrorActionPreference = "Stop"
         $version = $env:INPUT_VERSION
@@ -173,9 +179,9 @@ runs:
         # can be written once and work on both.
         "bin=$dest\sakimori-win.exe" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
         "SAKIMORI_BIN=$dest\sakimori-win.exe" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_POLICY=${{ inputs.policy }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_MODE=${{ inputs.mode }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_LOG=${{ inputs.log }}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_POLICY=$env:INPUT_POLICY" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_MODE=$env:INPUT_MODE" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_LOG=$env:INPUT_LOG" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
         "SAKIMORI_OS=windows" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
     # --------------- anything else (macOS) ---------------

--- a/comment/action.yml
+++ b/comment/action.yml
@@ -38,6 +38,9 @@ runs:
         MARKER: ${{ inputs.marker }}
         FAIL_ON_DENIED: ${{ inputs.fail-on-denied }}
         TITLE: ${{ inputs.title }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        HTML_FILENAME: ${{ inputs.html-filename }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
 
@@ -55,13 +58,18 @@ runs:
         # Build the one-liner that downloads the HTML artifact and opens it
         # locally. Only emitted when the caller tells us the artifact name.
         oneliner=""
-        if [[ -n "${{ inputs.artifact-name }}" ]]; then
+        if [[ -n "${ARTIFACT_NAME}" ]]; then
           # Scope destination by run-id so re-runs / parallel PRs don't clobber
           # each other, and `rm -rf` first so `gh run download` (which refuses
           # to overwrite existing files) works on the second+ invocation.
           dir="/tmp/sakimori-${GITHUB_RUN_ID}"
-          html="${dir}/${{ inputs.html-filename }}"
-          oneliner="rm -rf ${dir} && gh run download ${GITHUB_RUN_ID} -R ${GITHUB_REPOSITORY} -n ${{ inputs.artifact-name }} -D ${dir} && (open ${html} 2>/dev/null || xdg-open ${html} 2>/dev/null || echo \"open file://${html}\")"
+          html="${dir}/${HTML_FILENAME}"
+          printf -v q_dir '%q' "${dir}"
+          printf -v q_html '%q' "${html}"
+          printf -v q_run_id '%q' "${GITHUB_RUN_ID}"
+          printf -v q_repo '%q' "${GITHUB_REPOSITORY}"
+          printf -v q_artifact '%q' "${ARTIFACT_NAME}"
+          oneliner="rm -rf -- ${q_dir} && gh run download ${q_run_id} -R ${q_repo} -n ${q_artifact} -D ${q_dir} && (open ${q_html} 2>/dev/null || xdg-open ${q_html} 2>/dev/null || echo file://${q_html})"
         fi
 
         body=$(ONELINER="${oneliner}" python3 - "${LOG}" "${MARKER}" "${TITLE}" <<'PY'
@@ -131,7 +139,11 @@ runs:
 
         # Upsert by marker: if a previous comment on this PR contains the
         # marker, edit it; otherwise create a new one.
-        pr_number="${{ github.event.pull_request.number }}"
+        pr_number="${PR_NUMBER}"
+        if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+          echo "::error::invalid pull request number"
+          exit 1
+        fi
         repo="${GITHUB_REPOSITORY}"
         existing=$(gh api -X GET "repos/${repo}/issues/${pr_number}/comments" --paginate \
           --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n1)

--- a/crates/sakimori-proxy/Cargo.toml
+++ b/crates/sakimori-proxy/Cargo.toml
@@ -24,10 +24,10 @@ sakimori-core = { path = "../sakimori-core" }
 # per-host leaf cert signing, and the request/response hook plumbing.
 # `rcgen` generates the root CA on first run.
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "fs"] }
-hudsucker = { version = "0.22", default-features = false, features = ["rustls-client", "rcgen-ca"] }
-rcgen = { version = "0.13", default-features = false, features = ["pem", "aws_lc_rs"] }
+hudsucker = { version = "0.24", default-features = false, features = ["rustls-client", "rcgen-ca"] }
+rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
 time = "0.3"
-rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "aws_lc_rs"] }
 http = "1"
 http-body-util = "0.1"
 bytes = "1"
@@ -51,12 +51,12 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 toml = { workspace = true }
 
 # Custom upstream TLS client for `extra_upstream_roots`. Versions
-# pinned to match what hudsucker 0.22 itself uses internally — the
+# pinned to match what hudsucker 0.24 itself uses internally — the
 # `ClientConfig` types these construct must be the same rustls
-# version hudsucker's connector expects (rustls 0.22 via
+# version hudsucker's connector expects (rustls 0.23 via
 # tokio-rustls). We reuse `hudsucker::rustls` for the rustls types
 # so we don't add a second `rustls` direct dep.
-hyper-rustls = { version = "0.26", default-features = false, features = ["http1", "logging", "ring", "tls12", "webpki-tokio"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "logging", "aws-lc-rs", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-legacy", "http1", "tokio"] }
 webpki-roots = "0.26"
 # NB: PEM parsing uses `rustls_pki_types::pem::PemObject` (reached
@@ -67,10 +67,10 @@ webpki-roots = "0.26"
 
 [dev-dependencies]
 proptest = { workspace = true }
-# Mock HTTPS upstream for proxy_https_e2e.rs. tokio-rustls 0.25
-# matches hudsucker's internal rustls 0.22 pin (same TLS types
+# Mock HTTPS upstream for proxy_https_e2e.rs. tokio-rustls 0.26
+# matches hudsucker's internal rustls 0.23 pin (same TLS types
 # both ends of the proxy must speak).
-tokio-rustls = { version = "0.25", default-features = false, features = ["logging", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "aws_lc_rs"] }
 # Strict OTLP/HTTP JSON shape validation. The proto-generated types
 # carry the canonical OTLP field set + JSON name mapping (camelCase
 # wire names → snake_case Rust fields, int64 → decimal string, etc.).

--- a/crates/sakimori-proxy/src/proxy.rs
+++ b/crates/sakimori-proxy/src/proxy.rs
@@ -15,7 +15,8 @@ use hudsucker::{
     Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
     certificate_authority::RcgenAuthority,
     hyper::{Request, Response, StatusCode},
-    rcgen::KeyPair,
+    rcgen::{Issuer, KeyPair},
+    rustls::crypto::aws_lc_rs,
 };
 
 use sakimori_core::deps::Ecosystem;
@@ -262,8 +263,9 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
 
     let key = KeyPair::from_pem(&String::from_utf8_lossy(&key_pem))
         .context("loading CA key into rcgen")?;
-    let ca_cert = rcgen_cert_from_pem(&cert_pem)?;
-    let authority = RcgenAuthority::new(key, ca_cert, 1_000);
+    let issuer = Issuer::from_ca_cert_pem(&String::from_utf8_lossy(&cert_pem), key)
+        .context("loading CA certificate into rcgen")?;
+    let authority = RcgenAuthority::new(issuer, 1_000, aws_lc_rs::default_provider());
 
     let oracle: Box<dyn AgeOracle> = cfg
         .oracle
@@ -454,11 +456,9 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
         upstream_user_agent: cfg.user_agent.clone(),
     };
 
-    // `.build()` in hudsucker 0.22 returns Proxy<…> directly; no Result.
-    //
     // Branch on whether the user supplied any extra upstream roots.
     // The empty path stays on hudsucker's built-in
-    // `with_rustls_client()` so we don't perturb the default code
+    // `with_rustls_connector()` so we don't perturb the default code
     // path. With extras, we build the same connector shape
     // (`https_or_http()` + `enable_http1()` +
     // `http1_title_case_headers(true)` +
@@ -470,20 +470,22 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
     if cfg.extra_upstream_roots.is_empty() {
         let proxy = Proxy::builder()
             .with_addr(cfg.listen)
-            .with_rustls_client()
             .with_ca(authority)
+            .with_rustls_connector(aws_lc_rs::default_provider())
             .with_http_handler(handler)
-            .build();
+            .build()
+            .context("building proxy")?;
         log::info!("sakimori-proxy listening on {}", cfg.listen);
         proxy.start().await.context("proxy.start()")
     } else {
-        let client = build_upstream_client_with_extra_roots(&cfg.extra_upstream_roots)?;
+        let connector = build_upstream_connector_with_extra_roots(&cfg.extra_upstream_roots)?;
         let proxy = Proxy::builder()
             .with_addr(cfg.listen)
-            .with_client(client)
             .with_ca(authority)
+            .with_http_connector(connector)
             .with_http_handler(handler)
-            .build();
+            .build()
+            .context("building proxy")?;
         log::info!(
             "sakimori-proxy listening on {} (with {} extra upstream root(s))",
             cfg.listen,
@@ -497,20 +499,15 @@ pub async fn run(cfg: ProxyConfig) -> Result<()> {
 /// webpki-roots PLUS each PEM file in `extras`. Used by `run()`
 /// when `ProxyConfig.extra_upstream_roots` is non-empty.
 ///
-/// Mirrors hudsucker 0.22's `with_rustls_client()` connector
+/// Mirrors hudsucker 0.24's `with_rustls_connector()` connector
 /// shape (HTTP/1 only, title-case + preserve-case headers) so the
 /// only behavioural delta vs the default path is the root store.
-fn build_upstream_client_with_extra_roots(
+fn build_upstream_connector_with_extra_roots(
     extras: &[std::path::PathBuf],
-) -> Result<
-    hyper_util::client::legacy::Client<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-        hudsucker::Body,
-    >,
-> {
-    // hudsucker re-exports rustls 0.22 via tokio-rustls. Using
+) -> Result<hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>> {
+    // hudsucker re-exports rustls 0.23 via tokio-rustls. Using
     // that re-export keeps us off the workspace's direct
-    // `rustls 0.23` dep — `hyper-rustls 0.26` won't accept types
+    // `rustls 0.23` dep — `hyper-rustls 0.27` won't accept types
     // from a different rustls crate compilation unit.
     use hudsucker::rustls::pki_types::CertificateDer;
     use hudsucker::rustls::pki_types::pem::PemObject;
@@ -555,7 +552,9 @@ fn build_upstream_client_with_extra_roots(
         extras.len(),
     );
 
-    let tls = ClientConfig::builder()
+    let tls = ClientConfig::builder_with_provider(Arc::new(aws_lc_rs::default_provider()))
+        .with_safe_default_protocol_versions()
+        .context("selecting upstream TLS protocol versions")?
         .with_root_certificates(roots)
         .with_no_client_auth();
 
@@ -565,21 +564,7 @@ fn build_upstream_client_with_extra_roots(
         .enable_http1()
         .build();
 
-    Ok(
-        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-            .http1_title_case_headers(true)
-            .http1_preserve_header_case(true)
-            .build(https),
-    )
-}
-
-fn rcgen_cert_from_pem(pem: &[u8]) -> Result<rcgen::Certificate> {
-    let text = String::from_utf8_lossy(pem).to_string();
-    let params =
-        rcgen::CertificateParams::from_ca_cert_pem(&text).context("parsing CA cert PEM")?;
-    let key = rcgen::KeyPair::generate().context("regen keypair for rcgen cert")?;
-    let cert = params.self_signed(&key).context("re-sign CA cert")?;
-    Ok(cert)
+    Ok(https)
 }
 
 /// Only MITM traffic bound for hosts we care about. Everything else

--- a/crates/sakimori-proxy/tests/proxy_https_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_https_e2e.rs
@@ -97,7 +97,7 @@ fn generate_self_signed_for_loopback(tag: &str) -> SelfSigned {
 
 /// Spawn a TLS mock upstream on a random `127.0.0.1` port that
 /// serves the given JSON body for every request. Uses
-/// `tokio-rustls 0.25` + `hudsucker::rustls` (0.22) so the cert
+/// `tokio-rustls 0.26` + `hudsucker::rustls` (0.23) so the cert
 /// types match the proxy side.
 async fn spawn_mock_tls_upstream(cert: &SelfSigned, body: Vec<u8>) -> std::net::SocketAddr {
     use hud_rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -106,10 +106,14 @@ async fn spawn_mock_tls_upstream(cert: &SelfSigned, body: Vec<u8>) -> std::net::
     let key =
         PrivateKeyDer::try_from(cert.key_der.clone()).expect("PrivateKeyDer accepts PKCS#8 DER");
 
-    let server_config = hud_rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .expect("rustls server config");
+    let server_config = hud_rustls::ServerConfig::builder_with_provider(Arc::new(
+        hud_rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("rustls protocol versions")
+    .with_no_client_auth()
+    .with_single_cert(cert_chain, key)
+    .expect("rustls server config");
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -233,9 +237,13 @@ fn https_get_through_proxy(
         roots.add(cert).map_err(|e| e.to_string())?;
     }
 
-    let tls = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+    let tls = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| e.to_string())?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
 
     let proxy_spec = format!("http://{proxy_addr}");
     let agent = ureq::AgentBuilder::new()

--- a/crates/sakimori-proxy/tests/proxy_lifecycle_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_lifecycle_e2e.rs
@@ -137,10 +137,14 @@ async fn spawn_mock_tarball_upstream(cert: &SelfSigned, body: Vec<u8>) -> std::n
     use hud_rustls::pki_types::{CertificateDer, PrivateKeyDer};
     let cert_chain = vec![CertificateDer::from(cert.cert_der.clone())];
     let key = PrivateKeyDer::try_from(cert.key_der.clone()).unwrap();
-    let server_config = hud_rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .unwrap();
+    let server_config = hud_rustls::ServerConfig::builder_with_provider(Arc::new(
+        hud_rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(cert_chain, key)
+    .unwrap();
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -250,9 +254,13 @@ fn https_get(
         let cert = cert.map_err(|e| e.to_string())?;
         roots.add(cert).map_err(|e| e.to_string())?;
     }
-    let tls = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+    let tls = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| e.to_string())?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
 
     let proxy_spec = format!("http://{proxy_addr}");
     let agent = ureq::AgentBuilder::new()

--- a/crates/sakimori-proxy/tests/proxy_pypi_lifecycle_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_pypi_lifecycle_e2e.rs
@@ -152,10 +152,14 @@ async fn spawn_mock_sdist_upstream(cert: &SelfSigned, body: Vec<u8>) -> std::net
     use hud_rustls::pki_types::{CertificateDer, PrivateKeyDer};
     let cert_chain = vec![CertificateDer::from(cert.cert_der.clone())];
     let key = PrivateKeyDer::try_from(cert.key_der.clone()).unwrap();
-    let server_config = hud_rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .unwrap();
+    let server_config = hud_rustls::ServerConfig::builder_with_provider(Arc::new(
+        hud_rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(cert_chain, key)
+    .unwrap();
     let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -262,9 +266,13 @@ fn https_get(
         let cert = cert.map_err(|e| e.to_string())?;
         roots.add(cert).map_err(|e| e.to_string())?;
     }
-    let tls = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+    let tls = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| e.to_string())?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
 
     let proxy_spec = format!("http://{proxy_addr}");
     let agent = ureq::AgentBuilder::new()

--- a/crates/sakimori/src/resolve.rs
+++ b/crates/sakimori/src/resolve.rs
@@ -6,7 +6,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use anyhow::{Context, Result};
-use hickory_resolver::{TokioAsyncResolver, config::*};
+use hickory_resolver::{TokioResolver, config::*, net::runtime::TokioRuntimeProvider};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 
 use crate::policy::NetRule;
@@ -28,17 +28,25 @@ pub struct Endpoint {
 const MAX_CIDR_EXPANSION: usize = 65_536;
 
 pub struct Resolver {
-    inner: TokioAsyncResolver,
+    inner: TokioResolver,
 }
 
 impl Resolver {
     pub fn from_system() -> Result<Self> {
         // `from_system_conf` reads /etc/resolv.conf on unix. On hosts where it
         // fails (e.g. minimal containers) we fall back to 1.1.1.1 / 8.8.8.8.
-        let inner = TokioAsyncResolver::tokio_from_system_conf().unwrap_or_else(|err| {
-            log::debug!("system resolver unavailable ({err}); falling back to cloudflare");
-            TokioAsyncResolver::tokio(ResolverConfig::cloudflare(), ResolverOpts::default())
-        });
+        let inner = match TokioResolver::builder_tokio().and_then(|builder| builder.build()) {
+            Ok(resolver) => resolver,
+            Err(err) => {
+                log::debug!("system resolver unavailable ({err}); falling back to cloudflare");
+                TokioResolver::builder_with_config(
+                    ResolverConfig::udp_and_tcp(&CLOUDFLARE),
+                    TokioRuntimeProvider::default(),
+                )
+                .build()
+                .context("building Cloudflare fallback resolver")?
+            }
+        };
         Ok(Self { inner })
     }
 

--- a/crates/sakimori/src/resolve_hostnames.rs
+++ b/crates/sakimori/src/resolve_hostnames.rs
@@ -14,7 +14,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::time::Duration;
 
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::TokioResolver;
+use hickory_resolver::proto::rr::RData;
 use sakimori_core::events::Event;
 use sakimori_core::stats::Stats;
 
@@ -54,8 +55,8 @@ pub async fn resolve(stats: &mut Stats) {
     //    macOS) or system config (Windows). If construction fails we
     //    just skip the whole step — the report still renders, just
     //    without hostnames.
-    let resolver = match TokioAsyncResolver::tokio_from_system_conf() {
-        Ok(r) => r,
+    let resolver = match TokioResolver::builder_tokio().and_then(|builder| builder.build()) {
+        Ok(resolver) => resolver,
         Err(e) => {
             log::debug!("resolve_hostnames: skipping, resolver init failed: {e}");
             return;
@@ -70,10 +71,10 @@ pub async fn resolve(stats: &mut Stats) {
         async move {
             let res = tokio::time::timeout(LOOKUP_TIMEOUT, resolver.reverse_lookup(ip)).await;
             let name = match res {
-                Ok(Ok(rev)) => rev
-                    .iter()
-                    .next()
-                    .map(|n| n.to_string().trim_end_matches('.').to_string()),
+                Ok(Ok(rev)) => rev.answers().iter().find_map(|record| match &record.data {
+                    RData::PTR(name) => Some(name.to_string().trim_end_matches('.').to_string()),
+                    _ => None,
+                }),
                 Ok(Err(e)) => {
                     log::debug!("PTR for {ip} failed: {e}");
                     None

--- a/deny.toml
+++ b/deny.toml
@@ -14,45 +14,7 @@ version = 2
 # we'd rather merge a yanked-but-still-used release than block
 # every push until lockfile refresh.
 yanked = "warn"
-# ---------------------------------------------------------------
-# Time-boxed ignores (review at the deadline noted in each
-# `reason`). Real advisories against transitive deps we can't
-# bump without a separate API-migration PR. Tracked as
-# follow-ups. `audit.toml` and `osv-scanner.toml` carry the
-# same set so all three scanners stay in sync; bumping one
-# without the others makes the gate inconsistent.
-# ---------------------------------------------------------------
-ignore = [
-  # `hudsucker 0.22 → rustls 0.22 → rustls-webpki 0.102.8`.
-  # Real risk surface: the MITM proxy validates server certs
-  # outbound, so a malicious upstream can trigger these bugs.
-  # Fix path: bump hudsucker 0.22 → 0.24 (pulls rustls 0.23 +
-  # webpki 0.103.13+). API migration required in
-  # `crates/sakimori-proxy/src/proxy.rs` (ProxyBuilder shape
-  # + rcgen::CertificateParams::from_ca_cert_pem removed).
-  { id = "RUSTSEC-2026-0049", reason = "rustls-webpki 0.102 via hudsucker 0.22; pin until 2026-06-30 follow-up bumps hudsucker → 0.24" },
-  { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.102 via hudsucker 0.22; pin until 2026-06-30 follow-up bumps hudsucker → 0.24" },
-  { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102 via hudsucker 0.22; pin until 2026-06-30 follow-up bumps hudsucker → 0.24" },
-  { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102 via hudsucker 0.22; pin until 2026-06-30 follow-up bumps hudsucker → 0.24" },
-  # `hickory-resolver 0.24 → hickory-proto 0.24.4`.
-  # Risk surface: the proxy uses hickory-resolver for outbound
-  # name lookups; an attacker controlling the DNS server's
-  # response can trigger O(n²) CPU exhaustion in message
-  # encoding. Fix path: bump hickory-resolver 0.24 → 0.26.x —
-  # breaking change (NameServerConfig constructor signature +
-  # ResolverConfig::from_parts removed).
-  { id = "RUSTSEC-2026-0119", reason = "hickory-proto 0.24.4 via hickory-resolver 0.24; pin until 2026-06-30 follow-up bumps to 0.26.x" },
-]
-# Removal condition (codex round-1 finding):
-#   - Remove ALL FIVE RUSTSEC-2026-{0049,0098,0099,0104,0119}
-#     entries above once `hudsucker >= 0.24` AND
-#     `hickory-resolver >= 0.26` are in Cargo.lock.
-#   - The `ignore-expiry` job in .github/workflows/security.yml
-#     hard-fails after 2026-06-30 if these IDs are still listed
-#     here, in .cargo/audit.toml, or in osv-scanner.toml.
-#     cargo-audit + cargo-deny don't support per-entry
-#     `ignoreUntil` natively (osv-scanner.toml does), so the
-#     workflow enforces a single deadline across all three.
+ignore = []
 
 [bans]
 # `multiple-versions = "warn"` is a deliberate first-cut: the

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,35 +1,4 @@
 # osv-scanner configuration. See .github/workflows/security.yml.
 #
-# This file mirrors the `ignore` list in `deny.toml` /
-# `audit.toml` so all three scanners agree on which advisories
-# are in-flight follow-ups vs new findings.
-#
-# osv-scanner uses OSV ids (GHSA / CVE / RUSTSEC accepted), and
-# the `ignoreUntil` field is the hard deadline. After that date
-# the entry is ignored as if absent and the gate re-fails — the
-# bump becomes blocking.
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0049"
-ignoreUntil = "2026-06-30T00:00:00Z"
-reason = "rustls-webpki 0.102 via hudsucker 0.22 → CRL Distribution Point matching. Bump hudsucker 0.22 → 0.24 (API migration in sakimori-proxy/src/proxy.rs)."
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0098"
-ignoreUntil = "2026-06-30T00:00:00Z"
-reason = "rustls-webpki 0.102 via hudsucker 0.22 → URI name constraints. Same fix as 0049."
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0099"
-ignoreUntil = "2026-06-30T00:00:00Z"
-reason = "rustls-webpki 0.102 via hudsucker 0.22 → wildcard name constraints. Same fix as 0049."
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0104"
-ignoreUntil = "2026-06-30T00:00:00Z"
-reason = "rustls-webpki 0.102 via hudsucker 0.22 → reachable panic in CRL parsing. Same fix as 0049."
-
-[[IgnoredVulns]]
-id = "RUSTSEC-2026-0119"
-ignoreUntil = "2026-06-30T00:00:00Z"
-reason = "hickory-proto 0.24.4 via hickory-resolver 0.24 → O(n²) message-encoding CPU exhaustion. Bump hickory-resolver 0.24 → 0.26 (NameServerConfig constructor + ResolverConfig::from_parts API broke)."
+# No ignored vulnerabilities. Keep this file so local and CI
+# osv-scanner invocations share an explicit repository config.

--- a/tests/action-security.test.mjs
+++ b/tests/action-security.test.mjs
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(relative) {
+  return fs.readFileSync(path.join(root, relative), "utf8");
+}
+
+function runBodies(yaml) {
+  const lines = yaml.split("\n");
+  const bodies = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = lines[i].match(/^(\s*)run:\s*\|\s*$/);
+    if (!match) continue;
+    const indent = match[1].length;
+    const body = [];
+    for (i += 1; i < lines.length; i += 1) {
+      const line = lines[i];
+      const lineIndent = line.match(/^\s*/)[0].length;
+      if (line.trim() && lineIndent <= indent) {
+        i -= 1;
+        break;
+      }
+      body.push(line);
+    }
+    bodies.push(body.join("\n"));
+  }
+  return bodies;
+}
+
+test("composite actions keep untrusted expressions out of run scripts", () => {
+  for (const file of ["action.yml", "comment/action.yml"]) {
+    const scripts = runBodies(read(file)).join("\n");
+    assert.doesNotMatch(scripts, /\$\{\{\s*inputs\./, `${file} interpolates an input in run:`);
+    assert.doesNotMatch(
+      scripts,
+      /\$\{\{\s*github\.event\.pull_request\.number\s*\}\}/,
+      `${file} interpolates the PR number in run:`,
+    );
+  }
+});
+
+test("security-sensitive workflows pin every external action by commit SHA", () => {
+  for (const file of [".github/workflows/consumer-smoke.yml", ".github/workflows/docker.yml"]) {
+    const refs = [...read(file).matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map((m) => m[1]);
+    assert.ok(refs.length > 0, `${file} must contain actions to verify`);
+    for (const ref of refs) {
+      if (ref.startsWith("./") || ref.startsWith("docker://")) continue;
+      assert.match(ref, /@[0-9a-f]{40}$/, `${file}: ${ref} is mutable`);
+    }
+  }
+});


### PR DESCRIPTION
> Merge order: this branch is stacked on #123 so the expired advisory gate stays green. Merge #123 first; GitHub will then reduce this PR to the workflow-input hardening commit.

## Summary

- pass composite-action inputs through environment variables instead of interpolating them into scripts
- validate the pull-request number and shell-quote values embedded in the generated artifact command
- pin external actions in consumer-smoke and Docker workflows to immutable commit SHAs
- add a security contract test and run it from the security workflow

## Security alerts

Expected to remediate code-scanning alerts 20–39 covering expression injection and unpinned workflow actions.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `node --test tests/action-security.test.mjs`
- actionlint on the changed workflows
- `sakimori actions audit --strict` reports 0 warnings and 0 errors for consumer-smoke and Docker workflows
- YAML parsing and `git diff --check`