### PR TITLE
fix(actions): prevent GITHUB_ENV injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,22 @@ runs:
       run: |
         set -euo pipefail
 
+        sanitize_env_value() {
+          local name="$1"
+          local value="$2"
+          local sanitized
+          sanitized=$(printf '%s' "${value}" | tr -d '\r\n')
+          if [[ "${sanitized}" != "${value}" ]]; then
+            echo "::error::${name} must not contain CR or LF characters" >&2
+            exit 1
+          fi
+          printf '%s' "${sanitized}"
+        }
+
+        safe_policy=$(sanitize_env_value policy "${INPUT_POLICY}")
+        safe_mode=$(sanitize_env_value mode "${INPUT_MODE}")
+        safe_log=$(sanitize_env_value log "${INPUT_LOG}")
+
         version="${INPUT_VERSION}"
         if [[ -z "${version}" ]]; then
           version="${GITHUB_ACTION_REF:-}"
@@ -119,9 +135,9 @@ runs:
         echo "bpf=${dest}/sakimori.bpf.o" >> "${GITHUB_OUTPUT}"
         echo "SAKIMORI_BPF_OBJ=${dest}/sakimori.bpf.o" >> "${GITHUB_ENV}"
         echo "SAKIMORI_BIN=${dest}/sakimori" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_POLICY=${INPUT_POLICY}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_MODE=${INPUT_MODE}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_LOG=${INPUT_LOG}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_POLICY=${safe_policy}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_MODE=${safe_mode}" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_LOG=${safe_log}" >> "${GITHUB_ENV}"
         echo "SAKIMORI_OS=linux" >> "${GITHUB_ENV}"
 
     # --------------- Windows ---------------
@@ -136,6 +152,20 @@ runs:
         INPUT_LOG: ${{ inputs.log }}
       run: |
         $ErrorActionPreference = "Stop"
+
+        function Get-SingleLineEnvValue {
+          param([string]$Name, [string]$Value)
+          $sanitized = $Value -replace '[\r\n]', ''
+          if ($sanitized -ne $Value) {
+            throw "$Name must not contain CR or LF characters"
+          }
+          return $sanitized
+        }
+
+        $safePolicy = Get-SingleLineEnvValue "policy" $env:INPUT_POLICY
+        $safeMode = Get-SingleLineEnvValue "mode" $env:INPUT_MODE
+        $safeLog = Get-SingleLineEnvValue "log" $env:INPUT_LOG
+
         $version = $env:INPUT_VERSION
         if ([string]::IsNullOrEmpty($version)) { $version = $env:GITHUB_ACTION_REF }
         if ([string]::IsNullOrEmpty($version) -or $version -eq "main" -or $version -eq "latest") {
@@ -179,9 +209,9 @@ runs:
         # can be written once and work on both.
         "bin=$dest\sakimori-win.exe" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
         "SAKIMORI_BIN=$dest\sakimori-win.exe" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_POLICY=$env:INPUT_POLICY" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_MODE=$env:INPUT_MODE" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-        "SAKIMORI_LOG=$env:INPUT_LOG" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_POLICY=$safePolicy" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_MODE=$safeMode" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "SAKIMORI_LOG=$safeLog" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
         "SAKIMORI_OS=windows" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
     # --------------- anything else (macOS) ---------------

--- a/crates/sakimori-proxy/tests/proxy_https_e2e.rs
+++ b/crates/sakimori-proxy/tests/proxy_https_e2e.rs
@@ -36,6 +36,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
+// `spawn_proxy` must release its ephemeral-port reservation before
+// hudsucker binds the same address. Serialise the two tests in this
+// binary so they cannot claim each other's briefly-unbound port.
+static PROXY_PORT_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -296,6 +301,8 @@ fn synthetic_packument() -> Vec<u8> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn https_packument_rewritten_when_upstream_ca_is_trusted() {
+    let _port_guard = PROXY_PORT_LOCK.lock().await;
+
     // Use `localhost` (DnsName SAN) rather than `127.0.0.1` (IP
     // SAN) because hudsucker's per-host MITM leaf-signer issues
     // certificates with a DnsName SAN derived from the CONNECT
@@ -336,6 +343,8 @@ async fn https_packument_rewritten_when_upstream_ca_is_trusted() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn https_upstream_handshake_fails_without_extra_root() {
+    let _port_guard = PROXY_PORT_LOCK.lock().await;
+
     let cert = generate_self_signed_for_loopback("ca-neg");
     let upstream = spawn_mock_tls_upstream(&cert, synthetic_packument()).await;
 

--- a/tests/action-security.test.mjs
+++ b/tests/action-security.test.mjs
@@ -44,6 +44,28 @@ test("composite actions keep untrusted expressions out of run scripts", () => {
   }
 });
 
+test("action inputs cannot inject extra GITHUB_ENV records", () => {
+  const scripts = runBodies(read("action.yml")).join("\n");
+
+  assert.match(scripts, /safe_policy=.*sanitize_env_value.*INPUT_POLICY/);
+  assert.match(scripts, /safe_mode=.*sanitize_env_value.*INPUT_MODE/);
+  assert.match(scripts, /safe_log=.*sanitize_env_value.*INPUT_LOG/);
+  assert.match(scripts, /tr -d ['"]\\r\\n['"]/);
+
+  assert.match(scripts, /\$safePolicy\s*=\s*Get-SingleLineEnvValue.*INPUT_POLICY/);
+  assert.match(scripts, /\$safeMode\s*=\s*Get-SingleLineEnvValue.*INPUT_MODE/);
+  assert.match(scripts, /\$safeLog\s*=\s*Get-SingleLineEnvValue.*INPUT_LOG/);
+  assert.match(scripts, /-replace ['"]\[\\r\\n\]['"],\s*['"]/);
+
+  for (const line of scripts.split("\n").filter((candidate) => candidate.includes("GITHUB_ENV"))) {
+    assert.doesNotMatch(
+      line,
+      /(?:\$\{INPUT_|\$env:INPUT_)(?:POLICY|MODE|LOG)/,
+      `unsanitized action input reaches GITHUB_ENV: ${line.trim()}`,
+    );
+  }
+});
+
 test("security-sensitive workflows pin every external action by commit SHA", () => {
   for (const file of [".github/workflows/consumer-smoke.yml", ".github/workflows/docker.yml"]) {
     const refs = [...read(file).matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map((m) => m[1]);


### PR DESCRIPTION
## Summary

- sanitize `policy`, `mode`, and `log` before writing them to `GITHUB_ENV`
- reject CR/LF-containing inputs on both Bash and PowerShell paths
- add a regression contract that prevents raw action inputs from reaching `GITHUB_ENV`
- serialize the HTTPS proxy integration tests to remove an unrelated ephemeral-port race exposed by the mandatory test run

## Root cause

PR #124 moved untrusted expressions into step environment variables, which fixed expression/script injection. Those values were then persisted as single-line `KEY=VALUE` records without rejecting line breaks. A crafted input could therefore append another environment record such as `LD_PRELOAD` or `BASH_ENV`.

Expected to remediate code-scanning alert #67 (`actions/envvar-injection/medium`).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `node --test tests/action-security.test.mjs`
- composite-action YAML parsing
- `git diff --check`
