### PR TITLE
fix(actions): sanitize inputs at GITHUB_ENV sinks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,20 +74,16 @@ runs:
           local name="$1"
           local value="$2"
           local sanitized
-          # Keep CR and LF removal as separate commands. Besides making the
-          # single-line invariant explicit, CodeQL recognizes `tr -d '\n'`
-          # as the sanitizer for writes to GITHUB_ENV.
           sanitized=$(printf '%s' "${value}" | tr -d '\r' | tr -d '\n')
           if [[ "${sanitized}" != "${value}" ]]; then
             echo "::error::${name} must not contain CR or LF characters" >&2
             exit 1
           fi
-          printf '%s' "${sanitized}"
         }
 
-        safe_policy=$(sanitize_env_value policy "${INPUT_POLICY}")
-        safe_mode=$(sanitize_env_value mode "${INPUT_MODE}")
-        safe_log=$(sanitize_env_value log "${INPUT_LOG}")
+        sanitize_env_value policy "${INPUT_POLICY}"
+        sanitize_env_value mode "${INPUT_MODE}"
+        sanitize_env_value log "${INPUT_LOG}"
 
         version="${INPUT_VERSION}"
         if [[ -z "${version}" ]]; then
@@ -138,9 +134,11 @@ runs:
         echo "bpf=${dest}/sakimori.bpf.o" >> "${GITHUB_OUTPUT}"
         echo "SAKIMORI_BPF_OBJ=${dest}/sakimori.bpf.o" >> "${GITHUB_ENV}"
         echo "SAKIMORI_BIN=${dest}/sakimori" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_POLICY=${safe_policy}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_MODE=${safe_mode}" >> "${GITHUB_ENV}"
-        echo "SAKIMORI_LOG=${safe_log}" >> "${GITHUB_ENV}"
+        # Keep newline removal at each write so both the shell and static
+        # analysis can prove that one input creates exactly one env record.
+        echo "SAKIMORI_POLICY=$(printf '%s' "${INPUT_POLICY}" | tr -d '\r' | tr -d '\n')" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_MODE=$(printf '%s' "${INPUT_MODE}" | tr -d '\r' | tr -d '\n')" >> "${GITHUB_ENV}"
+        echo "SAKIMORI_LOG=$(printf '%s' "${INPUT_LOG}" | tr -d '\r' | tr -d '\n')" >> "${GITHUB_ENV}"
         echo "SAKIMORI_OS=linux" >> "${GITHUB_ENV}"
 
     # --------------- Windows ---------------

--- a/tests/action-security.test.mjs
+++ b/tests/action-security.test.mjs
@@ -47,27 +47,29 @@ test("composite actions keep untrusted expressions out of run scripts", () => {
 test("action inputs cannot inject extra GITHUB_ENV records", () => {
   const scripts = runBodies(read("action.yml")).join("\n");
 
-  assert.match(scripts, /safe_policy=.*sanitize_env_value.*INPUT_POLICY/);
-  assert.match(scripts, /safe_mode=.*sanitize_env_value.*INPUT_MODE/);
-  assert.match(scripts, /safe_log=.*sanitize_env_value.*INPUT_LOG/);
-  assert.match(
-    scripts,
-    /tr -d ['"]\\r['"]\s*\|\s*tr -d ['"]\\n['"]/,
-    "Linux sanitization must expose the newline-removal command to CodeQL",
-  );
+  assert.match(scripts, /^\s*sanitize_env_value policy "\$\{INPUT_POLICY\}"\s*$/m);
+  assert.match(scripts, /^\s*sanitize_env_value mode "\$\{INPUT_MODE\}"\s*$/m);
+  assert.match(scripts, /^\s*sanitize_env_value log "\$\{INPUT_LOG\}"\s*$/m);
+
+  for (const name of ["POLICY", "MODE", "LOG"]) {
+    const write = scripts
+      .split("\n")
+      .find((line) => line.includes("GITHUB_ENV") && line.includes(`INPUT_${name}`));
+    assert.ok(write, `Linux must sanitize INPUT_${name} at the GITHUB_ENV write`);
+    assert.match(write, /\$\(printf '%s'/);
+    assert.match(
+      write,
+      /tr -d ['"]\\r['"]\s*\|\s*tr -d ['"]\\n['"]/,
+      `INPUT_${name} must use CodeQL-recognized newline removal`,
+    );
+  }
 
   assert.match(scripts, /\$safePolicy\s*=\s*Get-SingleLineEnvValue.*INPUT_POLICY/);
   assert.match(scripts, /\$safeMode\s*=\s*Get-SingleLineEnvValue.*INPUT_MODE/);
   assert.match(scripts, /\$safeLog\s*=\s*Get-SingleLineEnvValue.*INPUT_LOG/);
   assert.match(scripts, /-replace ['"]\[\\r\\n\]['"],\s*['"]/);
 
-  for (const line of scripts.split("\n").filter((candidate) => candidate.includes("GITHUB_ENV"))) {
-    assert.doesNotMatch(
-      line,
-      /(?:\$\{INPUT_|\$env:INPUT_)(?:POLICY|MODE|LOG)/,
-      `unsanitized action input reaches GITHUB_ENV: ${line.trim()}`,
-    );
-  }
+  assert.doesNotMatch(scripts, /\$env:INPUT_(?:POLICY|MODE|LOG).*GITHUB_ENV/);
 });
 
 test("security-sensitive workflows pin every external action by commit SHA", () => {


### PR DESCRIPTION
## Summary

- retain fail-closed CR/LF validation for `policy`, `mode`, and `log` inputs
- repeat CR/LF removal inline at every Linux `GITHUB_ENV` sink
- strengthen the Action security contract test to require sink-local sanitization for all three inputs

## Root cause

The intermediate `safe_policy`, `safe_mode`, and `safe_log` variables introduced by #126 were safe at runtime, but CodeQL does not model the body of the shell helper as a sanitizer on the path to `GITHUB_ENV`. Splitting the helper pipeline in #127 therefore still produced [code scanning alert #69](https://github.com/bokuweb/sakimori/security/code-scanning/69) after merge.

This change follows CodeQL’s own non-vulnerable fixture shape: the untrusted value and `tr -d \\n\` sanitizer now appear in the same command substitution at each environment-file write. The earlier rejection check remains in place as defense in depth.\n\n## Validation\n\n- `node --test tests/action-security.test.mjs`\n- YAML parse of `action.yml`\n- `cargo fmt --all -- --check`\n- `cargo clippy --workspace --all-targets -- -D warnings`\n- `cargo test --workspace`\n- `git diff --check`