### PR TITLE
fix(actions): expose newline sanitizer to CodeQL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,10 @@ runs:
           local name="$1"
           local value="$2"
           local sanitized
-          sanitized=$(printf '%s' "${value}" | tr -d '\r\n')
+          # Keep CR and LF removal as separate commands. Besides making the
+          # single-line invariant explicit, CodeQL recognizes `tr -d '\n'`
+          # as the sanitizer for writes to GITHUB_ENV.
+          sanitized=$(printf '%s' "${value}" | tr -d '\r' | tr -d '\n')
           if [[ "${sanitized}" != "${value}" ]]; then
             echo "::error::${name} must not contain CR or LF characters" >&2
             exit 1

--- a/tests/action-security.test.mjs
+++ b/tests/action-security.test.mjs
@@ -50,7 +50,11 @@ test("action inputs cannot inject extra GITHUB_ENV records", () => {
   assert.match(scripts, /safe_policy=.*sanitize_env_value.*INPUT_POLICY/);
   assert.match(scripts, /safe_mode=.*sanitize_env_value.*INPUT_MODE/);
   assert.match(scripts, /safe_log=.*sanitize_env_value.*INPUT_LOG/);
-  assert.match(scripts, /tr -d ['"]\\r\\n['"]/);
+  assert.match(
+    scripts,
+    /tr -d ['"]\\r['"]\s*\|\s*tr -d ['"]\\n['"]/,
+    "Linux sanitization must expose the newline-removal command to CodeQL",
+  );
 
   assert.match(scripts, /\$safePolicy\s*=\s*Get-SingleLineEnvValue.*INPUT_POLICY/);
   assert.match(scripts, /\$safeMode\s*=\s*Get-SingleLineEnvValue.*INPUT_MODE/);


### PR DESCRIPTION
## Summary

- split Linux CR and LF removal into distinct `tr` commands
- preserve rejection of multiline `policy`, `mode`, and `log` inputs
- pin the CodeQL-recognized sanitizer shape in the Action security contract test

## Root cause

The fix in #126 removed both CR and LF before writing action inputs to `GITHUB_ENV`, but CodeQL only models commands matching forms such as `tr -d \\n\`. The combined `tr -d \\\r\n\` was safe at runtime but was not recognized by the Actions taint query, so main produced [code scanning alert #68](https://github.com/bokuweb/sakimori/security/code-scanning/68).\n\nThis change keeps the same fail-closed behavior and exposes the newline-removal sanitizer to the analyzer.\n\n## Validation\n\n- `node --test tests/action-security.test.mjs`\n- YAML parse of `action.yml`\n- `cargo fmt --all -- --check`\n- `cargo clippy --workspace --all-targets -- -D warnings`\n- `cargo test --workspace`\n- `git diff --check`